### PR TITLE
fix(snmp): encode values with correct RFC 1902 ASN.1 application types

### DIFF
--- a/go/simulator/constants.go
+++ b/go/simulator/constants.go
@@ -29,6 +29,13 @@ const (
 	ASN1_GET_BULK     = 0xA5
 	ASN1_OID          = 0x06
 	SNMP_GET_RESPONSE = 0xa2
+
+	// SNMPv2c application type tags (RFC 1902 §7.1)
+	ASN1_IPADDRESS = 0x40 // IpAddress  – 4-byte IPv4 address
+	ASN1_COUNTER32 = 0x41 // Counter32  – 32-bit monotonically increasing counter
+	ASN1_GAUGE32   = 0x42 // Gauge32    – 32-bit gauge (also used for Unsigned32)
+	ASN1_TIMETICKS = 0x43 // TimeTicks  – hundredths of a second since epoch
+	ASN1_COUNTER64 = 0x46 // Counter64  – 64-bit monotonically increasing counter
 )
 
 // SNMPv3 specific constants

--- a/go/simulator/snmp_encoding.go
+++ b/go/simulator/snmp_encoding.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"net"
 	"strconv"
 	"strings"
 )
@@ -222,6 +223,171 @@ func encodeSequence(contents []byte) []byte {
 
 func encodeNull() []byte {
 	return []byte{ASN1_NULL, 0x00}
+}
+
+// encodeUnsigned32 encodes a uint32 with the given application tag.
+// Used for Counter32 (0x41), Gauge32 (0x42), and TimeTicks (0x43).
+func encodeUnsigned32(tag byte, value uint32) []byte {
+	var b [4]byte
+	b[0] = byte(value >> 24)
+	b[1] = byte(value >> 16)
+	b[2] = byte(value >> 8)
+	b[3] = byte(value)
+	// Strip leading zero bytes (minimum-length encoding).
+	start := 0
+	for start < 3 && b[start] == 0 {
+		start++
+	}
+	result := []byte{tag}
+	result = append(result, encodeLength(4-start)...)
+	result = append(result, b[start:]...)
+	return result
+}
+
+// encodeCounter64 encodes a uint64 with tag ASN1_COUNTER64 (0x46).
+func encodeCounter64(value uint64) []byte {
+	var b [8]byte
+	for i := 7; i >= 0; i-- {
+		b[i] = byte(value)
+		value >>= 8
+	}
+	start := 0
+	for start < 7 && b[start] == 0 {
+		start++
+	}
+	result := []byte{ASN1_COUNTER64}
+	result = append(result, encodeLength(8-start)...)
+	result = append(result, b[start:]...)
+	return result
+}
+
+// encodeIPAddress encodes a dotted-decimal IPv4 string as an SNMP IpAddress (0x40).
+// Falls back to OCTET STRING if the string is not a valid IPv4 address.
+func encodeIPAddress(ipStr string) []byte {
+	ip := net.ParseIP(ipStr)
+	if ip4 := ip.To4(); ip4 != nil {
+		result := []byte{ASN1_IPADDRESS, 0x04}
+		result = append(result, ip4...)
+		return result
+	}
+	return encodeOctetString(ipStr)
+}
+
+// oidTypeEntry maps an OID column prefix to the SNMP application type tag
+// that must be used when encoding values for that column.
+type oidTypeEntry struct {
+	prefix string
+	tag    byte
+}
+
+// oidTypeTable maps standard MIB OID column prefixes to their RFC-mandated
+// ASN.1 application type tags. Leaf OIDs are matched by HasPrefix(oid, prefix+".").
+// The trailing "." in the check prevents digit-extension false matches
+// (e.g. column prefix "...1" cannot match "...10.*"), so ordering is irrelevant
+// for correctness.
+var oidTypeTable = []oidTypeEntry{
+	// MIB-II system group
+	{"1.3.6.1.2.1.1.3", ASN1_TIMETICKS}, // sysUpTime
+
+	// ifTable — RFC 2863
+	{"1.3.6.1.2.1.2.2.1.5", ASN1_GAUGE32},    // ifSpeed
+	{"1.3.6.1.2.1.2.2.1.9", ASN1_TIMETICKS},  // ifLastChange
+	{"1.3.6.1.2.1.2.2.1.10", ASN1_COUNTER32}, // ifInOctets
+	{"1.3.6.1.2.1.2.2.1.11", ASN1_COUNTER32}, // ifInUcastPkts
+	{"1.3.6.1.2.1.2.2.1.12", ASN1_COUNTER32}, // ifInNUcastPkts
+	{"1.3.6.1.2.1.2.2.1.13", ASN1_COUNTER32}, // ifInDiscards
+	{"1.3.6.1.2.1.2.2.1.14", ASN1_COUNTER32}, // ifInErrors
+	{"1.3.6.1.2.1.2.2.1.15", ASN1_COUNTER32}, // ifInUnknownProtos
+	{"1.3.6.1.2.1.2.2.1.16", ASN1_COUNTER32}, // ifOutOctets
+	{"1.3.6.1.2.1.2.2.1.17", ASN1_COUNTER32}, // ifOutUcastPkts
+	{"1.3.6.1.2.1.2.2.1.18", ASN1_COUNTER32}, // ifOutNUcastPkts
+	{"1.3.6.1.2.1.2.2.1.19", ASN1_COUNTER32}, // ifOutDiscards
+	{"1.3.6.1.2.1.2.2.1.20", ASN1_COUNTER32}, // ifOutErrors
+	{"1.3.6.1.2.1.2.2.1.21", ASN1_GAUGE32},   // ifOutQLen
+
+	// ifXTable — RFC 2863
+	{"1.3.6.1.2.1.31.1.1.1.2", ASN1_COUNTER32},  // ifInMulticastPkts
+	{"1.3.6.1.2.1.31.1.1.1.3", ASN1_COUNTER32},  // ifInBroadcastPkts
+	{"1.3.6.1.2.1.31.1.1.1.4", ASN1_COUNTER32},  // ifOutMulticastPkts
+	{"1.3.6.1.2.1.31.1.1.1.5", ASN1_COUNTER32},  // ifOutBroadcastPkts
+	{"1.3.6.1.2.1.31.1.1.1.6", ASN1_COUNTER64},  // ifHCInOctets
+	{"1.3.6.1.2.1.31.1.1.1.7", ASN1_COUNTER64},  // ifHCInUcastPkts
+	{"1.3.6.1.2.1.31.1.1.1.8", ASN1_COUNTER64},  // ifHCInMulticastPkts
+	{"1.3.6.1.2.1.31.1.1.1.9", ASN1_COUNTER64},  // ifHCInBroadcastPkts
+	{"1.3.6.1.2.1.31.1.1.1.10", ASN1_COUNTER64}, // ifHCOutOctets
+	{"1.3.6.1.2.1.31.1.1.1.11", ASN1_COUNTER64}, // ifHCOutUcastPkts
+	{"1.3.6.1.2.1.31.1.1.1.12", ASN1_COUNTER64}, // ifHCOutMulticastPkts
+	{"1.3.6.1.2.1.31.1.1.1.13", ASN1_COUNTER64}, // ifHCOutBroadcastPkts
+	{"1.3.6.1.2.1.31.1.1.1.15", ASN1_GAUGE32},   // ifHighSpeed
+	{"1.3.6.1.2.1.31.1.1.1.19", ASN1_TIMETICKS}, // ifCounterDiscontinuityTime
+
+	// ipAddrTable — RFC 4293
+	{"1.3.6.1.2.1.4.20.1.1", ASN1_IPADDRESS}, // ipAdEntAddr
+	{"1.3.6.1.2.1.4.20.1.3", ASN1_IPADDRESS}, // ipAdEntNetMask
+
+	// ipRouteTable (deprecated but still walked by many NMSes)
+	{"1.3.6.1.2.1.4.21.1.1", ASN1_IPADDRESS},  // ipRouteDest
+	{"1.3.6.1.2.1.4.21.1.7", ASN1_IPADDRESS},  // ipRouteNextHop
+	{"1.3.6.1.2.1.4.21.1.11", ASN1_IPADDRESS}, // ipRouteMask
+
+	// ipNetToMediaTable
+	{"1.3.6.1.2.1.4.22.1.3", ASN1_IPADDRESS}, // ipNetToMediaNetAddress
+}
+
+// snmpTypeTag returns the SNMP application type tag for the given OID, or 0
+// if the OID is not in the well-known type table (use INTEGER / OCTET_STRING).
+func snmpTypeTag(oid string) byte {
+	for _, e := range oidTypeTable {
+		if strings.HasPrefix(oid, e.prefix+".") || oid == e.prefix {
+			return e.tag
+		}
+	}
+	return 0
+}
+
+// encodeTypedValue encodes an SNMP value using the correct ASN.1 type tag for
+// the given OID. This replaces the old pattern of encoding every numeric value
+// as INTEGER (0x02) regardless of the OID's MIB definition.
+//
+// Type resolution priority:
+//  1. "endOfMibView" exception (SNMPv2c)
+//  2. OID-derived application type (Counter32, Gauge32, TimeTicks, Counter64, IpAddress)
+//  3. Integer-parseable value → INTEGER
+//  4. Everything else → OCTET STRING
+func encodeTypedValue(oid, value string) []byte {
+	if value == "endOfMibView" {
+		return []byte{0x82, 0x00}
+	}
+
+	tag := snmpTypeTag(oid)
+	switch tag {
+	case ASN1_IPADDRESS:
+		return encodeIPAddress(value)
+
+	case ASN1_COUNTER32, ASN1_GAUGE32, ASN1_TIMETICKS:
+		if u, err := strconv.ParseUint(value, 10, 32); err == nil {
+			return encodeUnsigned32(tag, uint32(u))
+		}
+		// Negative values are theoretically invalid for unsigned types, but
+		// some resource files use -1 as a placeholder. Wrap-cast to uint32.
+		if i, err := strconv.ParseInt(value, 10, 64); err == nil {
+			return encodeUnsigned32(tag, uint32(i))
+		}
+		return encodeOctetString(value)
+
+	case ASN1_COUNTER64:
+		if u, err := strconv.ParseUint(value, 10, 64); err == nil {
+			return encodeCounter64(u)
+		}
+		return encodeOctetString(value)
+
+	default:
+		// No special type: integer values → INTEGER, everything else → OCTET STRING.
+		if i, err := strconv.Atoi(value); err == nil {
+			return encodeInteger(i)
+		}
+		return encodeOctetString(value)
+	}
 }
 
 // extractOIDFromSNMPPacket parses SNMP BER/DER encoded packet to find OID

--- a/go/simulator/snmp_getbulk_test.go
+++ b/go/simulator/snmp_getbulk_test.go
@@ -154,6 +154,9 @@ func parseGetBulkResponse(data []byte) ([]string, []string, error) {
 }
 
 // extractVarBindValue returns a string representation of the next ASN.1 value.
+// Handles INTEGER, OCTET STRING, and SNMPv2c application types (Gauge32,
+// Counter32, TimeTicks, Counter64) so that test assertions can compare
+// numeric values regardless of which application tag was used.
 func extractVarBindValue(data []byte, pos int) string {
 	if pos >= len(data) {
 		return ""
@@ -170,6 +173,19 @@ func extractVarBindValue(data []byte, pos int) string {
 		v := 0
 		for i := 0; i < vLen && pos+i < len(data); i++ {
 			v = (v << 8) | int(data[pos+i])
+		}
+		return fmt.Sprintf("%d", v)
+	case ASN1_GAUGE32, ASN1_COUNTER32, ASN1_TIMETICKS:
+		// Unsigned 32-bit application types — decode as uint then format.
+		var v uint64
+		for i := 0; i < vLen && pos+i < len(data); i++ {
+			v = (v << 8) | uint64(data[pos+i])
+		}
+		return fmt.Sprintf("%d", v)
+	case ASN1_COUNTER64:
+		var v uint64
+		for i := 0; i < vLen && pos+i < len(data); i++ {
+			v = (v << 8) | uint64(data[pos+i])
 		}
 		return fmt.Sprintf("%d", v)
 	case ASN1_OCTET_STRING:

--- a/go/simulator/snmp_response.go
+++ b/go/simulator/snmp_response.go
@@ -20,7 +20,6 @@ import (
 	"crypto/des"
 	"crypto/md5"
 	"fmt"
-	"strconv"
 )
 
 // SNMP request parser
@@ -158,19 +157,8 @@ func (s *SNMPServer) createSNMPResponse(oid, value string, requestData []byte) [
 	// Parse incoming request to get actual community and request ID
 	req := s.parseIncomingRequest(requestData)
 
-	// Determine SNMP data type based on OID and value
-	var valueBytes []byte
-
-	if value == "endOfMibView" {
-		// Special handling for endOfMibView (SNMPv2c)
-		valueBytes = []byte{0x82, 0x00} // endOfMibView exception
-	} else if intVal, err := strconv.Atoi(value); err == nil {
-		// Integer value
-		valueBytes = encodeInteger(intVal)
-	} else {
-		// String value
-		valueBytes = encodeOctetString(value)
-	}
+	// Encode value with the correct ASN.1 type for this OID (RFC 1902).
+	valueBytes := encodeTypedValue(oid, value)
 
 	// Create variable binding (OID + value)
 	oidBytes := encodeOID(oid)
@@ -220,20 +208,9 @@ func (s *SNMPServer) createGetBulkResponse(oids []string, responses []string, re
 	var varBindList []byte
 
 	for i, oid := range oids {
-		// Determine proper value encoding (same logic as createSNMPResponse)
-		var valueBytes []byte
+		// Encode value with the correct ASN.1 type for this OID (RFC 1902).
 		value := responses[i]
-
-		if value == "endOfMibView" {
-			// Special handling for endOfMibView (SNMPv2c)
-			valueBytes = []byte{0x82, 0x00} // endOfMibView exception
-		} else if intVal, err := strconv.Atoi(value); err == nil {
-			// Integer value
-			valueBytes = encodeInteger(intVal)
-		} else {
-			// String value
-			valueBytes = encodeOctetString(value)
-		}
+		valueBytes := encodeTypedValue(oid, value)
 
 		// Create variable binding: SEQUENCE { OID, value } - CORRECT ORDER
 		oidBytes := encodeOID(oid)

--- a/go/simulator/snmp_type_test.go
+++ b/go/simulator/snmp_type_test.go
@@ -1,0 +1,241 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for RFC 1902 SNMP type encoding. No Linux syscalls — runs on any OS.
+
+package main
+
+import (
+	"testing"
+)
+
+// ── snmpTypeTag ───────────────────────────────────────────────────────────────
+
+func TestSnmpTypeTag(t *testing.T) {
+	tests := []struct {
+		oid  string
+		want byte
+	}{
+		// sysUpTime → TimeTicks
+		{"1.3.6.1.2.1.1.3.0", ASN1_TIMETICKS},
+
+		// ifSpeed → Gauge32
+		{"1.3.6.1.2.1.2.2.1.5.1", ASN1_GAUGE32},
+		{"1.3.6.1.2.1.2.2.1.5.24", ASN1_GAUGE32},
+
+		// ifLastChange → TimeTicks
+		{"1.3.6.1.2.1.2.2.1.9.1", ASN1_TIMETICKS},
+
+		// ifInOctets → Counter32
+		{"1.3.6.1.2.1.2.2.1.10.1", ASN1_COUNTER32},
+
+		// ifHighSpeed → Gauge32
+		{"1.3.6.1.2.1.31.1.1.1.15.1", ASN1_GAUGE32},
+
+		// ifHCInOctets → Counter64
+		{"1.3.6.1.2.1.31.1.1.1.6.1", ASN1_COUNTER64},
+
+		// ifHCOutOctets → Counter64
+		{"1.3.6.1.2.1.31.1.1.1.10.1", ASN1_COUNTER64},
+
+		// ipRouteDest → IpAddress
+		{"1.3.6.1.2.1.4.21.1.1.192.168.1.0", ASN1_IPADDRESS},
+
+		// ipRouteNextHop → IpAddress
+		{"1.3.6.1.2.1.4.21.1.7.0.0.0.0", ASN1_IPADDRESS},
+
+		// ifIndex → INTEGER (not in table → 0)
+		{"1.3.6.1.2.1.2.2.1.1.1", 0},
+
+		// ifAdminStatus → INTEGER (not in table → 0)
+		{"1.3.6.1.2.1.2.2.1.7.1", 0},
+
+		// sysDescr → OCTET STRING (not in table → 0)
+		{"1.3.6.1.2.1.1.1.0", 0},
+
+		// Unrecognised → 0
+		{"1.2.3.4.5", 0},
+	}
+
+	for _, tc := range tests {
+		got := snmpTypeTag(tc.oid)
+		if got != tc.want {
+			t.Errorf("snmpTypeTag(%q) = 0x%02x, want 0x%02x", tc.oid, got, tc.want)
+		}
+	}
+}
+
+// Verify that a partial prefix does not match a longer column.
+// e.g. prefix "1.3.6.1.2.1.2.2.1.1" (ifIndex) must NOT match
+// "1.3.6.1.2.1.2.2.1.10.1" (ifInOctets), which would give the wrong type.
+func TestSnmpTypeTag_NoPrefixFalseMatch(t *testing.T) {
+	// ifInOctets (column 10) must not match ifIndex (column 1)
+	if got := snmpTypeTag("1.3.6.1.2.1.2.2.1.10.1"); got != ASN1_COUNTER32 {
+		t.Errorf("ifInOctets OID: got 0x%02x, want ASN1_COUNTER32 (0x%02x)", got, ASN1_COUNTER32)
+	}
+	// ifHCOutOctets (column 10 in ifXTable) must not match ifInMulticastPkts (column 2)
+	if got := snmpTypeTag("1.3.6.1.2.1.31.1.1.1.10.1"); got != ASN1_COUNTER64 {
+		t.Errorf("ifHCOutOctets OID: got 0x%02x, want ASN1_COUNTER64 (0x%02x)", got, ASN1_COUNTER64)
+	}
+}
+
+// ── encodeUnsigned32 ──────────────────────────────────────────────────────────
+
+func TestEncodeUnsigned32(t *testing.T) {
+	tests := []struct {
+		tag   byte
+		value uint32
+		want  []byte
+	}{
+		{ASN1_GAUGE32, 0, []byte{0x42, 0x01, 0x00}},
+		{ASN1_GAUGE32, 1000, []byte{0x42, 0x02, 0x03, 0xE8}},
+		{ASN1_GAUGE32, 1000000000, []byte{0x42, 0x04, 0x3B, 0x9A, 0xCA, 0x00}},
+		{ASN1_COUNTER32, 4294967295, []byte{0x41, 0x04, 0xFF, 0xFF, 0xFF, 0xFF}}, // max uint32
+		{ASN1_TIMETICKS, 123456789, []byte{0x43, 0x04, 0x07, 0x5B, 0xCD, 0x15}},
+	}
+
+	for _, tc := range tests {
+		got := encodeUnsigned32(tc.tag, tc.value)
+		if !bytesEqual(got, tc.want) {
+			t.Errorf("encodeUnsigned32(0x%02x, %d) = %x, want %x", tc.tag, tc.value, got, tc.want)
+		}
+	}
+}
+
+// ── encodeCounter64 ───────────────────────────────────────────────────────────
+
+func TestEncodeCounter64(t *testing.T) {
+	tests := []struct {
+		value uint64
+		want  []byte
+	}{
+		{0, []byte{0x46, 0x01, 0x00}},
+		{1, []byte{0x46, 0x01, 0x01}},
+		// 13897247566 = 0x33C572B4E (value from cisco_ios_snmp_hcif.json ifHCInOctets)
+		{13897247566, []byte{0x46, 0x05, 0x03, 0x3C, 0x57, 0x2B, 0x4E}},
+		// max uint64
+		{18446744073709551615, []byte{0x46, 0x08, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+
+	for _, tc := range tests {
+		got := encodeCounter64(tc.value)
+		if !bytesEqual(got, tc.want) {
+			t.Errorf("encodeCounter64(%d) = %x, want %x", tc.value, got, tc.want)
+		}
+	}
+}
+
+// ── encodeIPAddress ───────────────────────────────────────────────────────────
+
+func TestEncodeIPAddress(t *testing.T) {
+	tests := []struct {
+		ipStr string
+		want  []byte
+	}{
+		{"192.168.1.0", []byte{0x40, 0x04, 192, 168, 1, 0}},
+		{"0.0.0.0", []byte{0x40, 0x04, 0, 0, 0, 0}},
+		{"255.255.255.255", []byte{0x40, 0x04, 255, 255, 255, 255}},
+		{"10.0.0.1", []byte{0x40, 0x04, 10, 0, 0, 1}},
+	}
+
+	for _, tc := range tests {
+		got := encodeIPAddress(tc.ipStr)
+		if !bytesEqual(got, tc.want) {
+			t.Errorf("encodeIPAddress(%q) = %x, want %x", tc.ipStr, got, tc.want)
+		}
+	}
+
+	// Non-IP string should fall back to OCTET STRING (tag 0x04).
+	got := encodeIPAddress("not-an-ip")
+	if len(got) == 0 || got[0] != ASN1_OCTET_STRING {
+		t.Errorf("encodeIPAddress(invalid) tag = 0x%02x, want OCTET STRING (0x04)", got[0])
+	}
+}
+
+// ── encodeTypedValue ─────────────────────────────────────────────────────────
+
+func TestEncodeTypedValue_EndOfMibView(t *testing.T) {
+	got := encodeTypedValue("1.3.6.1.2.1.2.2.1.5.1", "endOfMibView")
+	want := []byte{0x82, 0x00}
+	if !bytesEqual(got, want) {
+		t.Errorf("endOfMibView: got %x, want %x", got, want)
+	}
+}
+
+func TestEncodeTypedValue_Gauge32(t *testing.T) {
+	// ifSpeed = 1000 Mbps expressed in bps = 1000000000
+	got := encodeTypedValue("1.3.6.1.2.1.2.2.1.5.1", "1000000000")
+	if len(got) == 0 || got[0] != ASN1_GAUGE32 {
+		t.Errorf("ifSpeed tag: got 0x%02x, want Gauge32 (0x%02x)", got[0], ASN1_GAUGE32)
+	}
+}
+
+func TestEncodeTypedValue_Counter32(t *testing.T) {
+	got := encodeTypedValue("1.3.6.1.2.1.2.2.1.10.1", "123456") // ifInOctets
+	if len(got) == 0 || got[0] != ASN1_COUNTER32 {
+		t.Errorf("ifInOctets tag: got 0x%02x, want Counter32 (0x%02x)", got[0], ASN1_COUNTER32)
+	}
+}
+
+func TestEncodeTypedValue_Counter64(t *testing.T) {
+	got := encodeTypedValue("1.3.6.1.2.1.31.1.1.1.6.1", "13897247566") // ifHCInOctets
+	if len(got) == 0 || got[0] != ASN1_COUNTER64 {
+		t.Errorf("ifHCInOctets tag: got 0x%02x, want Counter64 (0x%02x)", got[0], ASN1_COUNTER64)
+	}
+}
+
+func TestEncodeTypedValue_TimeTicks(t *testing.T) {
+	got := encodeTypedValue("1.3.6.1.2.1.1.3.0", "123456789") // sysUpTime
+	if len(got) == 0 || got[0] != ASN1_TIMETICKS {
+		t.Errorf("sysUpTime tag: got 0x%02x, want TimeTicks (0x%02x)", got[0], ASN1_TIMETICKS)
+	}
+}
+
+func TestEncodeTypedValue_IpAddress(t *testing.T) {
+	got := encodeTypedValue("1.3.6.1.2.1.4.21.1.1.192.168.1.0", "192.168.1.0") // ipRouteDest
+	if len(got) == 0 || got[0] != ASN1_IPADDRESS {
+		t.Errorf("ipRouteDest tag: got 0x%02x, want IpAddress (0x%02x)", got[0], ASN1_IPADDRESS)
+	}
+}
+
+func TestEncodeTypedValue_Integer(t *testing.T) {
+	// ifAdminStatus is not in the type table → should be INTEGER
+	got := encodeTypedValue("1.3.6.1.2.1.2.2.1.7.1", "1")
+	if len(got) == 0 || got[0] != ASN1_INTEGER {
+		t.Errorf("ifAdminStatus tag: got 0x%02x, want INTEGER (0x%02x)", got[0], ASN1_INTEGER)
+	}
+}
+
+func TestEncodeTypedValue_OctetString(t *testing.T) {
+	// sysDescr → OCTET STRING (non-integer string, not in type table)
+	got := encodeTypedValue("1.3.6.1.2.1.1.1.0", "Cisco IOS")
+	if len(got) == 0 || got[0] != ASN1_OCTET_STRING {
+		t.Errorf("sysDescr tag: got 0x%02x, want OCTET STRING (0x%02x)", got[0], ASN1_OCTET_STRING)
+	}
+}
+
+// ── helper ────────────────────────────────────────────────────────────────────
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Problem

All numeric SNMP values were encoded with tag `0x02` (INTEGER) regardless of the OID's MIB definition. This caused OpenNMS and other NMS tools to misinterpret values:

- **ifSpeed / ifHighSpeed** shown as N/A or wrong units (should be Gauge32)
- **ifIn/OutOctets** not usable for rate graphs (should be Counter32)
- **ifHCIn/OutOctets** broken for 64-bit counters (should be Counter64)
- **sysUpTime** displayed incorrectly (should be TimeTicks)
- **IP route/address columns** shown as integers (should be IpAddress)

## Solution

Introduce an OID-to-type prefix table mapping ~35 standard MIB columns to their RFC 1902 application type tags. A new `encodeTypedValue(oid, value)` function replaces the old generic integer/string if-else in both `createSNMPResponse` and `createGetBulkResponse`.

### New encoding functions
| Function | Tag | Used for |
|---|---|---|
| `encodeUnsigned32(tag, value)` | 0x41 / 0x42 / 0x43 | Counter32, Gauge32, TimeTicks |
| `encodeCounter64(value)` | 0x46 | ifHCIn/OutOctets and friends |
| `encodeIPAddress(ipStr)` | 0x40 | ipRoute*, ipAddr* columns |

### Type table highlights
- `sysUpTime` → TimeTicks
- `ifSpeed`, `ifHighSpeed`, `ifOutQLen` → Gauge32
- `ifLastChange`, `ifCounterDiscontinuityTime` → TimeTicks
- `ifIn/OutOctets` and all other 32-bit counters → Counter32
- `ifHCIn/OutOctets` and other HC columns → Counter64
- `ipRouteDest`, `ipRouteNextHop`, `ipRouteMask`, `ipAdEntAddr`, `ipAdEntNetMask` → IpAddress

## Test plan
- [ ] `go test ./simulator/` passes (new `snmp_type_test.go` covers all encoders and type-tag lookup including false-match regression)
- [ ] `snmpwalk` against a running simulator shows correct types (e.g. `GAUGE` for ifSpeed, `Counter32` for ifInOctets)
- [ ] OpenNMS interface table shows speed values and traffic graphs populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)