### PR TITLE
feat: add Dockerfile and multi-platform Docker image support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -26,8 +27,8 @@ jobs:
       - name: Build release binaries
         run: |
           mkdir -p dist
-          CGO_ENABLED=0 GOOS=linux  GOARCH=amd64 go build -C go/simulator -o ../../dist/simulator-linux-amd64  .
-          CGO_ENABLED=0 GOOS=linux  GOARCH=arm64 go build -C go/simulator -o ../../dist/simulator-linux-arm64  .
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C go/simulator -o ../../dist/simulator-linux-amd64 .
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -C go/simulator -o ../../dist/simulator-linux-arm64 .
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
@@ -43,3 +44,34 @@ jobs:
           files: |
             dist/simulator-linux-amd64
             dist/simulator-linux-arm64
+
+  docker:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage runs on the host platform (native, no emulation needed).
+# The binary is cross-compiled for the target platform.
+FROM --platform=${BUILDPLATFORM} golang:1.26-alpine AS build
+
+ARG TARGETARCH
+
+WORKDIR /src
+
+COPY go/ .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /simulator ./simulator
+
+# ----
+
+FROM alpine:3.21
+
+RUN apk add --no-cache iproute2
+
+COPY --from=build /simulator /usr/local/bin/simulator
+COPY go/simulator/resources/ /resources/
+
+EXPOSE 8080/tcp 161/udp
+
+ENTRYPOINT ["/usr/local/bin/simulator"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-BINARY    := simulator
-BUILD_DIR := go/simulator
-GO_DIR    := go
-IMAGE     := saichler/opensim-web:latest
+BINARY       := simulator
+BUILD_DIR    := go/simulator
+GO_DIR       := go
+IMAGE        := saichler/opensim-web:latest
+SIM_IMAGE    := ghcr.io/labmonkeys-space/l8opensim:latest
 
 # Simulator uses Linux-only syscalls (TUN, network namespaces).
 # Cross-compile by default so the binary runs in the container / on Linux hosts.
@@ -10,8 +11,8 @@ GOARCH ?= amd64
 
 UNAME_S := $(shell uname -s)
 
-.PHONY: all build run test tidy clean docker help \
-        check-go check-docker check-linux
+.PHONY: all build run test tidy clean docker docker-build docker-push docker-up docker-down help \
+        check-go check-docker check-buildx check-linux
 
 all: build
 
@@ -36,6 +37,25 @@ endif
 ## run: Build and run the simulator (Linux only — requires root for TUN interfaces)
 run: check-linux build
 	cd $(BUILD_DIR) && sudo ./$(BINARY)
+
+## docker-build: Build the simulator Docker image for the host platform
+docker-build: check-docker
+	docker build -t $(SIM_IMAGE) .
+
+## docker-push: Build and push a multi-platform image (linux/amd64 + linux/arm64)
+docker-push: check-buildx
+	docker buildx build \
+	  --platform linux/amd64,linux/arm64 \
+	  --push \
+	  -t $(SIM_IMAGE) .
+
+## docker-up: Start the simulator with docker compose
+docker-up: check-docker
+	docker compose up --build
+
+## docker-down: Stop and remove the simulator container
+docker-down: check-docker
+	docker compose down
 
 ## docker: Build the L8 web Docker image (linux/amd64)
 docker: check-docker
@@ -73,6 +93,23 @@ check-docker:
 	  echo "       Start Docker Desktop (or the Docker service) and retry."; \
 	  exit 1; \
 	}
+
+check-buildx: check-docker
+	@docker buildx version >/dev/null 2>&1 || { \
+	  echo "Error: 'docker buildx' not available."; \
+	  echo "       Install Docker Desktop >= 2.1 or the buildx plugin."; \
+	  exit 1; \
+	}
+	@# On Linux, multi-platform emulation requires binfmt_misc + QEMU.
+	@# On macOS, Docker Desktop and Orbstack provide this natively — no check needed.
+	@if [ "$(UNAME_S)" = "Linux" ]; then \
+	  docker buildx ls | grep -q 'linux/arm64' || { \
+	    echo "Error: active buildx builder does not support linux/arm64."; \
+	    echo "       Run: docker run --privileged --rm tonistiigi/binfmt --install all"; \
+	    echo "       Then: docker buildx create --use --name multiplatform"; \
+	    exit 1; \
+	  }; \
+	fi
 
 check-linux:
 	@[ "$(UNAME_S)" = "Linux" ] || { \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  simulator:
+    build: .
+    image: ghcr.io/labmonkeys-space/l8opensim:latest
+    # TUN interfaces and network namespaces require these capabilities.
+    cap_add:
+      - NET_ADMIN
+      - SYS_ADMIN
+    # /dev/net/tun must be accessible inside the container.
+    devices:
+      - /dev/net/tun
+    ports:
+      - "8080:8080"
+      - "161:161/udp"
+    # Pass flags as CMD overrides, e.g.:
+    #   docker compose run simulator -auto-start-ip 192.168.100.1 -auto-count 5


### PR DESCRIPTION
## Summary

- Multi-stage `Dockerfile` using `golang:1.26-alpine` (matching `go.mod`) with `BUILDPLATFORM`/`TARGETARCH` so the build stage compiles natively and cross-compiles the binary for the target platform; `alpine:3.21` with `iproute2` is the minimal runtime image.
- `docker-compose.yml` mounts `/dev/net/tun` and grants `NET_ADMIN` + `SYS_ADMIN` so TUN interfaces and network namespaces work inside the container.
- `Makefile` gains `docker-build`, `docker-push`, `docker-up`, and `docker-down` targets; `docker-push` builds and pushes `linux/amd64` + `linux/arm64` via `docker buildx` with a `check-buildx` guard.
- Release workflow extended with a `docker` job that publishes a multi-platform image to `ghcr.io` on every version tag, tagged as both `:vX.Y.Z` and `:latest`.

## Test plan

- [ ] `make docker-build` builds the image for the host platform without errors.
- [ ] `make docker-up` starts the simulator; `curl http://localhost:8080/health` returns 200.
- [ ] `docker compose run simulator -auto-start-ip 192.168.100.1 -auto-count 3` creates devices and they respond to `snmpwalk -v 2c -c public <ip>`.
- [ ] On a tag push, the release workflow `docker` job publishes `ghcr.io/labmonkeys-space/l8opensim:latest` with both `linux/amd64` and `linux/arm64` manifests (verify with `docker buildx imagetools inspect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)