### PR TITLE
feat(snmp): make SNMP UDP listener port configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ sudo ./simulator [flags]
 -auto-start-ip <IP>     # Auto-create devices starting at this IP
 -auto-count <N>         # Number of devices to auto-create
 -port <port>            # HTTP API port (default: 8080)
+-snmp-port <port>       # UDP port for SNMP listener on each device (default: 161)
 -snmpv3-engine-id <id>  # Enable SNMPv3 (omit for v2c only)
 -snmpv3-auth <proto>    # none | md5 | sha1
 -snmpv3-priv <proto>    # none | des | aes128

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Options:
   -auto-start-ip string       Auto-create devices starting from this IP (e.g., 192.168.100.1)
   -auto-count int             Number of devices to auto-create (requires -auto-start-ip)
   -auto-netmask string        Netmask for auto-created devices (default: "24")
-  -port string                Server port (default: "8080")
+  -port string                HTTP API server port (default: "8080")
+  -snmp-port int              UDP port for the SNMP listener on each device (default: 161)
   -snmpv3-engine-id string    Enable SNMPv3 with specified engine ID
   -snmpv3-auth string         SNMPv3 auth protocol: none, md5, sha1 (default: "md5")
   -snmpv3-priv string         SNMPv3 privacy protocol: none, des, aes128 (default: "none")
@@ -99,8 +100,11 @@ sudo ./simulator
 # Auto-create 5 devices starting from 192.168.100.1
 sudo ./simulator -auto-start-ip 192.168.100.1 -auto-count 5
 
-# Custom port and subnet
+# Custom API port and subnet
 sudo ./simulator -auto-start-ip 10.10.10.1 -auto-count 100 -port 9090
+
+# Use a non-privileged SNMP port (avoids requiring CAP_NET_BIND_SERVICE)
+sudo ./simulator -auto-start-ip 10.10.10.1 -auto-count 10 -snmp-port 1161
 
 # Enable SNMPv3 with MD5 authentication and AES128 privacy
 sudo ./simulator -snmpv3-engine-id 0x80001234 -snmpv3-auth md5 -snmpv3-priv aes128
@@ -181,6 +185,16 @@ curl -X POST http://localhost:8080/api/v1/devices \
     "round_robin": true
   }'
 
+# Create devices on a non-privileged SNMP port
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_ip": "192.168.100.1",
+    "device_count": 5,
+    "netmask": "24",
+    "snmp_port": 1161
+  }'
+
 # Create devices filtered by category
 curl -X POST http://localhost:8080/api/v1/devices \
   -H "Content-Type: application/json" \
@@ -257,6 +271,9 @@ snmpget -v2c -c public 192.168.100.1 1.3.6.1.2.1.1.1.0
 
 # Walk interface table
 snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.2.2.1
+
+# Query on a custom SNMP port (e.g. 1161)
+snmpwalk -v2c -c public -p 1161 192.168.100.1 1.3.6.1.2.1.1
 
 # SNMPv3 query (when enabled)
 snmpget -v3 -l authPriv -u admin -a MD5 -A authpass123 -x AES -X privpass123 \
@@ -479,11 +496,13 @@ Metrics are exposed via NVIDIA DCGM SNMP OIDs and cycle through 100 pre-generate
 
 Each device type has its own directory under `go/simulator/resources/` with JSON files split for maintainability. The loader automatically merges all JSON files in a device directory. There are currently 341 JSON resource files across 28 device types.
 
+OIDs in resource files may be written with or without a leading dot — the loader normalises them to the net-snmp convention (`.1.3.6.1…`) at startup.
+
 ```json
 {
   "snmp": [
     {
-      "oid": "1.3.6.1.2.1.1.1.0",
+      "oid": ".1.3.6.1.2.1.1.1.0",
       "response": "Cisco IOS Software, Router Version 15.1"
     }
   ],
@@ -625,10 +644,11 @@ The simulator is optimized for high-scale deployments:
 ### Common Issues
 
 1. **Permission Denied**: Ensure running with `sudo` for TUN interface creation
-2. **Port Conflicts**: Use `-port` flag to specify alternative port
-3. **TUN Module Missing**: Run `sudo modprobe tun`
-4. **High Resource Usage**: Increase file limits with `./increase_file_limits.sh` and use network namespaces (enabled by default)
-5. **SNMP Integer Encoding**: Fixed panic issues with negative integer values in ASN.1 encoding
+2. **Port Conflicts**: Use `-port` flag to specify an alternative HTTP API port
+3. **SNMP Privileged Port**: Port 161 requires root or `CAP_NET_BIND_SERVICE`; use `-snmp-port 1161` to bind a non-privileged port instead
+4. **TUN Module Missing**: Run `sudo modprobe tun`
+5. **High Resource Usage**: Increase file limits with `./increase_file_limits.sh` and use network namespaces (enabled by default)
+6. **SNMP Integer Encoding**: Fixed panic issues with negative integer values in ASN.1 encoding
 
 ### Debug Commands
 
@@ -636,8 +656,8 @@ The simulator is optimized for high-scale deployments:
 # Check TUN interfaces
 ip addr show | grep sim
 
-# Verify device processes
-ss -tulpn | grep -E "(161|22)"
+# Verify device processes (adjust port if using -snmp-port)
+ss -tulpn | grep -E "(161|1161|22)"
 
 # Monitor system resources
 htop

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -25,12 +25,16 @@ import (
 	"time"
 )
 
-func (sm *SimulatorManager) CreateDevices(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, roundRobin bool, category string) error {
-	return sm.CreateDevicesWithOptions(startIP, count, netmask, resourceFile, v3Config, true, 0, roundRobin, category)
+func (sm *SimulatorManager) CreateDevices(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, roundRobin bool, category string, snmpPort int) error {
+	return sm.CreateDevicesWithOptions(startIP, count, netmask, resourceFile, v3Config, true, 0, roundRobin, category, snmpPort)
 }
 
 // CreateDevicesWithOptions creates devices with optional pre-allocation control
-func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, preAllocate bool, maxWorkers int, roundRobin bool, category string) error {
+func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, preAllocate bool, maxWorkers int, roundRobin bool, category string, snmpPort int) error {
+	if snmpPort == 0 {
+		snmpPort = DEFAULT_SNMP_PORT
+	}
+
 	// Set device creation status
 	sm.isCreatingDevices.Store(true)
 	sm.deviceCreateProgress.Store(0)
@@ -147,7 +151,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 
 	if sm.tunPoolSize > 0 {
 		// Pre-allocation was done - create devices in parallel
-		sm.createDevicesParallel(count, netmask, resourceFile, resources, v3Config, &successCount, roundRobin, roundRobinResources, roundRobinResourceFiles)
+		sm.createDevicesParallel(count, netmask, resourceFile, resources, v3Config, &successCount, roundRobin, roundRobinResources, roundRobinResourceFiles, snmpPort)
 	} else {
 		// No pre-allocation - create devices sequentially (original logic)
 		for i := 0; i < count; i++ {
@@ -225,7 +229,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			device := &DeviceSimulator{
 				ID:           deviceID,
 				IP:           deviceIP,
-				SNMPPort:     DEFAULT_SNMP_PORT,
+				SNMPPort:     snmpPort,
 				SSHPort:      DEFAULT_SSH_PORT,
 				APIPort:      DEFAULT_API_PORT,
 				tunIface:     tunIface,
@@ -324,7 +328,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 }
 
 // createDevicesParallel creates devices in parallel when pre-allocation was done
-func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, successCount *int, roundRobin bool, roundRobinResources []*DeviceResources, roundRobinResourceFiles []string) {
+func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, successCount *int, roundRobin bool, roundRobinResources []*DeviceResources, roundRobinResourceFiles []string, snmpPort int) {
 	// Worker pool for parallel device creation
 	sem := make(chan struct{}, sm.maxWorkers) // Limit concurrent workers
 	var wg sync.WaitGroup
@@ -383,7 +387,7 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 			defer func() { <-sem }()
 
 			// Create device in parallel
-			if sm.createSingleDevice(deviceIndex, ip, devID, netmask, devResourceFile, devResources, v3Config) {
+			if sm.createSingleDevice(deviceIndex, ip, devID, netmask, devResourceFile, devResources, v3Config, snmpPort) {
 				mu.Lock()
 				(*successCount)++
 				progress := *successCount
@@ -408,7 +412,7 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 }
 
 // createSingleDevice creates a single device - used by parallel device creation
-func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP, deviceID string, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config) bool {
+func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP, deviceID string, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, snmpPort int) bool {
 	// Check if we have a pre-allocated interface for this IP
 	var tunIface *TunInterface
 
@@ -438,14 +442,13 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 		}
 	}
 
-	// Create device with default ports
 	sysLocationValue := getRandomCity()
 	sysNameValue := getRandomDeviceName()
 
 	device := &DeviceSimulator{
 		ID:           deviceID,
 		IP:           make(net.IP, len(deviceIP)),
-		SNMPPort:     DEFAULT_SNMP_PORT,
+		SNMPPort:     snmpPort,
 		SSHPort:      DEFAULT_SSH_PORT,
 		APIPort:      DEFAULT_API_PORT,
 		tunIface:     tunIface,

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -96,6 +96,7 @@ func main() {
 		snmpv3AuthProto = flag.String("snmpv3-auth", "md5", "SNMPv3 authentication protocol: none, md5, sha1 (default: md5)")
 		snmpv3PrivProto = flag.String("snmpv3-priv", "none", "SNMPv3 privacy protocol: none, des, aes128 (default: none)")
 		port            = flag.String("port", "8080", "Server port (default: 8080)")
+		snmpPort        = flag.Int("snmp-port", DEFAULT_SNMP_PORT, "UDP port for SNMP listener on each device (default: 161)")
 		noNamespace     = flag.Bool("no-namespace", false, "Disable network namespace isolation (use root namespace)")
 		showHelp        = flag.Bool("help", false, "Show this help message")
 		ifScenario      = flag.Int("if-scenario", 2, "Interface state scenario: 1=all-shutdown, 2=all-normal (default), 3=all-failure, 4=pct-failure")
@@ -129,7 +130,8 @@ func main() {
 		fmt.Println("Examples:")
 		fmt.Printf("  %s                                                    # Start server only\n", os.Args[0])
 		fmt.Printf("  %s -auto-start-ip 192.168.100.1 -auto-count 5       # Auto-create 5 devices\n", os.Args[0])
-		fmt.Printf("  %s -auto-start-ip 10.10.10.1 -auto-count 3 -port 9090  # Custom port\n", os.Args[0])
+		fmt.Printf("  %s -auto-start-ip 10.10.10.1 -auto-count 3 -port 9090  # Custom API port\n", os.Args[0])
+		fmt.Printf("  %s -auto-start-ip 10.10.10.1 -auto-count 3 -snmp-port 1161  # Non-privileged SNMP port\n", os.Args[0])
 		fmt.Printf("  %s -auto-start-ip 192.168.100.1 -auto-count 30000      # 30K devices (uses namespace)\n", os.Args[0])
 		fmt.Printf("  %s -auto-start-ip 192.168.100.1 -auto-count 100 -no-namespace  # Disable namespace\n", os.Args[0])
 		fmt.Printf("  %s -auto-start-ip 192.168.100.1 -auto-count 2 \\      # SNMPv3 with MD5 auth\n", os.Args[0])
@@ -222,7 +224,7 @@ func main() {
 					*snmpv3EngineID, *snmpv3AuthProto, *snmpv3PrivProto)
 			}
 
-			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "")
+			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort)
 			if err != nil {
 				log.Printf("Failed to auto-create devices: %v", err)
 			} else {

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -192,7 +192,8 @@ type CreateDevicesRequest struct {
 	Category     string         `json:"category,omitempty"`      // Optional: filter round robin to a category
 	SNMPv3       *SNMPv3Config  `json:"snmpv3,omitempty"`
 	PreAllocate  bool           `json:"pre_allocate,omitempty"` // Optional: explicitly enable/disable pre-allocation
-	MaxWorkers   int            `json:"max_workers,omitempty"` // Optional: max workers for pre-allocation
+	MaxWorkers   int            `json:"max_workers,omitempty"`  // Optional: max workers for pre-allocation
+	SNMPPort     int            `json:"snmp_port,omitempty"`    // Optional: UDP port for SNMP listener (default: 161)
 }
 
 // RoundRobinDeviceTypes defines all 28 device flavors for round robin creation

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -41,14 +41,23 @@ func createDevicesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	snmpPort := req.SNMPPort
+	if snmpPort == 0 {
+		snmpPort = DEFAULT_SNMP_PORT
+	}
+	if snmpPort < 1 || snmpPort > 65535 {
+		sendErrorResponse(w, "snmp_port must be between 1 and 65535", http.StatusBadRequest)
+		return
+	}
+
 	// Use CreateDevicesWithOptions if pre-allocation parameters are specified
 	if req.PreAllocate || req.MaxWorkers > 0 {
 		// If PreAllocate is not explicitly set but MaxWorkers is provided, enable pre-allocation
 		preAllocate := req.PreAllocate || req.MaxWorkers > 0
-		err = manager.CreateDevicesWithOptions(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, preAllocate, req.MaxWorkers, req.RoundRobin, req.Category)
+		err = manager.CreateDevicesWithOptions(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, preAllocate, req.MaxWorkers, req.RoundRobin, req.Category, snmpPort)
 	} else {
 		// Use default behavior (auto pre-allocates for 10+ devices)
-		err = manager.CreateDevices(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, req.RoundRobin, req.Category)
+		err = manager.CreateDevices(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, req.RoundRobin, req.Category, snmpPort)
 	}
 	if err != nil {
 		sendErrorResponse(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

- Adds `-snmp-port <N>` CLI flag so the SNMP UDP listener port can be changed from the default 161
- Adds `snmp_port` JSON field to the `POST /api/v1/devices` REST body for the same effect
- Useful when running without root (ports < 1024 require `CAP_NET_BIND_SERVICE`) or when multiple simulator instances share a host

## Usage

**CLI**
```bash
sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 5 -snmp-port 1161
```

**REST API**
```bash
curl -X POST http://localhost:8080/api/v1/devices \
  -H "Content-Type: application/json" \
  -d '{"start_ip":"10.0.0.1","device_count":3,"snmp_port":1161}'
```

Omitting `snmp_port` (or sending `0`) keeps the default of 161.

## Test plan

- [ ] Build passes: `cd go/simulator && go build .`
- [ ] Start simulator with `-snmp-port 1161`, confirm devices respond on UDP 1161: `snmpwalk -v2c -c public -p 1161 <device-ip> 1.3.6.1.2.1.1`
- [ ] Default (no flag) still binds port 161
- [ ] REST API path: POST with `"snmp_port":1161` and verify `snmp_port` in the device list response

🤖 Generated with [Claude Code](https://claude.com/claude-code)