### PR TITLE
fix(snmp): fix snmpbulkwalk timeout and end-of-MIB hang

### DIFF
--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -245,25 +245,19 @@ func (s *SNMPServer) handleGetBulk(startOID string, requestData []byte) []byte {
 	// Parse GetBulk parameters (non-repeaters and max-repetitions)
 	_, maxRepetitions := s.parseGetBulkParams(requestData)
 
-	// log.Printf("SNMP %s: GetBulk parameters - maxRepetitions: %d", s.device.ID, maxRepetitions)
-
-	// For simplicity, we'll return up to maxRepetitions OIDs starting from startOID
-	// In a real implementation, you'd handle non-repeaters properly
-
 	var oids []string
 	var responses []string
 
 	currentOID := startOID
 	count := 0
+	reachedEnd := false
 
 	// Collect up to maxRepetitions OIDs
 	for count < maxRepetitions {
 		nextOID, response := s.findNextOID(currentOID)
-		// log.Printf("SNMP %s: GetBulk iteration %d - currentOID: %s, nextOID: %s, response: %s",
-		//	s.device.ID, count, currentOID, nextOID, response)
 
 		if nextOID == "" || response == "endOfMibView" {
-			// log.Printf("SNMP %s: GetBulk reached end of MIB", s.device.ID)
+			reachedEnd = true
 			break
 		}
 
@@ -273,12 +267,17 @@ func (s *SNMPServer) handleGetBulk(startOID string, requestData []byte) []byte {
 		count++
 	}
 
-	// log.Printf("SNMP %s: GetBulk collected %d OIDs", s.device.ID, len(oids))
+	// RFC 3416 §4.2.3: if we hit end-of-MIB before filling maxRepetitions,
+	// pad remaining slots with the requested OID (startOID) + endOfMibView.
+	if reachedEnd {
+		for count < maxRepetitions {
+			oids = append(oids, startOID)
+			responses = append(responses, "endOfMibView")
+			count++
+		}
+	}
 
-	// Create GetBulk response with multiple variable bindings
-	responseBytes := s.createGetBulkResponse(oids, responses, requestData)
-	// log.Printf("SNMP %s: GetBulk response created, length: %d bytes", s.device.ID, len(responseBytes))
-	return responseBytes
+	return s.createGetBulkResponse(oids, responses, requestData)
 }
 
 // parseGetBulkParams extracts non-repeaters and max-repetitions from GetBulk request

--- a/go/simulator/snmp_response.go
+++ b/go/simulator/snmp_response.go
@@ -80,8 +80,8 @@ func (s *SNMPServer) parseIncomingRequest(data []byte) SNMPRequest {
 		}
 	}
 
-	// Parse PDU (GetRequest = 0xa0, GetNext = 0xa1)
-	if pos < len(data) && (data[pos] == 0xa0 || data[pos] == 0xa1) {
+	// Parse PDU (GetRequest = 0xa0, GetNext = 0xa1, GetBulk = 0xa5)
+	if pos < len(data) && (data[pos] == 0xa0 || data[pos] == 0xa1 || data[pos] == 0xa5) {
 		pos++
 		pduLengthSkip := s.skipLength(data[pos:])
 		pos += pduLengthSkip


### PR DESCRIPTION
## Summary

Two bugs that broke `snmpbulkwalk -v 2c -c public <device-ip>`:

- **Request-ID mismatch** — `parseIncomingRequest` only matched GET (`0xa0`) and GETNEXT (`0xa1`) PDU types when extracting the request-id. GETBULK (`0xa5`) fell through to the hardcoded default of `123`, so every response was silently dropped by the client, causing a timeout.

- **Missing `endOfMibView` padding** — per RFC 3416, when a GETBULK response has fewer OIDs than `maxRepetitions` because the end of the MIB was reached, the remaining slots must be filled with `endOfMibView` exceptions. Without this, `snmpbulkwalk` hangs indefinitely at the end of the walk waiting for a termination signal that never arrives.

## Test plan

- [ ] `snmpwalk -v 2c -c public <ip>` still works
- [ ] `snmpbulkwalk -v 2c -c public <ip>` completes without timeout
- [ ] `snmpbulkwalk -v 2c -c public <ip>` terminates cleanly at end of MIB (last lines show `No more variables left in this MIB View`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)