### PR TITLE
fix(snmp): use parseLength for all BER length fields in parseIncomingRequest

### DIFF
--- a/go/simulator/snmp_getbulk_test.go
+++ b/go/simulator/snmp_getbulk_test.go
@@ -391,6 +391,54 @@ func TestHandleGetBulkEndOfMib(t *testing.T) {
 	}
 }
 
+// TestParseIncomingRequest_RequestID verifies that parseIncomingRequest
+// correctly extracts the request-id from GET, GETNEXT, and GETBULK PDUs.
+// Before the 0xa5 fix, GETBULK fell through and always returned the default
+// request-id of 123, causing all GETBULK responses to be dropped by clients.
+func TestParseIncomingRequest_RequestID(t *testing.T) {
+	s := &SNMPServer{device: &DeviceSimulator{}}
+
+	tests := []struct {
+		name      string
+		pdu       []byte
+		wantReqID int
+	}{
+		{
+			name:      "GETBULK request-id 42",
+			pdu:       buildGetBulkPDU(0, 10, []string{".1.3.6.1.2.1.2.2.1.2"}),
+			wantReqID: 42,
+		},
+		{
+			name: "GETBULK request-id 12345678 (multi-byte)",
+			pdu: func() []byte {
+				// Build a GETBULK PDU with a 3-byte request-id.
+				varBindList := encodeSequence(append(encodeOID(".1.3.6.1.2.1.2.2.1.2"), encodeNull()...))
+				pduContents := encodeInteger(12345678)
+				pduContents = append(pduContents, encodeInteger(0)...)   // nonRepeaters
+				pduContents = append(pduContents, encodeInteger(10)...)  // maxRepetitions
+				pduContents = append(pduContents, encodeSequence(varBindList)...)
+				pdu := []byte{ASN1_GET_BULK}
+				pdu = append(pdu, encodeLength(len(pduContents))...)
+				pdu = append(pdu, pduContents...)
+				msg := encodeInteger(1)
+				msg = append(msg, encodeOctetString("public")...)
+				msg = append(msg, pdu...)
+				return encodeSequence(msg)
+			}(),
+			wantReqID: 12345678,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := s.parseIncomingRequest(tc.pdu)
+			if req.RequestID != tc.wantReqID {
+				t.Errorf("RequestID = %d, want %d", req.RequestID, tc.wantReqID)
+			}
+		})
+	}
+}
+
 // TestHandleGetBulkFallback verifies backward compatibility: when the PDU
 // cannot be parsed for OIDs, the single startOID fallback still works.
 func TestHandleGetBulkFallback(t *testing.T) {

--- a/go/simulator/snmp_response.go
+++ b/go/simulator/snmp_response.go
@@ -58,22 +58,22 @@ func (s *SNMPServer) parseIncomingRequest(data []byte) SNMPRequest {
 	// Parse version
 	if pos < len(data) && data[pos] == ASN1_INTEGER {
 		pos++
-		versionLen := int(data[pos])
-		pos++
-		if pos+versionLen <= len(data) && versionLen == 1 {
+		versionLen, newPos := parseLength(data, pos)
+		pos = newPos
+		if versionLen == 1 && pos < len(data) {
 			req.Version = int(data[pos])
+		}
+		if versionLen > 0 {
 			pos += versionLen
-		} else {
-			pos += versionLen // skip if we can't parse
 		}
 	}
 
 	// Parse community
 	if pos < len(data) && data[pos] == ASN1_OCTET_STRING {
 		pos++
-		communityLen := int(data[pos])
-		pos++
-		if pos+communityLen <= len(data) {
+		communityLen, newPos := parseLength(data, pos)
+		pos = newPos
+		if communityLen > 0 && pos+communityLen <= len(data) {
 			req.Community = string(data[pos : pos+communityLen])
 			pos += communityLen
 		}
@@ -88,9 +88,9 @@ func (s *SNMPServer) parseIncomingRequest(data []byte) SNMPRequest {
 		// Parse request ID
 		if pos < len(data) && data[pos] == ASN1_INTEGER {
 			pos++
-			reqIDLen := int(data[pos])
-			pos++
-			if pos+reqIDLen <= len(data) && reqIDLen <= 4 {
+			reqIDLen, newPos := parseLength(data, pos)
+			pos = newPos
+			if reqIDLen > 0 && reqIDLen <= 4 && pos+reqIDLen <= len(data) {
 				req.RequestID = 0
 				for i := 0; i < reqIDLen; i++ {
 					req.RequestID = (req.RequestID << 8) | int(data[pos+i])
@@ -103,8 +103,10 @@ func (s *SNMPServer) parseIncomingRequest(data []byte) SNMPRequest {
 		for i := 0; i < 2; i++ {
 			if pos < len(data) && data[pos] == ASN1_INTEGER {
 				pos++
-				pos += s.skipLength(data[pos:])
-				pos++ // skip value
+				fieldLen, newPos := parseLength(data, pos)
+				if fieldLen >= 0 {
+					pos = newPos + fieldLen
+				}
 			}
 		}
 
@@ -121,9 +123,9 @@ func (s *SNMPServer) parseIncomingRequest(data []byte) SNMPRequest {
 				// Parse OID
 				if pos < len(data) && data[pos] == ASN1_OID {
 					pos++
-					oidLen := int(data[pos])
-					pos++
-					if pos+oidLen <= len(data) {
+					oidLen, newPos := parseLength(data, pos)
+					pos = newPos
+					if oidLen > 0 && pos+oidLen <= len(data) {
 						oidBytes := data[pos : pos+oidLen]
 						if oid := decodeOID(oidBytes); oid != "" {
 							req.OID = oid


### PR DESCRIPTION
## Problem

`parseIncomingRequest` in `snmp_response.go` used raw single-byte reads for every BER length field:

```go
reqIDLen := int(data[pos])  // wrong — should be parseLength
```

This works for all observed SNMP traffic (short-form BER, length < 128), but it's inconsistent with every other parser in the package (`parseGetBulkParams`, `parseAllOIDsFromRequest`, `extractOIDFromSNMPPacket`) which all use `parseLength` correctly. Identified during code review of PR #7 against upstream.

Affected fields:
- `versionLen` — version INTEGER length
- `communityLen` — community OCTET STRING length  
- `reqIDLen` — request-id INTEGER length (the highest-risk field)
- `oidLen` — OID length in the first VarBind
- error-status/error-index skip loop (used `pos++` instead of advancing by actual field length)

## Fix

Replace all raw `int(data[pos])` length reads with `parseLength(data, pos)`. Also fix the error-status/error-index skip loop to advance by the actual field length.

## Test

Add `TestParseIncomingRequest_RequestID` which builds GETBULK PDUs with known request-ids (42 and 12345678) and asserts that `parseIncomingRequest` echoes them back correctly. This locks in regression protection for the root cause of the original GETBULK timeout bug (request-id mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)