### PR TITLE
ci: align release workflow with ci.yml build & test steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    name: Build & Release
+  ci:
+    name: Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -24,11 +24,43 @@ jobs:
           go-version-file: go/go.mod
           cache-dependency-path: go/go.sum
 
-      - name: Build release binaries
+      - name: Verify go.mod is tidy
+        working-directory: go
         run: |
-          mkdir -p dist
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -C go/simulator -o ../../dist/simulator-linux-amd64 .
-          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -C go/simulator -o ../../dist/simulator-linux-arm64 .
+          go mod tidy
+          git diff --exit-code go.mod go.sum || {
+            echo "go.mod or go.sum is out of date — run 'make tidy' and commit the result."
+            exit 1
+          }
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test
+
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    needs: ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go/go.mod
+          cache-dependency-path: go/go.sum
+
+      - name: Build release binaries
+        working-directory: go
+        run: |
+          go mod tidy
+          mkdir -p ../dist
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../dist/simulator-linux-amd64 ./simulator
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ../dist/simulator-linux-arm64 ./simulator
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -48,10 +80,11 @@ jobs:
   docker:
     name: Publish Docker image
     runs-on: ubuntu-latest
+    needs: ci
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3


### PR DESCRIPTION
## Summary

- Adds a `ci` job to `release.yml` that mirrors `ci.yml` exactly: tidy check, `make build`, `make test`
- The `release` and `docker` jobs now `needs: ci`, so a broken build can never produce a release artefact
- Fixes the `missing go.sum entry` error by running `go mod tidy` before building release binaries
- Uses the same action SHAs and `working-directory` conventions as `ci.yml`

## Test plan

- [ ] Push a `v*.*.*` tag and confirm the `ci` job runs first, then `release` and `docker` run in parallel only after it passes
- [ ] Confirm the release binaries are attached to the GitHub Release
- [ ] Confirm the Docker image is published to `ghcr.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)