### PR TITLE
refactor: use Makefile goals in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,7 @@ jobs:
           cache-dependency-path: go/go.sum
 
       - name: Verify go.mod is tidy
-        working-directory: go
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum || {
-            echo "go.mod or go.sum is out of date — run 'make tidy' and commit the result."
-            exit 1
-          }
+        run: make check-tidy
 
       - name: Build
         run: make build
@@ -55,12 +49,7 @@ jobs:
           cache-dependency-path: go/go.sum
 
       - name: Build release binaries
-        working-directory: go
-        run: |
-          go mod tidy
-          mkdir -p ../dist
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../dist/simulator-linux-amd64 ./simulator
-          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ../dist/simulator-linux-arm64 ./simulator
+        run: make dist
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -100,11 +89,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-platform image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+        run: make docker-push DOCKER_TAGS="ghcr.io/${{ github.repository }}:${{ github.ref_name }} ghcr.io/${{ github.repository }}:latest"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ BUILD_DIR    := go/simulator
 GO_DIR       := go
 IMAGE        := saichler/opensim-web:latest
 SIM_IMAGE    := ghcr.io/labmonkeys-space/l8opensim:latest
+# Space-separated list of -t tags for docker-push; override in CI with release tags.
+DOCKER_TAGS  ?= $(SIM_IMAGE)
 
 # Simulator uses Linux-only syscalls (TUN, network namespaces).
 # Cross-compile by default so the binary runs in the container / on Linux hosts.
@@ -11,7 +13,7 @@ GOARCH ?= amd64
 
 UNAME_S := $(shell uname -s)
 
-.PHONY: all build run test tidy clean docker docker-build docker-push docker-up docker-down help \
+.PHONY: all build run test tidy check-tidy dist clean docker docker-build docker-push docker-up docker-down help \
         check-go check-docker check-buildx check-linux
 
 all: build
@@ -23,6 +25,20 @@ build: check-go
 ## tidy: Sync go.mod and go.sum
 tidy: check-go
 	cd $(GO_DIR) && go mod tidy
+
+## check-tidy: Verify go.mod and go.sum are up to date (fails if tidy would change them)
+check-tidy: check-go
+	cd $(GO_DIR) && go mod tidy
+	git diff --exit-code $(GO_DIR)/go.mod $(GO_DIR)/go.sum || { \
+	  echo "go.mod or go.sum is out of date — run 'make tidy' and commit the result."; \
+	  exit 1; \
+	}
+
+## dist: Build release binaries for linux/amd64 and linux/arm64 into dist/
+dist: check-go
+	mkdir -p dist
+	cd $(GO_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../dist/$(BINARY)-linux-amd64 ./simulator
+	cd $(GO_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ../dist/$(BINARY)-linux-arm64 ./simulator
 
 ## test: Run tests (simulator package requires Linux; other packages run on any OS)
 test: check-go
@@ -47,7 +63,8 @@ docker-push: check-buildx
 	docker buildx build \
 	  --platform linux/amd64,linux/arm64 \
 	  --push \
-	  -t $(SIM_IMAGE) .
+	  $(addprefix -t ,$(DOCKER_TAGS)) \
+	  .
 
 ## docker-up: Start the simulator with docker compose
 docker-up: check-docker
@@ -63,9 +80,10 @@ docker: check-docker
 	@echo "      to be available in your Docker registry. Pull them first if needed."
 	cd go/l8 && docker build --no-cache --platform=linux/amd64 -t $(IMAGE) .
 
-## clean: Remove the simulator binary
+## clean: Remove build artefacts (binary and dist/)
 clean:
 	rm -f $(BUILD_DIR)/$(BINARY)
+	rm -rf dist/
 
 ## help: Show this help
 help:


### PR DESCRIPTION
## Summary

- Adds `check-tidy`, `dist`, and updates `docker-push` in the Makefile so the release workflow delegates all build logic to `make`
- `release.yml` now calls `make check-tidy`, `make build`, `make test`, `make dist`, and `make docker-push` — no raw `go` or `docker` commands inline
- `clean` also removes `dist/`

## New Makefile targets

| Target | Description |
|--------|-------------|
| `make check-tidy` | Runs `go mod tidy` and fails if `go.mod`/`go.sum` would change |
| `make dist` | Builds `dist/simulator-linux-amd64` and `dist/simulator-linux-arm64` |
| `make docker-push DOCKER_TAGS="..."` | Multi-platform push with overridable tags |

## Test plan

- [ ] `make check-tidy` passes on a clean checkout
- [ ] `make dist` produces both binaries in `dist/`
- [ ] Release workflow `ci`, `release`, and `docker` jobs all pass on a tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)