### PR TITLE
fix(snmp): implement RFC 3416 multi-column GETBULK response

### DIFF
--- a/go/simulator/snmp_getbulk_test.go
+++ b/go/simulator/snmp_getbulk_test.go
@@ -1,0 +1,397 @@
+//go:build linux
+
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: the simulator package uses Linux-only syscalls (TUN/netns) so tests
+// must be run on Linux. The //go:build linux constraint above ensures this file
+// is skipped on macOS/Windows during local development.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+// newTestServer returns an SNMPServer backed by the supplied OID→value map.
+// Indexes are built via buildResourceIndexes so findNextOID works correctly.
+func newTestServer(oidValues map[string]string) *SNMPServer {
+	res := &DeviceResources{
+		SNMP: make([]SNMPResource, 0, len(oidValues)),
+	}
+	for oid, val := range oidValues {
+		res.SNMP = append(res.SNMP, SNMPResource{OID: oid, Response: val})
+	}
+	sm := &SimulatorManager{}
+	sm.buildResourceIndexes(res)
+
+	device := &DeviceSimulator{resources: res}
+	return &SNMPServer{device: device}
+}
+
+// buildGetBulkPDU constructs a minimal SNMPv2c GETBULK packet for the given
+// OIDs, non-repeaters, and max-repetitions values.
+func buildGetBulkPDU(nonRepeaters, maxRepetitions int, oids []string) []byte {
+	var varBindList []byte
+	for _, oid := range oids {
+		vb := encodeSequence(append(encodeOID(oid), encodeNull()...))
+		varBindList = append(varBindList, vb...)
+	}
+
+	pduContents := encodeInteger(42) // request-id
+	pduContents = append(pduContents, encodeInteger(nonRepeaters)...)
+	pduContents = append(pduContents, encodeInteger(maxRepetitions)...)
+	pduContents = append(pduContents, encodeSequence(varBindList)...)
+
+	pdu := []byte{ASN1_GET_BULK}
+	pdu = append(pdu, encodeLength(len(pduContents))...)
+	pdu = append(pdu, pduContents...)
+
+	msgContents := encodeInteger(1) // SNMPv2c
+	msgContents = append(msgContents, encodeOctetString("public")...)
+	msgContents = append(msgContents, pdu...)
+
+	return encodeSequence(msgContents)
+}
+
+// parseGetBulkResponse parses an SNMP GetResponse packet and returns parallel
+// slices of OID strings and their string values (integers returned as decimal).
+func parseGetBulkResponse(data []byte) ([]string, []string, error) {
+	var oids, values []string
+	pos := 0
+
+	// Outer SEQUENCE
+	if pos >= len(data) || data[pos] != ASN1_SEQUENCE {
+		return nil, nil, fmt.Errorf("expected SEQUENCE at pos 0, got 0x%02x", safeAt(data, pos))
+	}
+	pos++
+	_, pos = parseLength(data, pos)
+
+	// Skip version (INTEGER)
+	if pos >= len(data) || data[pos] != ASN1_INTEGER {
+		return nil, nil, fmt.Errorf("expected INTEGER (version)")
+	}
+	pos++
+	vLen, pos2 := parseLength(data, pos)
+	pos = pos2 + vLen
+
+	// Skip community (OCTET STRING)
+	if pos >= len(data) || data[pos] != ASN1_OCTET_STRING {
+		return nil, nil, fmt.Errorf("expected OCTET STRING (community)")
+	}
+	pos++
+	cLen, pos2 := parseLength(data, pos)
+	pos = pos2 + cLen
+
+	// GetResponse PDU (0xa2)
+	if pos >= len(data) || data[pos] != ASN1_GET_RESPONSE {
+		return nil, nil, fmt.Errorf("expected GetResponse (0xa2), got 0x%02x", safeAt(data, pos))
+	}
+	pos++
+	_, pos = parseLength(data, pos)
+
+	// Skip request-id, error-status, error-index (3 INTEGERs)
+	for i := 0; i < 3; i++ {
+		if pos >= len(data) || data[pos] != ASN1_INTEGER {
+			return nil, nil, fmt.Errorf("expected INTEGER (PDU header field %d)", i)
+		}
+		pos++
+		fLen, pos2 := parseLength(data, pos)
+		pos = pos2 + fLen
+	}
+
+	// VarBindList SEQUENCE
+	if pos >= len(data) || data[pos] != ASN1_SEQUENCE {
+		return nil, nil, fmt.Errorf("expected SEQUENCE (VarBindList)")
+	}
+	pos++
+	vbListLen, pos := parseLength(data, pos)
+	end := pos + vbListLen
+
+	for pos < end {
+		if data[pos] != ASN1_SEQUENCE {
+			break
+		}
+		pos++
+		vbLen, pos2 := parseLength(data, pos)
+		pos = pos2
+		nextVB := pos + vbLen
+
+		// OID
+		if pos >= len(data) || data[pos] != ASN1_OID {
+			return nil, nil, fmt.Errorf("expected OID tag in VarBind")
+		}
+		pos++
+		oidLen, pos2 := parseLength(data, pos)
+		pos = pos2
+		oid := decodeOID(data[pos : pos+oidLen])
+		oids = append(oids, oid)
+		pos += oidLen
+
+		// Value — we only need to distinguish endOfMibView from real values.
+		val := extractVarBindValue(data, pos)
+		values = append(values, val)
+
+		pos = nextVB
+	}
+
+	return oids, values, nil
+}
+
+// extractVarBindValue returns a string representation of the next ASN.1 value.
+func extractVarBindValue(data []byte, pos int) string {
+	if pos >= len(data) {
+		return ""
+	}
+	tag := data[pos]
+	pos++
+	vLen, pos2 := parseLength(data, pos)
+	pos = pos2
+
+	switch tag {
+	case 0x82: // endOfMibView exception (SNMPv2c)
+		return "endOfMibView"
+	case ASN1_INTEGER:
+		v := 0
+		for i := 0; i < vLen && pos+i < len(data); i++ {
+			v = (v << 8) | int(data[pos+i])
+		}
+		return fmt.Sprintf("%d", v)
+	case ASN1_OCTET_STRING:
+		if pos+vLen <= len(data) {
+			return string(data[pos : pos+vLen])
+		}
+	}
+	return fmt.Sprintf("tag=0x%02x", tag)
+}
+
+func safeAt(data []byte, pos int) byte {
+	if pos < len(data) {
+		return data[pos]
+	}
+	return 0
+}
+
+// ── parseAllOIDsFromRequest tests ────────────────────────────────────────────
+
+func TestParseAllOIDsFromRequest_SingleOID(t *testing.T) {
+	s := &SNMPServer{device: &DeviceSimulator{}}
+	want := []string{"1.3.6.1.2.1.2.2.1.2"}
+
+	pdu := buildGetBulkPDU(0, 10, want)
+	got := s.parseAllOIDsFromRequest(pdu)
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d OID(s), want %d", len(got), len(want))
+	}
+	if got[0] != want[0] {
+		t.Errorf("OID[0]: got %q, want %q", got[0], want[0])
+	}
+}
+
+func TestParseAllOIDsFromRequest_MultipleOIDs(t *testing.T) {
+	s := &SNMPServer{device: &DeviceSimulator{}}
+	want := []string{
+		"1.3.6.1.2.1.2.2.1.2",  // ifDescr column
+		"1.3.6.1.2.1.2.2.1.5",  // ifSpeed column
+		"1.3.6.1.2.1.2.2.1.7",  // ifAdminStatus column
+		"1.3.6.1.2.1.2.2.1.8",  // ifOperStatus column
+		"1.3.6.1.2.1.31.1.1.1.1",  // ifName column
+		"1.3.6.1.2.1.31.1.1.1.18", // ifAlias column
+	}
+
+	pdu := buildGetBulkPDU(0, 10, want)
+	got := s.parseAllOIDsFromRequest(pdu)
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d OIDs, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("OID[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseAllOIDsFromRequest_MalformedPDU(t *testing.T) {
+	s := &SNMPServer{device: &DeviceSimulator{}}
+
+	// Should return empty slice without panicking.
+	got := s.parseAllOIDsFromRequest([]byte{0x00, 0x01, 0x02})
+	if len(got) != 0 {
+		t.Errorf("expected empty slice for malformed PDU, got %v", got)
+	}
+
+	got = s.parseAllOIDsFromRequest(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice for nil input, got %v", got)
+	}
+}
+
+// ── handleGetBulk tests ──────────────────────────────────────────────────────
+
+// TestHandleGetBulkMultiColumn verifies that a two-column GETBULK request
+// produces correctly interleaved responses: col1.row1, col2.row1, col1.row2, …
+func TestHandleGetBulkMultiColumn(t *testing.T) {
+	s := newTestServer(map[string]string{
+		"1.3.6.1.2.1.2.2.1.2.1": "eth0",
+		"1.3.6.1.2.1.2.2.1.2.2": "eth1",
+		"1.3.6.1.2.1.2.2.1.5.1": "1000000000",
+		"1.3.6.1.2.1.2.2.1.5.2": "1000000000",
+	})
+
+	// Ask for ifDescr column and ifSpeed column, 2 repetitions.
+	colOIDs := []string{
+		"1.3.6.1.2.1.2.2.1.2", // ifDescr column prefix
+		"1.3.6.1.2.1.2.2.1.5", // ifSpeed column prefix
+	}
+	pdu := buildGetBulkPDU(0, 2, colOIDs)
+
+	resp := s.handleGetBulk("1.3.6.1.2.1.2.2.1.2", pdu)
+
+	gotOIDs, gotVals, err := parseGetBulkResponse(resp)
+	if err != nil {
+		t.Fatalf("parseGetBulkResponse: %v", err)
+	}
+
+	// Expected interleaved order: ifDescr.1, ifSpeed.1, ifDescr.2, ifSpeed.2
+	wantOIDs := []string{
+		"1.3.6.1.2.1.2.2.1.2.1",
+		"1.3.6.1.2.1.2.2.1.5.1",
+		"1.3.6.1.2.1.2.2.1.2.2",
+		"1.3.6.1.2.1.2.2.1.5.2",
+	}
+	wantVals := []string{"eth0", "1000000000", "eth1", "1000000000"}
+
+	if len(gotOIDs) != len(wantOIDs) {
+		t.Fatalf("varbind count: got %d, want %d\nOIDs: %v", len(gotOIDs), len(wantOIDs), gotOIDs)
+	}
+	for i := range wantOIDs {
+		if gotOIDs[i] != wantOIDs[i] {
+			t.Errorf("varbind[%d] OID: got %q, want %q", i, gotOIDs[i], wantOIDs[i])
+		}
+		if gotVals[i] != wantVals[i] {
+			t.Errorf("varbind[%d] value: got %q, want %q", i, gotVals[i], wantVals[i])
+		}
+	}
+}
+
+// TestHandleGetBulkNonRepeaters verifies that non-repeater OIDs are handled
+// with GETNEXT semantics and repeater OIDs are iterated max-repetitions times.
+func TestHandleGetBulkNonRepeaters(t *testing.T) {
+	s := newTestServer(map[string]string{
+		"1.3.6.1.2.1.1.1.0":     "Cisco IOS",     // sysDescr (non-repeater target)
+		"1.3.6.1.2.1.2.2.1.2.1": "eth0",
+		"1.3.6.1.2.1.2.2.1.2.2": "eth1",
+	})
+
+	// non-repeaters=1 (sysDescr column), repeater=ifDescr column, maxRep=2
+	colOIDs := []string{
+		"1.3.6.1.2.1.1.1", // non-repeater: next after sysDescr prefix → sysDescr.0
+		"1.3.6.1.2.1.2.2.1.2", // repeater: ifDescr column
+	}
+	pdu := buildGetBulkPDU(1, 2, colOIDs)
+
+	resp := s.handleGetBulk(colOIDs[0], pdu)
+
+	gotOIDs, _, err := parseGetBulkResponse(resp)
+	if err != nil {
+		t.Fatalf("parseGetBulkResponse: %v", err)
+	}
+
+	// Expect: 1 non-repeater result + 2 repeater results = 3 varbinds total.
+	if len(gotOIDs) != 3 {
+		t.Fatalf("varbind count: got %d, want 3 (1 non-repeater + 2 repeater)\nOIDs: %v", len(gotOIDs), gotOIDs)
+	}
+
+	// First entry is the non-repeater GETNEXT result.
+	if gotOIDs[0] != "1.3.6.1.2.1.1.1.0" {
+		t.Errorf("non-repeater OID: got %q, want %q", gotOIDs[0], "1.3.6.1.2.1.1.1.0")
+	}
+	// Next two are the repeater column.
+	if gotOIDs[1] != "1.3.6.1.2.1.2.2.1.2.1" {
+		t.Errorf("repeater[0] OID: got %q, want %q", gotOIDs[1], "1.3.6.1.2.1.2.2.1.2.1")
+	}
+	if gotOIDs[2] != "1.3.6.1.2.1.2.2.1.2.2" {
+		t.Errorf("repeater[1] OID: got %q, want %q", gotOIDs[2], "1.3.6.1.2.1.2.2.1.2.2")
+	}
+}
+
+// TestHandleGetBulkEndOfMib verifies that once a column is exhausted, all
+// remaining rows for that column are padded with endOfMibView as required by
+// RFC 3416 §4.2.3, while other columns continue walking.
+func TestHandleGetBulkEndOfMib(t *testing.T) {
+	// col1 has 1 entry, col2 has 2 entries; ask for maxRep=2.
+	s := newTestServer(map[string]string{
+		"1.3.6.1.2.1.2.2.1.2.1": "eth0",           // only one ifDescr entry
+		"1.3.6.1.2.1.2.2.1.7.1": "1",               // ifAdminStatus.1
+		"1.3.6.1.2.1.2.2.1.7.2": "1",               // ifAdminStatus.2
+	})
+
+	colOIDs := []string{
+		"1.3.6.1.2.1.2.2.1.2", // ifDescr column — exhausts after row 1
+		"1.3.6.1.2.1.2.2.1.7", // ifAdminStatus column — has 2 rows
+	}
+	pdu := buildGetBulkPDU(0, 2, colOIDs)
+
+	resp := s.handleGetBulk(colOIDs[0], pdu)
+
+	_, gotVals, err := parseGetBulkResponse(resp)
+	if err != nil {
+		t.Fatalf("parseGetBulkResponse: %v", err)
+	}
+
+	// Expected (2 reps × 2 cols = 4 varbinds):
+	// rep 0: ifDescr.1="eth0",       ifAdminStatus.1="1"
+	// rep 1: ifDescr col exhausted → "endOfMibView",  ifAdminStatus.2="1"
+	if len(gotVals) != 4 {
+		t.Fatalf("varbind count: got %d, want 4\nValues: %v", len(gotVals), gotVals)
+	}
+	if gotVals[0] == "endOfMibView" {
+		t.Errorf("rep0/col0: should have a real value, got endOfMibView")
+	}
+	if gotVals[2] != "endOfMibView" {
+		t.Errorf("rep1/col0: expected endOfMibView after column exhaustion, got %q", gotVals[2])
+	}
+	if gotVals[3] == "endOfMibView" {
+		t.Errorf("rep1/col1: should have a real value (ifAdminStatus.2), got endOfMibView")
+	}
+}
+
+// TestHandleGetBulkFallback verifies backward compatibility: when the PDU
+// cannot be parsed for OIDs, the single startOID fallback still works.
+func TestHandleGetBulkFallback(t *testing.T) {
+	s := newTestServer(map[string]string{
+		"1.3.6.1.2.1.1.1.0": "Cisco IOS",
+		"1.3.6.1.2.1.1.2.0": "1.3.6.1.4.1.9",
+	})
+
+	// Pass a garbage PDU — parseAllOIDsFromRequest returns empty, fallback activates.
+	garblePDU := []byte{0x00, 0x01, 0x02, 0x03}
+
+	resp := s.handleGetBulk("1.3.6.1.2.1.1.1", garblePDU)
+
+	// Should still produce a valid response with at least one varbind.
+	gotOIDs, _, err := parseGetBulkResponse(resp)
+	if err != nil {
+		t.Fatalf("parseGetBulkResponse: %v", err)
+	}
+	if len(gotOIDs) == 0 {
+		t.Error("fallback produced no varbinds")
+	}
+}

--- a/go/simulator/snmp_getbulk_test.go
+++ b/go/simulator/snmp_getbulk_test.go
@@ -332,44 +332,46 @@ func TestHandleGetBulkNonRepeaters(t *testing.T) {
 	}
 }
 
-// TestHandleGetBulkEndOfMib verifies that once a column is exhausted, all
-// remaining rows for that column are padded with endOfMibView as required by
-// RFC 3416 §4.2.3, while other columns continue walking.
+// TestHandleGetBulkEndOfMib verifies RFC 3416 §4.2.3 endOfMibView padding.
+//
+// SNMP agents do not know about column boundaries — findNextOID always returns
+// the lexicographically next OID in the MIB regardless of column prefix.
+// endOfMibView is only emitted when the MIB is fully exhausted (no more OIDs).
+// Once a column hits end-of-MIB, handleGetBulk must pad all remaining
+// repetitions for that column with the original requested OID + endOfMibView.
 func TestHandleGetBulkEndOfMib(t *testing.T) {
-	// col1 has 1 entry, col2 has 2 entries; ask for maxRep=2.
+	// Single OID in the MIB. After one repetition the MIB is exhausted and
+	// the remaining 2 repetitions must be padded with endOfMibView.
 	s := newTestServer(map[string]string{
-		"1.3.6.1.2.1.2.2.1.2.1": "eth0",           // only one ifDescr entry
-		"1.3.6.1.2.1.2.2.1.7.1": "1",               // ifAdminStatus.1
-		"1.3.6.1.2.1.2.2.1.7.2": "1",               // ifAdminStatus.2
+		"1.3.6.1.2.1.2.2.1.2.1": "eth0",
 	})
 
-	colOIDs := []string{
-		"1.3.6.1.2.1.2.2.1.2", // ifDescr column — exhausts after row 1
-		"1.3.6.1.2.1.2.2.1.7", // ifAdminStatus column — has 2 rows
-	}
-	pdu := buildGetBulkPDU(0, 2, colOIDs)
+	colOIDs := []string{"1.3.6.1.2.1.2.2.1.2"} // ifDescr column prefix
+	pdu := buildGetBulkPDU(0, 3, colOIDs)
 
 	resp := s.handleGetBulk(colOIDs[0], pdu)
 
-	_, gotVals, err := parseGetBulkResponse(resp)
+	gotOIDs, gotVals, err := parseGetBulkResponse(resp)
 	if err != nil {
 		t.Fatalf("parseGetBulkResponse: %v", err)
 	}
 
-	// Expected (2 reps × 2 cols = 4 varbinds):
-	// rep 0: ifDescr.1="eth0",       ifAdminStatus.1="1"
-	// rep 1: ifDescr col exhausted → "endOfMibView",  ifAdminStatus.2="1"
-	if len(gotVals) != 4 {
-		t.Fatalf("varbind count: got %d, want 4\nValues: %v", len(gotVals), gotVals)
+	// 3 reps × 1 col = 3 varbinds.
+	if len(gotVals) != 3 {
+		t.Fatalf("varbind count: got %d, want 3\nOIDs: %v\nVals: %v", len(gotVals), gotOIDs, gotVals)
 	}
+
+	// rep 0: the real entry
 	if gotVals[0] == "endOfMibView" {
-		t.Errorf("rep0/col0: should have a real value, got endOfMibView")
+		t.Errorf("rep0: expected real value, got endOfMibView")
+	}
+
+	// rep 1 and rep 2: endOfMibView padding (MIB fully exhausted)
+	if gotVals[1] != "endOfMibView" {
+		t.Errorf("rep1: expected endOfMibView (MIB exhausted), got %q", gotVals[1])
 	}
 	if gotVals[2] != "endOfMibView" {
-		t.Errorf("rep1/col0: expected endOfMibView after column exhaustion, got %q", gotVals[2])
-	}
-	if gotVals[3] == "endOfMibView" {
-		t.Errorf("rep1/col1: should have a real value (ifAdminStatus.2), got endOfMibView")
+		t.Errorf("rep2: expected endOfMibView (MIB exhausted), got %q", gotVals[2])
 	}
 }
 

--- a/go/simulator/snmp_getbulk_test.go
+++ b/go/simulator/snmp_getbulk_test.go
@@ -384,16 +384,27 @@ func TestHandleGetBulkFallback(t *testing.T) {
 	})
 
 	// Pass a garbage PDU — parseAllOIDsFromRequest returns empty, fallback activates.
+	// handleGetBulk falls back to startOID="1.3.6.1.2.1.1.1", so GETNEXT produces
+	// the first OID in the MIB: 1.3.6.1.2.1.1.1.0 (sysDescr).
 	garblePDU := []byte{0x00, 0x01, 0x02, 0x03}
 
 	resp := s.handleGetBulk("1.3.6.1.2.1.1.1", garblePDU)
 
-	// Should still produce a valid response with at least one varbind.
-	gotOIDs, _, err := parseGetBulkResponse(resp)
+	gotOIDs, gotVals, err := parseGetBulkResponse(resp)
 	if err != nil {
 		t.Fatalf("parseGetBulkResponse: %v", err)
 	}
 	if len(gotOIDs) == 0 {
-		t.Error("fallback produced no varbinds")
+		t.Fatal("fallback produced no varbinds")
+	}
+	// The fallback must return 1.3.6.1.2.1.1.1.0 (the first — and only — OID
+	// lexicographically greater than the start prefix "1.3.6.1.2.1.1.1").
+	wantOID := "1.3.6.1.2.1.1.1.0"
+	wantVal := "Cisco IOS"
+	if gotOIDs[0] != wantOID {
+		t.Errorf("fallback OID: got %q, want %q", gotOIDs[0], wantOID)
+	}
+	if gotVals[0] != wantVal {
+		t.Errorf("fallback value: got %q, want %q", gotVals[0], wantVal)
 	}
 }

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -334,7 +334,11 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 		return oids
 	}
 	pos++
-	_, pos = parseLength(data, pos)
+	outerLen, newPos := parseLength(data, pos)
+	if outerLen < 0 {
+		return oids
+	}
+	pos = newPos
 
 	// Version (INTEGER)
 	if pos >= len(data) || data[pos] != ASN1_INTEGER {
@@ -342,6 +346,9 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	}
 	pos++
 	verLen, newPos := parseLength(data, pos)
+	if verLen < 0 {
+		return oids
+	}
 	pos = newPos + verLen
 
 	// Community (OCTET STRING)
@@ -350,6 +357,9 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	}
 	pos++
 	commLen, newPos := parseLength(data, pos)
+	if commLen < 0 {
+		return oids
+	}
 	pos = newPos + commLen
 
 	// PDU tag (any: GET / GETNEXT / GETBULK / …)
@@ -357,7 +367,11 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 		return oids
 	}
 	pos++ // consume PDU type byte
-	_, pos = parseLength(data, pos)
+	pduLen, newPos := parseLength(data, pos)
+	if pduLen < 0 {
+		return oids
+	}
+	pos = newPos
 
 	// Request-ID (INTEGER)
 	if pos >= len(data) || data[pos] != ASN1_INTEGER {
@@ -365,6 +379,9 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	}
 	pos++
 	reqIDLen, newPos := parseLength(data, pos)
+	if reqIDLen < 0 {
+		return oids
+	}
 	pos = newPos + reqIDLen
 
 	// error-status / non-repeaters (INTEGER)
@@ -373,6 +390,9 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	}
 	pos++
 	f1Len, newPos := parseLength(data, pos)
+	if f1Len < 0 {
+		return oids
+	}
 	pos = newPos + f1Len
 
 	// error-index / max-repetitions (INTEGER)
@@ -381,6 +401,9 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	}
 	pos++
 	f2Len, newPos := parseLength(data, pos)
+	if f2Len < 0 {
+		return oids
+	}
 	pos = newPos + f2Len
 
 	// VarBindList (SEQUENCE)
@@ -389,6 +412,9 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	}
 	pos++
 	vbListLen, newPos := parseLength(data, pos)
+	if vbListLen < 0 {
+		return oids
+	}
 	pos = newPos
 	end := pos + vbListLen
 
@@ -399,16 +425,21 @@ func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 		}
 		pos++
 		vbLen, newPos := parseLength(data, pos)
+		if vbLen < 0 {
+			break
+		}
 		pos = newPos
 		nextVarBind := pos + vbLen
+		if nextVarBind > end {
+			break // VarBind claims to extend beyond declared VarBindList boundary
+		}
 
 		// OID inside VarBind
 		if pos < len(data) && data[pos] == ASN1_OID {
 			pos++
 			oidLen, newPos := parseLength(data, pos)
-			pos = newPos
-			if pos+oidLen <= len(data) {
-				if oid := decodeOID(data[pos : pos+oidLen]); oid != "" {
+			if oidLen >= 0 && newPos+oidLen <= len(data) {
+				if oid := decodeOID(data[newPos : newPos+oidLen]); oid != "" {
 					oids = append(oids, oid)
 				}
 			}

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -246,43 +246,178 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 }
 
 // handleGetBulk processes SNMP GetBulk requests
+// handleGetBulk implements RFC 3416 §4.2.3 GetBulk processing.
+//
+// A GETBULK request carries multiple OIDs in its variable-bindings list:
+//   - The first nonRepeaters OIDs are treated like GETNEXT (one result each).
+//   - The remaining OIDs are "repeater" columns: for each repetition the
+//     response contains one GETNEXT result per column, interleaved in order.
+//
+// Previous implementation only processed the first OID, so OpenNMS's
+// multi-column GETBULK requests only ever returned values for the first
+// requested column, leaving ifDescr/ifName/ifAlias/ifSpeed as N/A.
 func (s *SNMPServer) handleGetBulk(startOID string, requestData []byte) []byte {
-	// Parse GetBulk parameters (non-repeaters and max-repetitions)
-	_, maxRepetitions := s.parseGetBulkParams(requestData)
+	nonRepeaters, maxRepetitions := s.parseGetBulkParams(requestData)
 
+	// Parse every OID from the variable-bindings list.
+	allOIDs := s.parseAllOIDsFromRequest(requestData)
+	if len(allOIDs) == 0 {
+		// Fallback: use the single OID extracted by the general request parser.
+		allOIDs = []string{startOID}
+	}
+
+	var responseOIDs []string
+	var responseValues []string
+
+	// ── Non-repeater section (GETNEXT semantics) ──────────────────────────
+	cap := nonRepeaters
+	if cap > len(allOIDs) {
+		cap = len(allOIDs)
+	}
+	for i := 0; i < cap; i++ {
+		nextOID, nextVal := s.findNextOID(allOIDs[i])
+		if nextOID == "" {
+			nextOID = allOIDs[i]
+			nextVal = "endOfMibView"
+		}
+		responseOIDs = append(responseOIDs, nextOID)
+		responseValues = append(responseValues, nextVal)
+	}
+
+	// ── Repeater section (multi-column GETNEXT × maxRepetitions) ──────────
+	repeaterCols := allOIDs[cap:] // columns to repeat
+	if len(repeaterCols) == 0 || maxRepetitions == 0 {
+		return s.createGetBulkResponse(responseOIDs, responseValues, requestData)
+	}
+
+	// currentOIDs tracks the "cursor" position in each column.
+	currentOIDs := make([]string, len(repeaterCols))
+	copy(currentOIDs, repeaterCols)
+
+	// endOfMib[i] == true once column i has exhausted the MIB.
+	endOfMib := make([]bool, len(repeaterCols))
+
+	for rep := 0; rep < maxRepetitions; rep++ {
+		for col, startCol := range repeaterCols {
+			if endOfMib[col] {
+				// RFC 3416: pad with the ORIGINAL requested OID + endOfMibView.
+				responseOIDs = append(responseOIDs, startCol)
+				responseValues = append(responseValues, "endOfMibView")
+				continue
+			}
+			nextOID, nextVal := s.findNextOID(currentOIDs[col])
+			if nextOID == "" || nextVal == "endOfMibView" {
+				endOfMib[col] = true
+				responseOIDs = append(responseOIDs, startCol)
+				responseValues = append(responseValues, "endOfMibView")
+			} else {
+				responseOIDs = append(responseOIDs, nextOID)
+				responseValues = append(responseValues, nextVal)
+				currentOIDs[col] = nextOID
+			}
+		}
+	}
+
+	return s.createGetBulkResponse(responseOIDs, responseValues, requestData)
+}
+
+// parseAllOIDsFromRequest extracts every OID from the variable-bindings list
+// of an SNMP PDU (GET, GETNEXT, or GETBULK). For GETBULK this returns all
+// column starters; for GET/GETNEXT it returns the single requested OID.
+func (s *SNMPServer) parseAllOIDsFromRequest(data []byte) []string {
 	var oids []string
-	var responses []string
 
-	currentOID := startOID
-	count := 0
-	reachedEnd := false
+	pos := 0
 
-	// Collect up to maxRepetitions OIDs
-	for count < maxRepetitions {
-		nextOID, response := s.findNextOID(currentOID)
+	// Outer SEQUENCE
+	if pos >= len(data) || data[pos] != ASN1_SEQUENCE {
+		return oids
+	}
+	pos++
+	_, pos = parseLength(data, pos)
 
-		if nextOID == "" || response == "endOfMibView" {
-			reachedEnd = true
+	// Version (INTEGER)
+	if pos >= len(data) || data[pos] != ASN1_INTEGER {
+		return oids
+	}
+	pos++
+	verLen, newPos := parseLength(data, pos)
+	pos = newPos + verLen
+
+	// Community (OCTET STRING)
+	if pos >= len(data) || data[pos] != ASN1_OCTET_STRING {
+		return oids
+	}
+	pos++
+	commLen, newPos := parseLength(data, pos)
+	pos = newPos + commLen
+
+	// PDU tag (any: GET / GETNEXT / GETBULK / …)
+	if pos >= len(data) {
+		return oids
+	}
+	pos++ // consume PDU type byte
+	_, pos = parseLength(data, pos)
+
+	// Request-ID (INTEGER)
+	if pos >= len(data) || data[pos] != ASN1_INTEGER {
+		return oids
+	}
+	pos++
+	reqIDLen, newPos := parseLength(data, pos)
+	pos = newPos + reqIDLen
+
+	// error-status / non-repeaters (INTEGER)
+	if pos >= len(data) || data[pos] != ASN1_INTEGER {
+		return oids
+	}
+	pos++
+	f1Len, newPos := parseLength(data, pos)
+	pos = newPos + f1Len
+
+	// error-index / max-repetitions (INTEGER)
+	if pos >= len(data) || data[pos] != ASN1_INTEGER {
+		return oids
+	}
+	pos++
+	f2Len, newPos := parseLength(data, pos)
+	pos = newPos + f2Len
+
+	// VarBindList (SEQUENCE)
+	if pos >= len(data) || data[pos] != ASN1_SEQUENCE {
+		return oids
+	}
+	pos++
+	vbListLen, newPos := parseLength(data, pos)
+	pos = newPos
+	end := pos + vbListLen
+
+	// Walk every VarBind
+	for pos < end && pos < len(data) {
+		if data[pos] != ASN1_SEQUENCE {
 			break
 		}
+		pos++
+		vbLen, newPos := parseLength(data, pos)
+		pos = newPos
+		nextVarBind := pos + vbLen
 
-		oids = append(oids, nextOID)
-		responses = append(responses, response)
-		currentOID = nextOID
-		count++
-	}
-
-	// RFC 3416 §4.2.3: if we hit end-of-MIB before filling maxRepetitions,
-	// pad remaining slots with the requested OID (startOID) + endOfMibView.
-	if reachedEnd {
-		for count < maxRepetitions {
-			oids = append(oids, startOID)
-			responses = append(responses, "endOfMibView")
-			count++
+		// OID inside VarBind
+		if pos < len(data) && data[pos] == ASN1_OID {
+			pos++
+			oidLen, newPos := parseLength(data, pos)
+			pos = newPos
+			if pos+oidLen <= len(data) {
+				if oid := decodeOID(data[pos : pos+oidLen]); oid != "" {
+					oids = append(oids, oid)
+				}
+			}
 		}
+
+		pos = nextVarBind
 	}
 
-	return s.createGetBulkResponse(oids, responses, requestData)
+	return oids
 }
 
 // parseGetBulkParams extracts non-repeaters and max-repetitions from GetBulk request


### PR DESCRIPTION
## Problem

OpenNMS provisioning (and other NMS tools) use **multi-column GETBULK**: a single request carries one starting OID per ifTable column in its variable-bindings list, e.g.:

```
GETBULK non-repeaters=0 max-repetitions=10
Variable bindings:
  1.3.6.1.2.1.2.2.1.2   ← ifDescr
  1.3.6.1.2.1.2.2.1.5   ← ifSpeed
  1.3.6.1.2.1.2.2.1.7   ← ifAdminStatus
  1.3.6.1.2.1.2.2.1.8   ← ifOperStatus
  1.3.6.1.2.1.31.1.1.1.1  ← ifName
  1.3.6.1.2.1.31.1.1.1.18 ← ifAlias
```

Per RFC 3416 §4.2.3 the response must interleave values across all columns:
```
ifDescr.1, ifSpeed.1, ifAdminStatus.1, ifOperStatus.1, ifName.1, ifAlias.1,
ifDescr.2, ifSpeed.2, ...
```

The previous `handleGetBulk` only parsed the **first** OID and walked from there, returning `maxRepetitions` consecutive entries for that single column. All other columns came back as N/A in OpenNMS, and interface status defaulted to unknown (shown in red) because ifAdminStatus/ifOperStatus were missing.

## Fix

### `parseAllOIDsFromRequest(data []byte) []string`  
New helper that walks the full ASN.1 variable-bindings SEQUENCE and returns every OID present in the request — not just the first.

### `handleGetBulk` — rewritten to RFC 3416 §4.2.3

- **Non-repeaters** (first `nonRepeaters` OIDs): one GETNEXT result each.
- **Repeater columns** (remaining OIDs): `maxRepetitions` rows, interleaved in request column order.
- Columns that exhaust the MIB are padded with the original requested OID + `endOfMibView` for the remaining repetitions.
- **Fallback**: if `parseAllOIDsFromRequest` returns nothing (malformed PDU), the original single-OID behaviour is preserved.

## Test plan

- [ ] Build succeeds on Linux (`make build`)
- [ ] `snmpbulkwalk -v2c -c public <ip> 1.3.6.1.2.1.2.2.1` returns all ifTable columns (ifDescr, ifSpeed, ifAdminStatus, ifOperStatus) in a single walk
- [ ] OpenNMS provisioning shows ifDescr, ifName, ifAlias, ifSpeed populated (not N/A)
- [ ] OpenNMS interface status shows green (ifAdminStatus=1, ifOperStatus=1)
- [ ] `snmpbulkwalk` with multiple OIDs (simulating multi-column GETBULK) returns correctly interleaved responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)