### PR TITLE
fix(resources): align ifDescr with ifName across all device types

### DIFF
--- a/go/simulator/resources/nvidia_dgx_h100/nvidia_dgx_h100_snmp_system.json
+++ b/go/simulator/resources/nvidia_dgx_h100/nvidia_dgx_h100_snmp_system.json
@@ -70,7 +70,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.2",
-      "response": "ib0 - ConnectX-7 NDR InfiniBand"
+      "response": "ib0"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.2",
@@ -102,7 +102,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.3",
-      "response": "ib1 - ConnectX-7 NDR InfiniBand"
+      "response": "ib1"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.3",
@@ -134,7 +134,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.4",
-      "response": "ib2 - ConnectX-7 NDR InfiniBand"
+      "response": "ib2"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.4",
@@ -166,7 +166,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.5",
-      "response": "ib3 - ConnectX-7 NDR InfiniBand"
+      "response": "ib3"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.5",

--- a/go/simulator/resources/nvidia_hgx_h200/nvidia_hgx_h200_snmp_system.json
+++ b/go/simulator/resources/nvidia_hgx_h200/nvidia_hgx_h200_snmp_system.json
@@ -70,7 +70,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.2",
-      "response": "ib0 - ConnectX-7 NDR InfiniBand"
+      "response": "ib0"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.2",
@@ -102,7 +102,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.3",
-      "response": "ib1 - ConnectX-7 NDR InfiniBand"
+      "response": "ib1"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.3",
@@ -134,7 +134,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.4",
-      "response": "ib2 - ConnectX-7 NDR InfiniBand"
+      "response": "ib2"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.4",
@@ -166,7 +166,7 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.5",
-      "response": "ib3 - ConnectX-7 NDR InfiniBand"
+      "response": "ib3"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.5",

--- a/go/simulator/resources/palo_alto_pa3220/palo_alto_pa3220_snmp_1.json
+++ b/go/simulator/resources/palo_alto_pa3220/palo_alto_pa3220_snmp_1.json
@@ -34,67 +34,67 @@
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.1",
-      "response": "GigabitEthernet0/0/1"
+      "response": "ethernet1/1"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.10",
-      "response": "GigabitEthernet0/0/10"
+      "response": "ethernet1/10"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.11",
-      "response": "GigabitEthernet0/0/11"
+      "response": "ethernet1/11"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.12",
-      "response": "GigabitEthernet0/0/12"
+      "response": "ethernet1/12"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.13",
-      "response": "GigabitEthernet0/0/13"
+      "response": "ethernet1/13"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.14",
-      "response": "GigabitEthernet0/0/14"
+      "response": "ethernet1/14"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.15",
-      "response": "GigabitEthernet0/0/15"
+      "response": "ethernet1/15"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.16",
-      "response": "GigabitEthernet0/0/16"
+      "response": "ethernet1/16"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.2",
-      "response": "GigabitEthernet0/0/2"
+      "response": "ethernet1/2"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.3",
-      "response": "GigabitEthernet0/0/3"
+      "response": "ethernet1/3"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.4",
-      "response": "GigabitEthernet0/0/4"
+      "response": "ethernet1/4"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.5",
-      "response": "GigabitEthernet0/0/5"
+      "response": "ethernet1/5"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.6",
-      "response": "GigabitEthernet0/0/6"
+      "response": "ethernet1/6"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.7",
-      "response": "GigabitEthernet0/0/7"
+      "response": "ethernet1/7"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.8",
-      "response": "GigabitEthernet0/0/8"
+      "response": "ethernet1/8"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.2.9",
-      "response": "GigabitEthernet0/0/9"
+      "response": "ethernet1/9"
     },
     {
       "oid": "1.3.6.1.2.1.2.2.1.3.1",


### PR DESCRIPTION
## Summary

Fixes naming inconsistencies between `ifDescr` (ifTable) and `ifName`/`ifAlias` (ifXTable) for four device types, aligning the simulated data with what real devices return over SNMP.

- **palo_alto_pa3220** — `ifDescr` was using Cisco-style naming (`GigabitEthernet0/0/N`); corrected to PAN-OS convention (`ethernet1/N`), consistent with `ifName`
- **nvidia_dgx_h100 / hgx_h200** — `ifDescr` had a verbose hardware suffix (`ib0 - ConnectX-7 NDR InfiniBand`); trimmed to the kernel interface name (`ib0`) to match `ifName`, as Linux net-snmp returns
- **cisco_catalyst_9500 / nexus_9500** — `ifName` correctly kept as the OS abbreviation (`Gi1/0/N`, `Eth1/N`) while `ifDescr` retains the full name — this mismatch is intentional vendor behavior on IOS-XE and NX-OS

## Test plan

- [ ] `snmpget -v2c -c public <palo-ip> 1.3.6.1.2.1.2.2.1.2.1` → `ethernet1/1`
- [ ] `snmpget -v2c -c public <dgx-h100-ip> 1.3.6.1.2.1.2.2.1.2.2` → `ib0`
- [ ] `snmpget -v2c -c public <catalyst-ip> 1.3.6.1.2.1.2.2.1.2.1` → `GigabitEthernet1/0/1` (ifDescr, full name)
- [ ] `snmpget -v2c -c public <catalyst-ip> 1.3.6.1.2.1.31.1.1.1.1.1` → `Gi1/0/1` (ifName, abbreviated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)