### PR TITLE
fix(snmp): encode sysObjectID as OBJECT IDENTIFIER, not OCTET STRING

### DIFF
--- a/go/simulator/snmp_encoding.go
+++ b/go/simulator/snmp_encoding.go
@@ -282,12 +282,15 @@ type oidTypeEntry struct {
 }
 
 // oidTypeTable maps standard MIB OID column prefixes to their RFC-mandated
-// ASN.1 application type tags. Leaf OIDs are matched by HasPrefix(oid, prefix+".").
-// The trailing "." in the check prevents digit-extension false matches
-// (e.g. column prefix "...1" cannot match "...10.*"), so ordering is irrelevant
-// for correctness.
+// ASN.1 application type tags. snmpTypeTag() matches a leaf OID against each
+// entry using HasPrefix(oid, prefix+".") OR exact equality (oid == prefix),
+// so both ".1.3.6.1.2.1.1.2.0" and the bare ".1.3.6.1.2.1.1.2" match the
+// sysObjectID entry. The trailing "." in the HasPrefix check prevents
+// digit-extension false matches (e.g. prefix "...1" cannot match "...10.*"),
+// so ordering within the table is irrelevant for correctness.
 var oidTypeTable = []oidTypeEntry{
 	// MIB-II system group
+	{".1.3.6.1.2.1.1.2", ASN1_OBJECT_ID}, // sysObjectID
 	{".1.3.6.1.2.1.1.3", ASN1_TIMETICKS}, // sysUpTime
 
 	// ifTable — RFC 2863
@@ -362,6 +365,9 @@ func encodeTypedValue(oid, value string) []byte {
 
 	tag := snmpTypeTag(oid)
 	switch tag {
+	case ASN1_OBJECT_ID:
+		return encodeOID(value)
+
 	case ASN1_IPADDRESS:
 		return encodeIPAddress(value)
 

--- a/go/simulator/snmp_type_test.go
+++ b/go/simulator/snmp_type_test.go
@@ -28,6 +28,9 @@ func TestSnmpTypeTag(t *testing.T) {
 		oid  string
 		want byte
 	}{
+		// sysObjectID → OBJECT IDENTIFIER
+		{".1.3.6.1.2.1.1.2.0", ASN1_OBJECT_ID},
+
 		// sysUpTime → TimeTicks
 		{".1.3.6.1.2.1.1.3.0", ASN1_TIMETICKS},
 
@@ -165,6 +168,36 @@ func TestEncodeIPAddress(t *testing.T) {
 }
 
 // ── encodeTypedValue ─────────────────────────────────────────────────────────
+
+func TestEncodeTypedValue_SysObjectID(t *testing.T) {
+	// sysObjectID value must be encoded as OBJECT IDENTIFIER (0x06), not OCTET STRING.
+	// The value may arrive with or without a leading dot from JSON resource files.
+	for _, val := range []string{"1.3.6.1.4.1.9.1.1", ".1.3.6.1.4.1.9.1.1"} {
+		got := encodeTypedValue(".1.3.6.1.2.1.1.2.0", val)
+		if len(got) == 0 || got[0] != ASN1_OBJECT_ID {
+			t.Errorf("sysObjectID value %q: tag = 0x%02x, want OBJECT IDENTIFIER (0x%02x)", val, got[0], ASN1_OBJECT_ID)
+		}
+	}
+
+	// Both forms must produce identical wire bytes (encodeOID strips the dot).
+	a := encodeTypedValue(".1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.9.1.1")
+	b := encodeTypedValue(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.1")
+	if !bytesEqual(a, b) {
+		t.Errorf("sysObjectID with/without dot produce different bytes: %x vs %x", a, b)
+	}
+
+	// Round-trip: encoded payload must decode back to the canonical dotted form.
+	const canonical = ".1.3.6.1.4.1.9.1.1"
+	encoded := encodeTypedValue(".1.3.6.1.2.1.1.2.0", canonical)
+	if len(encoded) < 2 {
+		t.Fatalf("encoded sysObjectID too short (%d bytes)", len(encoded))
+	}
+	_, payloadStart := parseLength(encoded, 1)
+	decoded := decodeOID(encoded[payloadStart:])
+	if decoded != canonical {
+		t.Errorf("sysObjectID round-trip: got %q, want %q", decoded, canonical)
+	}
+}
 
 func TestEncodeTypedValue_EndOfMibView(t *testing.T) {
 	got := encodeTypedValue(".1.3.6.1.2.1.2.2.1.5.1", "endOfMibView")


### PR DESCRIPTION
## Problem

`sysObjectID` (`.1.3.6.1.2.1.1.2.0`) was absent from the `oidTypeTable` in `snmp_encoding.go`. As a result, `encodeTypedValue()` fell through to the default branch and encoded the enterprise OID value (e.g. `1.3.6.1.4.1.9.1.1`) as an **OCTET STRING** (tag `0x04`) instead of an **OBJECT IDENTIFIER** (tag `0x06`).

SNMP managers such as OpenNMS received the value as a raw byte string rather than a proper OID, so `nodesysoid` was stored without the correct ASN.1 type — and without a leading dot, since the string normalisation path is never reached for OCTET STRING values.

## Fix

- Add `{".1.3.6.1.2.1.1.2", ASN1_OBJECT_ID}` to `oidTypeTable` (`snmp_encoding.go`)
- Add `case ASN1_OBJECT_ID: return encodeOID(value)` to `encodeTypedValue()` — `encodeOID` already handles both `"1.3.6.1…"` and `".1.3.6.1…"` inputs identically by stripping any leading dot before BER-encoding

## Tests

- `TestSnmpTypeTag`: asserts `.1.3.6.1.2.1.1.2.0` → `ASN1_OBJECT_ID`
- `TestEncodeTypedValue_SysObjectID`: verifies the encoded tag is `0x06` for both dotted and undotted value strings, and that both produce identical wire bytes

## Test plan

- [ ] `go build ./simulator/` passes (Linux)
- [ ] `snmpget -v2c -c public <device> 1.3.6.1.2.1.1.2.0` returns an OID value (not a string)
- [ ] OpenNMS `nodesysoid` is populated with a proper OID after re-provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)