### PR TITLE
feat(snmp): generate dynamic ifHCInOctets/ifHCOutOctets counters

### DIFF
--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -248,7 +248,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			profile := GetDeviceProfile(deviceResourceFile)
 			device.metricsCycler = NewMetricsCycler(int64(i), profile)
 			device.metricsCycler.InitGPUMetrics(int64(i), profile.GPU)
-			device.metricsCycler.InitIfCounters(deviceResources, int64(i))
+			device.metricsCycler.InitIfCounters(deviceResources, int64(i)^0x4843_0000)
 
 			// Cache the dynamic values using atomic for lock-free access
 			device.cachedSysName.Store(sysNameValue)
@@ -469,7 +469,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	profile := GetDeviceProfile(resourceFile)
 	device.metricsCycler = NewMetricsCycler(int64(deviceIndex), profile)
 	device.metricsCycler.InitGPUMetrics(int64(deviceIndex), profile.GPU)
-	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex))
+	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex)^0x4843_0000)
 
 	// Cache the dynamic values using atomic for lock-free access
 	device.cachedSysName.Store(sysNameValue)

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -248,6 +248,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			profile := GetDeviceProfile(deviceResourceFile)
 			device.metricsCycler = NewMetricsCycler(int64(i), profile)
 			device.metricsCycler.InitGPUMetrics(int64(i), profile.GPU)
+			device.metricsCycler.InitIfCounters(deviceResources, int64(i))
 
 			// Cache the dynamic values using atomic for lock-free access
 			device.cachedSysName.Store(sysNameValue)
@@ -468,6 +469,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	profile := GetDeviceProfile(resourceFile)
 	device.metricsCycler = NewMetricsCycler(int64(deviceIndex), profile)
 	device.metricsCycler.InitGPUMetrics(int64(deviceIndex), profile.GPU)
+	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex))
 
 	// Cache the dynamic values using atomic for lock-free access
 	device.cachedSysName.Store(sysNameValue)

--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -41,14 +41,19 @@ const (
 //
 // where T = 3600 s and φᵢ is a per-interface random phase offset.
 // The rate never falls below 60% of capacity, so the counter is strictly monotonic.
+//
+// Thread safety: all fields are written once by InitIfCounters before the device's
+// SNMP server goroutine is started. Concurrent reads in GetHCOctets are safe because
+// goroutine creation provides the required happens-before relationship.
 type IfCounterCycler struct {
-	startTime  time.Time
-	ifCount    int
-	ifSpeedBps []uint64  // per-interface link speed in bps (slot 0 = ifIndex 1)
-	baseIn     []uint64  // per-interface starting octet counter (in)
-	baseOut    []uint64  // per-interface starting octet counter (out)
-	phaseIn    []float64 // per-interface random phase offset in [0, 2π)
-	phaseOut   []float64
+	startTime      time.Time
+	maxIfIndex     int              // upper bound for array indexing
+	knownIfIndexes map[int]struct{} // exact set of ifIndex values present in oidIndex
+	ifSpeedBps     []uint64         // per-interface link speed in bps (slot = ifIndex-1)
+	baseIn         []uint64         // per-interface starting octet counter (in)
+	baseOut        []uint64         // per-interface starting octet counter (out)
+	phaseIn        []float64        // per-interface random phase offset in [0, 2π)
+	phaseOut       []float64
 }
 
 // GetHCOctets returns the current dynamic counter value for an HC OID, or ""
@@ -68,7 +73,12 @@ func (ic *IfCounterCycler) GetHCOctets(oid string) string {
 	}
 
 	ifIndex, err := strconv.Atoi(oid[len(prefix):])
-	if err != nil || ifIndex < 1 || ifIndex > ic.ifCount {
+	if err != nil || ifIndex < 1 || ifIndex > ic.maxIfIndex {
+		return ""
+	}
+	// Reject ifIndex values that don't exist in the device's OID table
+	// (guards against sparse interface numbering, e.g., ifIndex 1, 3, 5).
+	if _, known := ic.knownIfIndexes[ifIndex]; !known {
 		return ""
 	}
 	slot := ifIndex - 1
@@ -91,71 +101,90 @@ func (ic *IfCounterCycler) GetHCOctets(oid string) string {
 	T := hcPeriodSec
 	deltaOctets := speedBytesPerSec * (0.8*t + 0.2*(T/(2*math.Pi))*(math.Cos(phase)-math.Cos(2*math.Pi*t/T+phase)))
 
+	// Clamp to zero: floating-point imprecision at t≈0 can produce a
+	// tiny negative value; casting a negative float64 to uint64 wraps.
+	if deltaOctets < 0 {
+		deltaOctets = 0
+	}
 	return fmt.Sprintf("%d", base+uint64(deltaOctets))
 }
 
 // InitIfCounters sets up per-interface HC counter cycling for dynamic
 // ifHCInOctets / ifHCOutOctets values. Interface speeds are read from
 // the device's oidIndex (ifHighSpeed in Mbps preferred; falls back to
-// ifSpeed in bps). Must be called after NewMetricsCycler and before the
-// device starts serving requests.
+// ifSpeed in bps).
+//
+// Must be called after NewMetricsCycler and before device.Start() so that
+// goroutine creation provides the happens-before edge required for thread safety.
 func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
 	if resources == nil || resources.oidIndex == nil {
 		return
 	}
 
-	// Discover the highest ifIndex that has an HC in-octets OID.
-	maxIfIndex := 0
+	// Collect the exact set of ifIndex values that have HC in-octets OIDs.
+	knownIdxs := make(map[int]struct{})
 	resources.oidIndex.Range(func(k, _ interface{}) bool {
 		oid, ok := k.(string)
 		if !ok {
 			return true
 		}
 		if strings.HasPrefix(oid, hcInOIDPrefix) {
-			if idx, err := strconv.Atoi(oid[len(hcInOIDPrefix):]); err == nil && idx > maxIfIndex {
-				maxIfIndex = idx
+			if idx, err := strconv.Atoi(oid[len(hcInOIDPrefix):]); err == nil && idx > 0 {
+				knownIdxs[idx] = struct{}{}
 			}
 		}
 		return true
 	})
-	if maxIfIndex == 0 {
+	if len(knownIdxs) == 0 {
 		return // no HC counters for this device type
 	}
 
+	maxIdx := 0
+	for idx := range knownIdxs {
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+	}
+
 	ic := &IfCounterCycler{
-		startTime:  time.Now(),
-		ifCount:    maxIfIndex,
-		ifSpeedBps: make([]uint64, maxIfIndex),
-		baseIn:     make([]uint64, maxIfIndex),
-		baseOut:    make([]uint64, maxIfIndex),
-		phaseIn:    make([]float64, maxIfIndex),
-		phaseOut:   make([]float64, maxIfIndex),
+		startTime:      time.Now(),
+		maxIfIndex:     maxIdx,
+		knownIfIndexes: knownIdxs,
+		ifSpeedBps:     make([]uint64, maxIdx),
+		baseIn:         make([]uint64, maxIdx),
+		baseOut:        make([]uint64, maxIdx),
+		phaseIn:        make([]float64, maxIdx),
+		phaseOut:       make([]float64, maxIdx),
 	}
 
 	rng := rand.New(rand.NewSource(seed))
 
-	for i := 1; i <= maxIfIndex; i++ {
-		slot := i - 1
+	for idx := range knownIdxs {
+		slot := idx - 1
 
 		// Prefer ifHighSpeed (Mbps → bps) over ifSpeed (bps, capped at ~4 Gbps).
 		var speedBps uint64 = 1_000_000_000 // default 1 Gbps
-		highSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", i)
+		highSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", idx)
 		if v, ok := resources.oidIndex.Load(highSpeedOID); ok {
-			if mbps, err := strconv.ParseUint(v.(string), 10, 64); err == nil && mbps > 0 {
-				speedBps = mbps * 1_000_000
+			if s, ok := v.(string); ok {
+				if mbps, err := strconv.ParseUint(s, 10, 64); err == nil && mbps > 0 {
+					speedBps = mbps * 1_000_000
+				}
 			}
 		} else {
-			ifSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.5.%d", i)
+			ifSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.5.%d", idx)
 			if v, ok := resources.oidIndex.Load(ifSpeedOID); ok {
-				if bps, err := strconv.ParseUint(v.(string), 10, 64); err == nil && bps > 0 {
-					speedBps = bps
+				if s, ok := v.(string); ok {
+					if bps, err := strconv.ParseUint(s, 10, 64); err == nil && bps > 0 {
+						speedBps = bps
+					}
 				}
 			}
 		}
 		ic.ifSpeedBps[slot] = speedBps
 
 		// Seed counters with ~24 h of 80%-average traffic so they look realistic
-		// from the first poll. Add ±5% per-interface jitter for variety.
+		// from the first poll. Add up to +5% per-interface jitter for variety.
 		avg24h := uint64(float64(speedBps) / 8.0 * 0.8 * 86400.0)
 		ic.baseIn[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
 		ic.baseOut[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)

--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -1,0 +1,169 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	hcInOIDPrefix  = ".1.3.6.1.2.1.31.1.1.1.6."
+	hcOutOIDPrefix = ".1.3.6.1.2.1.31.1.1.1.10."
+	hcPeriodSec    = 3600.0 // 1-hour sine-wave cycle
+)
+
+// IfCounterCycler generates monotonically increasing HC counter values
+// (ifHCInOctets / ifHCOutOctets) whose byte-rate follows a sine wave
+// between 60% and 100% of interface speed over a 1-hour period.
+//
+// Formula per interface i at time t seconds since device start:
+//
+//	rate(t) = ifSpeed_Bps × (0.8 + 0.2·sin(2π·t/T + φᵢ))
+//	octets(t) = base_i + ifSpeed_Bps × [0.8·t + (0.2·T/2π)·(cos(φᵢ) − cos(2π·t/T + φᵢ))]
+//
+// where T = 3600 s and φᵢ is a per-interface random phase offset.
+// The rate never falls below 60% of capacity, so the counter is strictly monotonic.
+type IfCounterCycler struct {
+	startTime  time.Time
+	ifCount    int
+	ifSpeedBps []uint64  // per-interface link speed in bps (slot 0 = ifIndex 1)
+	baseIn     []uint64  // per-interface starting octet counter (in)
+	baseOut    []uint64  // per-interface starting octet counter (out)
+	phaseIn    []float64 // per-interface random phase offset in [0, 2π)
+	phaseOut   []float64
+}
+
+// GetHCOctets returns the current dynamic counter value for an HC OID, or ""
+// if the OID is not an HC in/out-octets OID for a known interface index.
+func (ic *IfCounterCycler) GetHCOctets(oid string) string {
+	var prefix string
+	isIn := false
+
+	switch {
+	case strings.HasPrefix(oid, hcInOIDPrefix):
+		prefix = hcInOIDPrefix
+		isIn = true
+	case strings.HasPrefix(oid, hcOutOIDPrefix):
+		prefix = hcOutOIDPrefix
+	default:
+		return ""
+	}
+
+	ifIndex, err := strconv.Atoi(oid[len(prefix):])
+	if err != nil || ifIndex < 1 || ifIndex > ic.ifCount {
+		return ""
+	}
+	slot := ifIndex - 1
+
+	t := time.Since(ic.startTime).Seconds()
+	speedBytesPerSec := float64(ic.ifSpeedBps[slot]) / 8.0
+
+	var phase float64
+	var base uint64
+	if isIn {
+		phase = ic.phaseIn[slot]
+		base = ic.baseIn[slot]
+	} else {
+		phase = ic.phaseOut[slot]
+		base = ic.baseOut[slot]
+	}
+
+	// ∫₀ᵗ (0.8 + 0.2·sin(2π·τ/T + φ)) dτ
+	//   = 0.8·t + 0.2·(T/2π)·(cos(φ) − cos(2π·t/T + φ))
+	T := hcPeriodSec
+	deltaOctets := speedBytesPerSec * (0.8*t + 0.2*(T/(2*math.Pi))*(math.Cos(phase)-math.Cos(2*math.Pi*t/T+phase)))
+
+	return fmt.Sprintf("%d", base+uint64(deltaOctets))
+}
+
+// InitIfCounters sets up per-interface HC counter cycling for dynamic
+// ifHCInOctets / ifHCOutOctets values. Interface speeds are read from
+// the device's oidIndex (ifHighSpeed in Mbps preferred; falls back to
+// ifSpeed in bps). Must be called after NewMetricsCycler and before the
+// device starts serving requests.
+func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
+	if resources == nil || resources.oidIndex == nil {
+		return
+	}
+
+	// Discover the highest ifIndex that has an HC in-octets OID.
+	maxIfIndex := 0
+	resources.oidIndex.Range(func(k, _ interface{}) bool {
+		oid, ok := k.(string)
+		if !ok {
+			return true
+		}
+		if strings.HasPrefix(oid, hcInOIDPrefix) {
+			if idx, err := strconv.Atoi(oid[len(hcInOIDPrefix):]); err == nil && idx > maxIfIndex {
+				maxIfIndex = idx
+			}
+		}
+		return true
+	})
+	if maxIfIndex == 0 {
+		return // no HC counters for this device type
+	}
+
+	ic := &IfCounterCycler{
+		startTime:  time.Now(),
+		ifCount:    maxIfIndex,
+		ifSpeedBps: make([]uint64, maxIfIndex),
+		baseIn:     make([]uint64, maxIfIndex),
+		baseOut:    make([]uint64, maxIfIndex),
+		phaseIn:    make([]float64, maxIfIndex),
+		phaseOut:   make([]float64, maxIfIndex),
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+
+	for i := 1; i <= maxIfIndex; i++ {
+		slot := i - 1
+
+		// Prefer ifHighSpeed (Mbps → bps) over ifSpeed (bps, capped at ~4 Gbps).
+		var speedBps uint64 = 1_000_000_000 // default 1 Gbps
+		highSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", i)
+		if v, ok := resources.oidIndex.Load(highSpeedOID); ok {
+			if mbps, err := strconv.ParseUint(v.(string), 10, 64); err == nil && mbps > 0 {
+				speedBps = mbps * 1_000_000
+			}
+		} else {
+			ifSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.5.%d", i)
+			if v, ok := resources.oidIndex.Load(ifSpeedOID); ok {
+				if bps, err := strconv.ParseUint(v.(string), 10, 64); err == nil && bps > 0 {
+					speedBps = bps
+				}
+			}
+		}
+		ic.ifSpeedBps[slot] = speedBps
+
+		// Seed counters with ~24 h of 80%-average traffic so they look realistic
+		// from the first poll. Add ±5% per-interface jitter for variety.
+		avg24h := uint64(float64(speedBps) / 8.0 * 0.8 * 86400.0)
+		ic.baseIn[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
+		ic.baseOut[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
+
+		// Random phase offsets so interfaces don't peak simultaneously.
+		ic.phaseIn[slot] = rng.Float64() * 2 * math.Pi
+		ic.phaseOut[slot] = rng.Float64() * 2 * math.Pi
+	}
+
+	c.ifCounters = ic
+}

--- a/go/simulator/if_counters_test.go
+++ b/go/simulator/if_counters_test.go
@@ -1,0 +1,181 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// buildTestResources constructs a minimal DeviceResources with HC counter and
+// speed OIDs for the given interfaces. speeds are in bps.
+func buildTestResources(t *testing.T, speeds []uint64) *DeviceResources {
+	t.Helper()
+	res := &DeviceResources{
+		oidIndex: &sync.Map{},
+	}
+	for i, spd := range speeds {
+		ifIndex := i + 1
+		// ifHighSpeed in Mbps
+		res.oidIndex.Store(
+			fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", ifIndex),
+			strconv.FormatUint(spd/1_000_000, 10),
+		)
+		// HC in/out placeholders (any value — InitIfCounters only reads speed)
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", ifIndex), "0")
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", ifIndex), "0")
+	}
+	return res
+}
+
+func TestIfCounterCycler_Monotonic(t *testing.T) {
+	const gbps = 1_000_000_000
+	res := buildTestResources(t, []uint64{gbps, gbps})
+
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 42)
+
+	if c.ifCounters == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	// Poll 5 times with small sleeps and verify strict monotonic increase.
+	prev1, prev2 := uint64(0), uint64(0)
+	for poll := 0; poll < 5; poll++ {
+		time.Sleep(5 * time.Millisecond)
+
+		v1str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+		v2str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.2")
+		v1, err1 := strconv.ParseUint(v1str, 10, 64)
+		v2, err2 := strconv.ParseUint(v2str, 10, 64)
+		if err1 != nil || err2 != nil {
+			t.Fatalf("poll %d: non-numeric HC value (%q, %q)", poll, v1str, v2str)
+		}
+		if poll > 0 && v1 <= prev1 {
+			t.Errorf("poll %d: ifHCInOctets.1 not increasing: %d -> %d", poll, prev1, v1)
+		}
+		if poll > 0 && v2 <= prev2 {
+			t.Errorf("poll %d: ifHCInOctets.2 not increasing: %d -> %d", poll, prev2, v2)
+		}
+		prev1, prev2 = v1, v2
+	}
+}
+
+func TestIfCounterCycler_RateInRange(t *testing.T) {
+	// Use a 10 Gbps interface and verify the byte-rate is within [60%, 100%] of capacity.
+	const gbps10 = 10_000_000_000
+	res := buildTestResources(t, []uint64{gbps10})
+
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 7)
+
+	if c.ifCounters == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	// Sample over ~50 ms; compute average byte-rate.
+	start := time.Now()
+	v0str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	v0, _ := strconv.ParseUint(v0str, 10, 64)
+
+	time.Sleep(50 * time.Millisecond)
+
+	v1str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	v1, _ := strconv.ParseUint(v1str, 10, 64)
+	elapsed := time.Since(start).Seconds()
+
+	rate := float64(v1-v0) / elapsed // bytes/sec
+	speedBytesPerSec := float64(gbps10) / 8.0
+
+	minRate := speedBytesPerSec * 0.55 // allow 5% margin below 60%
+	maxRate := speedBytesPerSec * 1.05 // allow 5% margin above 100%
+
+	if rate < minRate || rate > maxRate {
+		t.Errorf("byte-rate %.0f B/s out of expected range [%.0f, %.0f] B/s (%.1f%%..%.1f%% of capacity)",
+			rate, minRate, maxRate, rate/speedBytesPerSec*100, rate/speedBytesPerSec*100)
+	}
+}
+
+func TestIfCounterCycler_UnknownOID(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 1)
+
+	// Wrong column — should return empty string
+	if v := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.7.1"); v != "" {
+		t.Errorf("expected empty for non-HC OID, got %q", v)
+	}
+	// Out-of-range interface index
+	if v := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.99"); v != "" {
+		t.Errorf("expected empty for out-of-range ifIndex, got %q", v)
+	}
+}
+
+func TestIfCounterCycler_InOutDiffer(t *testing.T) {
+	// In- and out-octets use independent phase offsets; they should differ after
+	// a brief interval (unless the seed is pathological — extremely unlikely).
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 123456)
+
+	time.Sleep(10 * time.Millisecond)
+	inStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	outStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.10.1")
+
+	in, _ := strconv.ParseUint(inStr, 10, 64)
+	out, _ := strconv.ParseUint(outStr, 10, 64)
+
+	// Different bases and phases almost certainly produce different values.
+	if in == out {
+		t.Errorf("ifHCInOctets and ifHCOutOctets are identical (%d) — phases may not be independent", in)
+	}
+}
+
+func TestIfCounterCycler_NoHCOIDs(t *testing.T) {
+	// A device with no HC OIDs in oidIndex must leave ifCounters nil.
+	res := &DeviceResources{oidIndex: &sync.Map{}}
+	res.oidIndex.Store(".1.3.6.1.2.1.1.1.0", "Linux 5.15")
+
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 1)
+
+	if c.ifCounters != nil {
+		t.Error("expected ifCounters to be nil for device with no HC OIDs")
+	}
+}
+
+func TestIfCounterCycler_BaseIsPositive(t *testing.T) {
+	// At t≈0, counter must equal base (large positive number, not 0).
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 99)
+
+	// Read immediately (t ≈ 0)
+	vStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	v, _ := strconv.ParseUint(vStr, 10, 64)
+
+	// ~24h of 80% traffic at 1 Gbps should be well above zero
+	minExpected := uint64(1e10) // 10 GB — modest lower bound
+	if v < minExpected {
+		t.Errorf("initial counter value %d is unexpectedly small (< %d); base seeding may have failed", v, minExpected)
+	}
+
+	_ = math.Pi // keep math import used
+}

--- a/go/simulator/if_counters_test.go
+++ b/go/simulator/if_counters_test.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"sync"
 	"testing"
@@ -25,7 +24,7 @@ import (
 )
 
 // buildTestResources constructs a minimal DeviceResources with HC counter and
-// speed OIDs for the given interfaces. speeds are in bps.
+// speed OIDs for the given contiguous interface list (speeds in bps).
 func buildTestResources(t *testing.T, speeds []uint64) *DeviceResources {
 	t.Helper()
 	res := &DeviceResources{
@@ -38,9 +37,23 @@ func buildTestResources(t *testing.T, speeds []uint64) *DeviceResources {
 			fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", ifIndex),
 			strconv.FormatUint(spd/1_000_000, 10),
 		)
-		// HC in/out placeholders (any value — InitIfCounters only reads speed)
+		// HC in/out placeholders (InitIfCounters only reads speed, not these values)
 		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", ifIndex), "0")
 		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", ifIndex), "0")
+	}
+	return res
+}
+
+// buildSparseTestResources constructs resources with HC OIDs only at the given
+// ifIndex values (sparse, non-contiguous).
+func buildSparseTestResources(t *testing.T, ifIndexes []int, speedBps uint64) *DeviceResources {
+	t.Helper()
+	res := &DeviceResources{oidIndex: &sync.Map{}}
+	for _, idx := range ifIndexes {
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", idx),
+			strconv.FormatUint(speedBps/1_000_000, 10))
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", idx), "0")
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", idx), "0")
 	}
 	return res
 }
@@ -78,6 +91,32 @@ func TestIfCounterCycler_Monotonic(t *testing.T) {
 	}
 }
 
+func TestIfCounterCycler_NoWrapAtZero(t *testing.T) {
+	// Read the counter immediately after init (t ≈ 0). The integral can be a
+	// tiny negative float due to floating-point imprecision; if cast directly to
+	// uint64 it wraps to ~2^64. The clamp-to-zero guard must prevent this.
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 99)
+
+	vStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	v, err := strconv.ParseUint(vStr, 10, 64)
+	if err != nil {
+		t.Fatalf("non-numeric value at t≈0: %q", vStr)
+	}
+
+	// Must be a sane positive value (≥10 GB from 24h seeding) and well below
+	// the uint64 wrap sentinel (> 2^63).
+	const minExpected = uint64(1e10)     // 10 GB
+	const wrapSentinel = uint64(1) << 63 // half of uint64 max
+	if v < minExpected {
+		t.Errorf("counter at t≈0 is %d, too small — base seeding failed or clamped to 0", v)
+	}
+	if v > wrapSentinel {
+		t.Errorf("counter at t≈0 is %d, suspiciously large — uint64 wrap likely occurred", v)
+	}
+}
+
 func TestIfCounterCycler_RateInRange(t *testing.T) {
 	// Use a 10 Gbps interface and verify the byte-rate is within [60%, 100%] of capacity.
 	const gbps10 = 10_000_000_000
@@ -90,12 +129,12 @@ func TestIfCounterCycler_RateInRange(t *testing.T) {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
 
-	// Sample over ~50 ms; compute average byte-rate.
+	// Sample over ~100 ms; compute average byte-rate.
 	start := time.Now()
 	v0str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v0, _ := strconv.ParseUint(v0str, 10, 64)
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	v1str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v1, _ := strconv.ParseUint(v1str, 10, 64)
@@ -104,12 +143,12 @@ func TestIfCounterCycler_RateInRange(t *testing.T) {
 	rate := float64(v1-v0) / elapsed // bytes/sec
 	speedBytesPerSec := float64(gbps10) / 8.0
 
-	minRate := speedBytesPerSec * 0.55 // allow 5% margin below 60%
-	maxRate := speedBytesPerSec * 1.05 // allow 5% margin above 100%
+	minRate := speedBytesPerSec * 0.50 // allow 10% margin below 60%
+	maxRate := speedBytesPerSec * 1.10 // allow 10% margin above 100%
 
 	if rate < minRate || rate > maxRate {
-		t.Errorf("byte-rate %.0f B/s out of expected range [%.0f, %.0f] B/s (%.1f%%..%.1f%% of capacity)",
-			rate, minRate, maxRate, rate/speedBytesPerSec*100, rate/speedBytesPerSec*100)
+		t.Errorf("byte-rate %.0f B/s out of expected range [%.0f, %.0f] B/s (%.1f%% of capacity)",
+			rate, minRate, maxRate, rate/speedBytesPerSec*100)
 	}
 }
 
@@ -128,9 +167,39 @@ func TestIfCounterCycler_UnknownOID(t *testing.T) {
 	}
 }
 
+func TestIfCounterCycler_SparseIfIndex(t *testing.T) {
+	// Device with ifIndex 1, 3, 5 only (gaps at 2 and 4).
+	// GetHCOctets for the missing indices must return "".
+	res := buildSparseTestResources(t, []int{1, 3, 5}, 1_000_000_000)
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 77)
+
+	if c.ifCounters == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	// Known indices should return live values.
+	for _, idx := range []int{1, 3, 5} {
+		oid := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", idx)
+		if v := c.ifCounters.GetHCOctets(oid); v == "" {
+			t.Errorf("expected non-empty for known ifIndex %d, got empty", idx)
+		}
+	}
+
+	// Missing indices must not return a live counter.
+	for _, idx := range []int{2, 4} {
+		oid := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", idx)
+		if v := c.ifCounters.GetHCOctets(oid); v != "" {
+			t.Errorf("expected empty for missing ifIndex %d, got %q", idx, v)
+		}
+	}
+}
+
 func TestIfCounterCycler_InOutDiffer(t *testing.T) {
-	// In- and out-octets use independent phase offsets; they should differ after
-	// a brief interval (unless the seed is pathological — extremely unlikely).
+	// In- and out-octets use independent phase offsets and bases; their values
+	// should differ by a measurable amount after a brief interval.
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 123456)
@@ -142,9 +211,17 @@ func TestIfCounterCycler_InOutDiffer(t *testing.T) {
 	in, _ := strconv.ParseUint(inStr, 10, 64)
 	out, _ := strconv.ParseUint(outStr, 10, 64)
 
-	// Different bases and phases almost certainly produce different values.
-	if in == out {
-		t.Errorf("ifHCInOctets and ifHCOutOctets are identical (%d) — phases may not be independent", in)
+	// The bases differ by up to ~5% of avg24h (~43 GB at 1 Gbps/80%/24h).
+	// Require at least 1 MB difference, which is well within the expected jitter.
+	const minDelta = uint64(1 << 20) // 1 MB
+	var delta uint64
+	if in > out {
+		delta = in - out
+	} else {
+		delta = out - in
+	}
+	if delta < minDelta {
+		t.Errorf("ifHCInOctets (%d) and ifHCOutOctets (%d) differ by only %d bytes — independent bases/phases may not be working", in, out, delta)
 	}
 }
 
@@ -162,7 +239,7 @@ func TestIfCounterCycler_NoHCOIDs(t *testing.T) {
 }
 
 func TestIfCounterCycler_BaseIsPositive(t *testing.T) {
-	// At t≈0, counter must equal base (large positive number, not 0).
+	// At t≈0, counter must equal approximately base (large positive number).
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 99)
@@ -171,11 +248,9 @@ func TestIfCounterCycler_BaseIsPositive(t *testing.T) {
 	vStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v, _ := strconv.ParseUint(vStr, 10, 64)
 
-	// ~24h of 80% traffic at 1 Gbps should be well above zero
-	minExpected := uint64(1e10) // 10 GB — modest lower bound
+	// ~24h of 80% traffic at 1 Gbps ≈ 8.64 TB; require at least 10 GB.
+	const minExpected = uint64(1e10)
 	if v < minExpected {
 		t.Errorf("initial counter value %d is unexpectedly small (< %d); base seeding may have failed", v, minExpected)
 	}
-
-	_ = math.Pi // keep math import used
 }

--- a/go/simulator/metrics_cycler.go
+++ b/go/simulator/metrics_cycler.go
@@ -35,6 +35,7 @@ type MetricsCycler struct {
 	memIndex   uint32               // atomic, current position
 	tempIndex  uint32               // atomic, current position
 	gpuMetrics []*GPUMetrics        // Per-GPU cycling metrics (nil for non-GPU devices)
+	ifCounters *IfCounterCycler     // Per-interface HC counter cycling (nil if no HC OIDs)
 }
 
 // NewMetricsCycler creates a cycler with 100 data points generated from the

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -42,6 +42,12 @@ func (s *SNMPServer) findResponse(oid string) string {
 		if val := s.getMetricValue(oid); val != "" {
 			return val
 		}
+		// Handle HC counter OIDs (ifHCInOctets, ifHCOutOctets) - time-based monotonic counters
+		if s.device.metricsCycler.ifCounters != nil {
+			if val := s.device.metricsCycler.ifCounters.GetHCOctets(oid); val != "" {
+				return val
+			}
+		}
 	}
 
 	// Interface state scenario override (admin/oper status)
@@ -117,7 +123,7 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 	// pre-computed next OID, return it immediately (O(1)).
 	sortedMetricOIDs := GetSortedMetricOIDs(s.device.resourceFile)
 	if len(sortedMetricOIDs) == 0 && precomputedNextOID != "" {
-		return precomputedNextOID, precomputedNextResp
+		return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
 	}
 
 	// If we have a pre-computed next OID and it's lexicographically before
@@ -126,12 +132,12 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 	if precomputedNextOID != "" && len(sortedMetricOIDs) > 0 {
 		firstMetricOID := sortedMetricOIDs[0]
 		if compareOIDs(precomputedNextOID, firstMetricOID) <= 0 {
-			return precomputedNextOID, precomputedNextResp
+			return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
 		}
 		// Also safe if currentOID is already past all metric OIDs
 		lastMetricOID := sortedMetricOIDs[len(sortedMetricOIDs)-1]
 		if compareOIDs(currentOID, lastMetricOID) >= 0 {
-			return precomputedNextOID, precomputedNextResp
+			return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
 		}
 	}
 
@@ -247,7 +253,7 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 		}
 	}
 
-	return nextOID, response
+	return nextOID, s.overrideIfHC(nextOID, response)
 }
 
 // handleGetBulk processes SNMP GetBulk requests
@@ -534,6 +540,18 @@ func (s *SNMPServer) parseGetBulkParams(data []byte) (int, int) {
 	//	s.device.ID, nonRepeaters, maxRepetitions)
 
 	return nonRepeaters, maxRepetitions
+}
+
+// overrideIfHC replaces staticResp with the dynamic HC counter value when oid
+// is an ifHCInOctets or ifHCOutOctets OID. Returns staticResp unchanged for
+// all other OIDs. Used by findNextOID to return live counter values during walks.
+func (s *SNMPServer) overrideIfHC(oid, staticResp string) string {
+	if s.device.metricsCycler != nil && s.device.metricsCycler.ifCounters != nil {
+		if dynVal := s.device.metricsCycler.ifCounters.GetHCOctets(oid); dynVal != "" {
+			return dynVal
+		}
+	}
+	return staticResp
 }
 
 // getMetricValue returns the cycling metric value for a dynamic OID,

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -546,10 +546,16 @@ func (s *SNMPServer) parseGetBulkParams(data []byte) (int, int) {
 // is an ifHCInOctets or ifHCOutOctets OID. Returns staticResp unchanged for
 // all other OIDs. Used by findNextOID to return live counter values during walks.
 func (s *SNMPServer) overrideIfHC(oid, staticResp string) string {
-	if s.device.metricsCycler != nil && s.device.metricsCycler.ifCounters != nil {
-		if dynVal := s.device.metricsCycler.ifCounters.GetHCOctets(oid); dynVal != "" {
-			return dynVal
-		}
+	if s.device.metricsCycler == nil || s.device.metricsCycler.ifCounters == nil {
+		return staticResp
+	}
+	// Fast pre-check: HC OIDs live under .1.3.6.1.2.1.31; skip the full
+	// prefix match for the vast majority of OIDs that are not in ifXTable.
+	if !strings.HasPrefix(oid, ".1.3.6.1.2.1.31.") {
+		return staticResp
+	}
+	if dynVal := s.device.metricsCycler.ifCounters.GetHCOctets(oid); dynVal != "" {
+		return dynVal
 	}
 	return staticResp
 }


### PR DESCRIPTION
## Summary

- Replaces static HC counter values from JSON with time-based monotonically increasing Counter64 values
- Byte-rate follows a sine wave between 60%–100% of interface speed over a 1-hour cycle, so OpenNMS/Minion sees non-zero bps on interface graphs
- Works for all 17 network device types (cisco_ios, catalyst_9500, juniper_mx240, arista_7280r3, etc.) — automatically skipped for storage/GPU devices with no HC OIDs

## How it works

The counter value at time `t` seconds since device start is computed analytically in O(1) — no goroutine or polling loop:

```
rate(t)   = ifSpeed_Bps × (0.8 + 0.2·sin(2π·t/3600 + φᵢ))
octets(t) = base_i + ifSpeed_Bps × [0.8·t + (0.2·3600/2π)·(cos(φᵢ)−cos(2π·t/3600+φᵢ))]
```

- **Strictly monotonic**: rate never drops below 60% of capacity
- **Realistic start**: counters seeded with ~24 h of 80%-average traffic so they look credible on the first poll
- **Per-interface independence**: random phase offset `φᵢ` and random base ensure interfaces don't peak simultaneously
- **Speed-aware**: reads `ifHighSpeed` (Mbps → bps, preferred for >4 Gbps links) or falls back to `ifSpeed` from the device's oidIndex at startup

## Files changed

| File | Change |
|------|--------|
| `go/simulator/if_counters.go` | New: `IfCounterCycler` struct + `GetHCOctets` + `InitIfCounters` |
| `go/simulator/if_counters_test.go` | New: 5 unit tests (monotonic, rate-in-range, unknown OID, in≠out, no-HC device) |
| `go/simulator/metrics_cycler.go` | Add `ifCounters *IfCounterCycler` field to `MetricsCycler` |
| `go/simulator/snmp_handlers.go` | `findResponse`: HC check before oidIndex; `findNextOID`: `overrideIfHC` on all return paths so GETBULK walks also return live values |
| `go/simulator/device.go` | Call `InitIfCounters` in both sequential and parallel device creation paths |

## Test plan

- [ ] Unit tests compile and pass on Linux (`go test ./simulator/ -run TestIfCounter`)
- [ ] Start simulator with `cisco_ios.json` device, run `snmpwalk -v2c -c public <ip> 1.3.6.1.2.1.31.1.1.1.6` — values increase between polls
- [ ] Verify OpenNMS interface graph for `ifHCInOctets`/`ifHCOutOctets` shows non-zero bps (previous: flat 0 bps)
- [ ] Confirm GETBULK walk of `ifXTable` returns monotonically increasing HC values across repetitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)