### PR TITLE
feat(netflow): phase 1 — NetFlow v9 encoder, flow cache, and flow profiles

### DIFF
--- a/go/simulator/flow_cache.go
+++ b/go/simulator/flow_cache.go
@@ -1,0 +1,227 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+// FlowKey is the 5-tuple that uniquely identifies a flow in the cache.
+// Using a fixed-size array type (not slices) allows it to be a map key.
+type FlowKey struct {
+	SrcIP    [4]byte
+	DstIP    [4]byte
+	SrcPort  uint16
+	DstPort  uint16
+	Protocol uint8
+}
+
+// FlowRecord is the canonical in-memory representation of a single flow.
+// It maps 1:1 to the 18 fields in the NetFlow v9 / IPFIX template used by
+// this simulator. All byte/packet counts are cumulative for the flow lifetime.
+type FlowRecord struct {
+	SrcIP    net.IP
+	DstIP    net.IP
+	NextHop  net.IP
+	SrcPort  uint16
+	DstPort  uint16
+	Protocol uint8
+	TCPFlags uint8
+	ToS      uint8
+	Bytes    uint64
+	Packets  uint32
+	StartMs  uint32 // ms since device uptime epoch (SysUptime at flow start)
+	EndMs    uint32 // ms since device uptime epoch (SysUptime at last packet)
+	InIface  uint16 // SNMP ifIndex of ingress interface
+	OutIface uint16 // SNMP ifIndex of egress interface
+	SrcAS    uint16
+	DstAS    uint16
+	SrcMask  uint8
+	DstMask  uint8
+}
+
+// flowEntry wraps a FlowRecord with metadata used by the aging engine.
+type flowEntry struct {
+	record     FlowRecord
+	createdAt  time.Time
+	lastSeenAt time.Time
+}
+
+// FlowCache maintains the set of active synthetic flows for a single device.
+//
+// Flows are inserted via Add and aged out by Expire. Callers should call
+// GenerateFlows periodically to keep the cache at the target concurrency level,
+// then call Expire to harvest records ready for export.
+//
+// All public methods are safe for concurrent use.
+type FlowCache struct {
+	flows           map[FlowKey]*flowEntry
+	activeTimeout   time.Duration
+	inactiveTimeout time.Duration
+	maxFlows        int
+	mu              sync.Mutex
+}
+
+// NewFlowCache creates a FlowCache with the given timeout values and maximum
+// number of concurrent flows.
+func NewFlowCache(activeTimeout, inactiveTimeout time.Duration, maxFlows int) *FlowCache {
+	return &FlowCache{
+		flows:           make(map[FlowKey]*flowEntry),
+		activeTimeout:   activeTimeout,
+		inactiveTimeout: inactiveTimeout,
+		maxFlows:        maxFlows,
+	}
+}
+
+// Add inserts r into the cache or accumulates bytes/packets into an existing
+// entry. New entries are silently dropped when the cache is at capacity,
+// mirroring real router behaviour under high flow load.
+func (fc *FlowCache) Add(r FlowRecord, now time.Time) {
+	key := recordKey(r)
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if e, ok := fc.flows[key]; ok {
+		// Accumulate into existing flow.
+		e.record.Bytes += r.Bytes
+		e.record.Packets += r.Packets
+		e.record.TCPFlags |= r.TCPFlags
+		e.record.EndMs = r.EndMs
+		e.lastSeenAt = now
+		return
+	}
+	if len(fc.flows) >= fc.maxFlows {
+		return // cache full — drop silently
+	}
+	fc.flows[key] = &flowEntry{
+		record:     r,
+		createdAt:  now,
+		lastSeenAt: now,
+	}
+}
+
+// Expire removes and returns all flows that have crossed either the active or
+// inactive timeout boundary. The returned records are ready for export.
+func (fc *FlowCache) Expire(now time.Time) []FlowRecord {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	var expired []FlowRecord
+	for key, e := range fc.flows {
+		if now.Sub(e.createdAt) >= fc.activeTimeout ||
+			now.Sub(e.lastSeenAt) >= fc.inactiveTimeout {
+			expired = append(expired, e.record)
+			delete(fc.flows, key)
+		}
+	}
+	return expired
+}
+
+// Len returns the current number of active flows in the cache.
+func (fc *FlowCache) Len() int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return len(fc.flows)
+}
+
+// GenerateFlows synthesises new FlowRecords from profile and adds them until
+// the cache reaches profile.ConcurrentFlows. startUptimeMs is the device's
+// current uptime in milliseconds, used to anchor flow start/end timestamps.
+func (fc *FlowCache) GenerateFlows(profile *FlowProfile, deviceIP net.IP, rng *rand.Rand, now time.Time, startUptimeMs uint32) {
+	fc.mu.Lock()
+	need := profile.ConcurrentFlows - len(fc.flows)
+	fc.mu.Unlock()
+	for i := 0; i < need; i++ {
+		r := syntheticFlow(profile, deviceIP, rng, startUptimeMs)
+		fc.Add(r, now)
+	}
+}
+
+// recordKey derives a FlowKey from a FlowRecord's 5-tuple.
+func recordKey(r FlowRecord) FlowKey {
+	var k FlowKey
+	if ip4 := r.SrcIP.To4(); ip4 != nil {
+		copy(k.SrcIP[:], ip4)
+	}
+	if ip4 := r.DstIP.To4(); ip4 != nil {
+		copy(k.DstIP[:], ip4)
+	}
+	k.SrcPort = r.SrcPort
+	k.DstPort = r.DstPort
+	k.Protocol = r.Protocol
+	return k
+}
+
+// syntheticFlow constructs a single realistic FlowRecord for the given device.
+// Destination IPs are drawn from the 10.0.0.0/8 range; source IP is always
+// the device's own address (as a router or server would appear in exports).
+func syntheticFlow(profile *FlowProfile, deviceIP net.IP, rng *rand.Rand, startUptimeMs uint32) FlowRecord {
+	proto := profile.SampleProtocol(rng)
+	dstPort := profile.SampleDstPort(rng)
+
+	var srcPort uint16
+	spread := int(profile.SrcPortMax) - int(profile.SrcPortMin)
+	if spread > 0 {
+		srcPort = profile.SrcPortMin + uint16(rng.Intn(spread))
+	} else {
+		srcPort = profile.SrcPortMin
+	}
+
+	// Random destination in 10.0.0.0/8.
+	var dstRaw [4]byte
+	binary.BigEndian.PutUint32(dstRaw[:], 0x0A000000|uint32(rng.Intn(0x00FFFFFF)))
+	dstIP := net.IP(append([]byte{}, dstRaw[:]...))
+
+	durationMs := uint32(profile.SampleDurationMs(rng))
+	endMs := startUptimeMs + durationMs
+
+	var tcpFlags uint8
+	if proto == 6 {
+		tcpFlags = 0x18 // ACK + PSH — normal established-session data
+	}
+
+	bytes := profile.SampleBytes(rng)
+	if bytes < 0 {
+		bytes = 0
+	}
+	pkts := profile.SamplePkts(rng)
+	if pkts < 0 {
+		pkts = 0
+	}
+
+	return FlowRecord{
+		SrcIP:    deviceIP.To4(),
+		DstIP:    dstIP,
+		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort:  srcPort,
+		DstPort:  dstPort,
+		Protocol: proto,
+		TCPFlags: tcpFlags,
+		ToS:      0,
+		Bytes:    uint64(bytes),
+		Packets:  uint32(pkts),
+		StartMs:  startUptimeMs,
+		EndMs:    endMs,
+		InIface:  1,
+		OutIface: 2,
+		SrcAS:    0,
+		DstAS:    0,
+		SrcMask:  24,
+		DstMask:  24,
+	}
+}

--- a/go/simulator/flow_cache.go
+++ b/go/simulator/flow_cache.go
@@ -146,9 +146,28 @@ func (fc *FlowCache) GenerateFlows(profile *FlowProfile, deviceIP net.IP, rng *r
 	fc.mu.Lock()
 	need := profile.ConcurrentFlows - len(fc.flows)
 	fc.mu.Unlock()
-	for i := 0; i < need; i++ {
-		r := syntheticFlow(profile, deviceIP, rng, startUptimeMs)
-		fc.Add(r, now)
+	if need <= 0 {
+		return
+	}
+
+	// Generate synthetic records outside the lock (pure CPU, no shared state).
+	batch := make([]FlowRecord, need)
+	for i := range batch {
+		batch[i] = syntheticFlow(profile, deviceIP, rng, startUptimeMs)
+	}
+
+	// Insert the whole batch under a single lock acquisition to avoid TOCTOU
+	// between the need-check and the individual Add calls.
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	for _, r := range batch {
+		if len(fc.flows) >= fc.maxFlows {
+			break
+		}
+		key := recordKey(r)
+		if _, ok := fc.flows[key]; !ok {
+			fc.flows[key] = &flowEntry{record: r, createdAt: now, lastSeenAt: now}
+		}
 	}
 }
 
@@ -182,13 +201,16 @@ func syntheticFlow(profile *FlowProfile, deviceIP net.IP, rng *rand.Rand, startU
 		srcPort = profile.SrcPortMin
 	}
 
-	// Random destination in 10.0.0.0/8.
+	// Random destination in 10.0.0.1–10.255.255.254 (exclude network/broadcast).
 	var dstRaw [4]byte
-	binary.BigEndian.PutUint32(dstRaw[:], 0x0A000000|uint32(rng.Intn(0x00FFFFFF)))
+	binary.BigEndian.PutUint32(dstRaw[:], 0x0A000000|uint32(rng.Intn(0x00FFFFFE)+1))
 	dstIP := net.IP(append([]byte{}, dstRaw[:]...))
 
 	durationMs := uint32(profile.SampleDurationMs(rng))
 	endMs := startUptimeMs + durationMs
+	if endMs < startUptimeMs { // uint32 overflow guard (~49-day uptime wrap)
+		endMs = startUptimeMs
+	}
 
 	var tcpFlags uint8
 	if proto == 6 {

--- a/go/simulator/flow_cache_test.go
+++ b/go/simulator/flow_cache_test.go
@@ -1,0 +1,261 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+)
+
+// makeRecord is a test helper that returns a minimal FlowRecord with the given
+// 5-tuple. Bytes and Packets are set to 1 so accumulation is easy to verify.
+func makeRecord(srcIP, dstIP string, srcPort, dstPort uint16, proto uint8) FlowRecord {
+	return FlowRecord{
+		SrcIP:    net.ParseIP(srcIP).To4(),
+		DstIP:    net.ParseIP(dstIP).To4(),
+		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort:  srcPort,
+		DstPort:  dstPort,
+		Protocol: proto,
+		Bytes:    100,
+		Packets:  1,
+		StartMs:  1000,
+		EndMs:    2000,
+		InIface:  1,
+		OutIface: 2,
+		SrcMask:  24,
+		DstMask:  24,
+	}
+}
+
+func TestFlowCache_AddAndLen(t *testing.T) {
+	fc := NewFlowCache(60*time.Second, 15*time.Second, 256)
+	now := time.Now()
+
+	fc.Add(makeRecord("10.0.0.1", "10.0.0.2", 12345, 443, 6), now)
+	fc.Add(makeRecord("10.0.0.1", "10.0.0.3", 12346, 80, 6), now)
+
+	if got := fc.Len(); got != 2 {
+		t.Errorf("expected 2 flows, got %d", got)
+	}
+}
+
+func TestFlowCache_Accumulate(t *testing.T) {
+	fc := NewFlowCache(60*time.Second, 15*time.Second, 256)
+	now := time.Now()
+
+	r := makeRecord("10.0.0.1", "10.0.0.2", 12345, 443, 6)
+	fc.Add(r, now)
+	fc.Add(r, now) // second add to same 5-tuple must accumulate
+
+	if fc.Len() != 1 {
+		t.Fatalf("expected 1 flow after duplicate add, got %d", fc.Len())
+	}
+
+	expired := fc.Expire(now.Add(61 * time.Second))
+	if len(expired) != 1 {
+		t.Fatalf("expected 1 expired record, got %d", len(expired))
+	}
+	if expired[0].Bytes != 200 {
+		t.Errorf("expected accumulated bytes=200, got %d", expired[0].Bytes)
+	}
+	if expired[0].Packets != 2 {
+		t.Errorf("expected accumulated packets=2, got %d", expired[0].Packets)
+	}
+}
+
+func TestFlowCache_ActiveTimeout(t *testing.T) {
+	active := 5 * time.Second
+	inactive := 30 * time.Second
+	fc := NewFlowCache(active, inactive, 256)
+	now := time.Now()
+
+	fc.Add(makeRecord("10.0.0.1", "10.0.0.2", 1000, 443, 6), now)
+
+	// Should not expire before active timeout.
+	if got := fc.Expire(now.Add(4 * time.Second)); len(got) != 0 {
+		t.Errorf("expected 0 expired before active timeout, got %d", len(got))
+	}
+
+	// Should expire at/after active timeout.
+	if got := fc.Expire(now.Add(5 * time.Second)); len(got) != 1 {
+		t.Errorf("expected 1 expired at active timeout, got %d", len(got))
+	}
+
+	if fc.Len() != 0 {
+		t.Errorf("expected empty cache after expiry, got %d", fc.Len())
+	}
+}
+
+func TestFlowCache_InactiveTimeout(t *testing.T) {
+	active := 60 * time.Second
+	inactive := 5 * time.Second
+	fc := NewFlowCache(active, inactive, 256)
+	t0 := time.Now()
+
+	fc.Add(makeRecord("10.0.0.1", "10.0.0.2", 2000, 80, 6), t0)
+
+	// Not yet inactive.
+	if got := fc.Expire(t0.Add(4 * time.Second)); len(got) != 0 {
+		t.Errorf("expected 0 expired before inactive timeout, got %d", len(got))
+	}
+
+	// Crossed inactive threshold without a fresh packet.
+	if got := fc.Expire(t0.Add(5 * time.Second)); len(got) != 1 {
+		t.Errorf("expected 1 expired at inactive timeout, got %d", len(got))
+	}
+}
+
+func TestFlowCache_InactiveReset(t *testing.T) {
+	// A second Add on the same 5-tuple resets the inactive timer.
+	active := 60 * time.Second
+	inactive := 5 * time.Second
+	fc := NewFlowCache(active, inactive, 256)
+	t0 := time.Now()
+
+	r := makeRecord("10.0.0.1", "10.0.0.2", 3000, 443, 6)
+	fc.Add(r, t0)
+
+	// Re-add (simulate new packet) at t+4s — resets lastSeenAt.
+	t1 := t0.Add(4 * time.Second)
+	fc.Add(r, t1)
+
+	// At t+8s the flow is 4s from the last packet — still within inactive timeout.
+	if got := fc.Expire(t0.Add(8 * time.Second)); len(got) != 0 {
+		t.Errorf("expected 0 expired (inactive reset), got %d", len(got))
+	}
+
+	// At t+10s the flow is 6s from the last packet — inactive timeout exceeded.
+	if got := fc.Expire(t0.Add(10 * time.Second)); len(got) != 1 {
+		t.Errorf("expected 1 expired after inactive reset, got %d", len(got))
+	}
+}
+
+func TestFlowCache_MaxFlows(t *testing.T) {
+	const cap = 3
+	fc := NewFlowCache(60*time.Second, 15*time.Second, cap)
+	now := time.Now()
+
+	for i := 0; i < cap+5; i++ {
+		fc.Add(makeRecord("10.0.0.1", "10.0.0.2", uint16(10000+i), 443, 6), now)
+	}
+
+	if got := fc.Len(); got != cap {
+		t.Errorf("expected cache capped at %d, got %d", cap, got)
+	}
+}
+
+func TestFlowCache_ExpireEmpty(t *testing.T) {
+	fc := NewFlowCache(60*time.Second, 15*time.Second, 256)
+	expired := fc.Expire(time.Now().Add(time.Hour))
+	if len(expired) != 0 {
+		t.Errorf("expected 0 expired from empty cache, got %d", len(expired))
+	}
+}
+
+func TestFlowCache_GenerateFlows(t *testing.T) {
+	profile := flowProfileServer
+	deviceIP := net.ParseIP("192.168.1.1")
+	rng := rand.New(rand.NewSource(42))
+	fc := NewFlowCache(60*time.Second, 15*time.Second, profile.MaxFlows)
+	now := time.Now()
+
+	fc.GenerateFlows(profile, deviceIP, rng, now, 0)
+
+	if got := fc.Len(); got != profile.ConcurrentFlows {
+		t.Errorf("expected %d concurrent flows, got %d", profile.ConcurrentFlows, got)
+	}
+
+	// A second call should be a no-op (already at target).
+	fc.GenerateFlows(profile, deviceIP, rng, now, 0)
+	if got := fc.Len(); got != profile.ConcurrentFlows {
+		t.Errorf("expected no extra flows on second generate, got %d", got)
+	}
+}
+
+func TestFlowCache_GeneratedFlowsHaveValidFields(t *testing.T) {
+	profile := flowProfileCoreRouter
+	deviceIP := net.ParseIP("10.1.2.3")
+	rng := rand.New(rand.NewSource(7))
+	fc := NewFlowCache(60*time.Second, 15*time.Second, profile.MaxFlows)
+	now := time.Now()
+
+	fc.GenerateFlows(profile, deviceIP, rng, now, 5000)
+	expired := fc.Expire(now.Add(61 * time.Second))
+
+	for i, r := range expired {
+		if r.SrcIP == nil || r.SrcIP.To4() == nil {
+			t.Errorf("record %d: nil or non-IPv4 SrcIP", i)
+		}
+		if r.DstIP == nil || r.DstIP.To4() == nil {
+			t.Errorf("record %d: nil or non-IPv4 DstIP", i)
+		}
+		if r.Protocol != 6 && r.Protocol != 17 && r.Protocol != 1 {
+			t.Errorf("record %d: unexpected protocol %d", i, r.Protocol)
+		}
+		if r.EndMs < r.StartMs {
+			t.Errorf("record %d: EndMs (%d) < StartMs (%d)", i, r.EndMs, r.StartMs)
+		}
+	}
+}
+
+func TestFlowProfile_SampleProtocol(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	counts := map[uint8]int{}
+	const n = 10000
+	for i := 0; i < n; i++ {
+		counts[flowProfileCoreRouter.SampleProtocol(rng)]++
+	}
+	// TCP weight 0.65 — expect roughly 6000-7000 TCP samples.
+	if counts[6] < 5500 || counts[6] > 7500 {
+		t.Errorf("TCP count %d out of expected range [5500,7500] over %d samples", counts[6], n)
+	}
+	// No unexpected protocol values.
+	for proto, c := range counts {
+		if proto != 6 && proto != 17 && proto != 1 {
+			t.Errorf("unexpected protocol %d with count %d", proto, c)
+		}
+	}
+}
+
+func TestFlowProfile_SampleDstPort_AllCovered(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+	seen := map[uint16]bool{}
+	for i := 0; i < 10000; i++ {
+		seen[flowProfileEdgeRouter.SampleDstPort(rng)] = true
+	}
+	for _, pw := range flowProfileEdgeRouter.DstPorts {
+		if !seen[pw.Port] {
+			t.Errorf("port %d never sampled in 10000 draws", pw.Port)
+		}
+	}
+}
+
+func TestGetFlowProfile_KnownDevice(t *testing.T) {
+	p := GetFlowProfile("cisco_nexus_9500.json")
+	if p != flowProfileDCSwitch {
+		t.Error("expected flowProfileDCSwitch for cisco_nexus_9500.json")
+	}
+}
+
+func TestGetFlowProfile_UnknownDevice(t *testing.T) {
+	p := GetFlowProfile("unknown_device.json")
+	if p != flowProfileEdgeRouter {
+		t.Error("expected fallback to flowProfileEdgeRouter for unknown device")
+	}
+}

--- a/go/simulator/flow_profiles.go
+++ b/go/simulator/flow_profiles.go
@@ -1,0 +1,308 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "math/rand"
+
+// FlowProfile defines synthetic traffic characteristics for a device category.
+// It drives 5-tuple generation (src/dst IP, src/dst port, protocol) and the
+// byte/packet sizing of FlowRecord entries produced by FlowCache.GenerateFlows.
+type FlowProfile struct {
+	// Protocol distribution — values must sum to 1.0.
+	TCPWeight  float64
+	UDPWeight  float64
+	ICMPWeight float64
+
+	// Destination port distribution (TCP/UDP). Weights must sum to 1.0.
+	DstPorts []PortWeight
+
+	// Ephemeral source port range (inclusive).
+	SrcPortMin uint16
+	SrcPortMax uint16
+
+	// Bytes per flow — sampled uniformly from [BytesMin, BytesMax).
+	BytesMin int64
+	BytesMax int64
+
+	// Packets per flow — sampled uniformly from [PktsMin, PktsMax).
+	PktsMin int32
+	PktsMax int32
+
+	// Flow duration in milliseconds — sampled uniformly from [DurationMinMs, DurationMaxMs).
+	DurationMinMs int64
+	DurationMaxMs int64
+
+	// Target number of concurrently active flows for this device.
+	ConcurrentFlows int
+
+	// Hard cap on active flows in the cache (mirrors real router behaviour).
+	MaxFlows int
+}
+
+// PortWeight pairs a destination port number with a sampling weight.
+type PortWeight struct {
+	Port   uint16
+	Weight float64
+}
+
+// SampleProtocol returns 6 (TCP), 17 (UDP), or 1 (ICMP) based on the
+// profile's distribution, using r as the random source.
+func (fp *FlowProfile) SampleProtocol(r *rand.Rand) uint8 {
+	v := r.Float64()
+	if v < fp.TCPWeight {
+		return 6
+	}
+	if v < fp.TCPWeight+fp.UDPWeight {
+		return 17
+	}
+	return 1
+}
+
+// SampleDstPort returns a destination port sampled from DstPorts.
+// Falls back to 443 if the distribution is empty.
+func (fp *FlowProfile) SampleDstPort(r *rand.Rand) uint16 {
+	if len(fp.DstPorts) == 0 {
+		return 443
+	}
+	v := r.Float64()
+	cumulative := 0.0
+	for _, pw := range fp.DstPorts {
+		cumulative += pw.Weight
+		if v < cumulative {
+			return pw.Port
+		}
+	}
+	return fp.DstPorts[len(fp.DstPorts)-1].Port
+}
+
+// SampleBytes returns a byte count sampled uniformly from [BytesMin, BytesMax).
+func (fp *FlowProfile) SampleBytes(r *rand.Rand) int64 {
+	if fp.BytesMax <= fp.BytesMin {
+		return fp.BytesMin
+	}
+	return fp.BytesMin + r.Int63n(fp.BytesMax-fp.BytesMin)
+}
+
+// SamplePkts returns a packet count sampled uniformly from [PktsMin, PktsMax).
+func (fp *FlowProfile) SamplePkts(r *rand.Rand) int32 {
+	if fp.PktsMax <= fp.PktsMin {
+		return fp.PktsMin
+	}
+	return fp.PktsMin + r.Int31n(fp.PktsMax-fp.PktsMin)
+}
+
+// SampleDurationMs returns a flow duration in milliseconds.
+func (fp *FlowProfile) SampleDurationMs(r *rand.Rand) int64 {
+	if fp.DurationMaxMs <= fp.DurationMinMs {
+		return fp.DurationMinMs
+	}
+	return fp.DurationMinMs + r.Int63n(fp.DurationMaxMs-fp.DurationMinMs)
+}
+
+// ---- Per-category profiles ----------------------------------------
+
+var flowProfileCoreRouter = &FlowProfile{
+	TCPWeight: 0.65, UDPWeight: 0.30, ICMPWeight: 0.05,
+	DstPorts: []PortWeight{
+		{443, 0.35}, {80, 0.15}, {179, 0.15}, {53, 0.15}, {22, 0.10}, {8080, 0.10},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        512,
+	BytesMax:        1_500_000,
+	PktsMin:         1,
+	PktsMax:         1000,
+	DurationMinMs:   500,
+	DurationMaxMs:   300_000,
+	ConcurrentFlows: 200,
+	MaxFlows:        256,
+}
+
+var flowProfileEdgeRouter = &FlowProfile{
+	TCPWeight: 0.70, UDPWeight: 0.25, ICMPWeight: 0.05,
+	DstPorts: []PortWeight{
+		{443, 0.50}, {80, 0.20}, {53, 0.15}, {22, 0.10}, {25, 0.05},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        256,
+	BytesMax:        500_000,
+	PktsMin:         1,
+	PktsMax:         500,
+	DurationMinMs:   200,
+	DurationMaxMs:   120_000,
+	ConcurrentFlows: 128,
+	MaxFlows:        256,
+}
+
+var flowProfileDCSwitch = &FlowProfile{
+	TCPWeight: 0.80, UDPWeight: 0.18, ICMPWeight: 0.02,
+	DstPorts: []PortWeight{
+		{3260, 0.30}, {2049, 0.25}, {443, 0.20}, {4789, 0.15}, {445, 0.10},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        4_096,
+	BytesMax:        10_000_000,
+	PktsMin:         4,
+	PktsMax:         8000,
+	DurationMinMs:   100,
+	DurationMaxMs:   60_000,
+	ConcurrentFlows: 128,
+	MaxFlows:        256,
+}
+
+var flowProfileCampusSwitch = &FlowProfile{
+	TCPWeight: 0.65, UDPWeight: 0.30, ICMPWeight: 0.05,
+	DstPorts: []PortWeight{
+		{443, 0.40}, {80, 0.20}, {53, 0.20}, {67, 0.10}, {389, 0.10},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        64,
+	BytesMax:        300_000,
+	PktsMin:         1,
+	PktsMax:         300,
+	DurationMinMs:   100,
+	DurationMaxMs:   30_000,
+	ConcurrentFlows: 64,
+	MaxFlows:        256,
+}
+
+var flowProfileFirewall = &FlowProfile{
+	TCPWeight: 0.60, UDPWeight: 0.30, ICMPWeight: 0.10,
+	DstPorts: []PortWeight{
+		{443, 0.35}, {80, 0.20}, {53, 0.20}, {22, 0.15}, {3389, 0.10},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        0, // blocked flows carry 0 bytes
+	BytesMax:        200_000,
+	PktsMin:         0,
+	PktsMax:         200,
+	DurationMinMs:   50,
+	DurationMaxMs:   60_000,
+	ConcurrentFlows: 64,
+	MaxFlows:        256,
+}
+
+var flowProfileServer = &FlowProfile{
+	TCPWeight: 0.85, UDPWeight: 0.13, ICMPWeight: 0.02,
+	DstPorts: []PortWeight{
+		{443, 0.40}, {22, 0.25}, {161, 0.20}, {80, 0.15},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        512,
+	BytesMax:        100_000,
+	PktsMin:         1,
+	PktsMax:         200,
+	DurationMinMs:   1_000,
+	DurationMaxMs:   60_000,
+	ConcurrentFlows: 32,
+	MaxFlows:        256,
+}
+
+var flowProfileGPUServer = &FlowProfile{
+	TCPWeight: 0.30, UDPWeight: 0.68, ICMPWeight: 0.02,
+	DstPorts: []PortWeight{
+		{4791, 0.60}, {443, 0.20}, {22, 0.10}, {8080, 0.10},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        1_000_000,
+	BytesMax:        10_000_000_000, // 10 GB — large RDMA/NCCL transfers
+	PktsMin:         1000,
+	PktsMax:         8_000_000,
+	DurationMinMs:   10_000,
+	DurationMaxMs:   600_000,
+	ConcurrentFlows: 8, // few but very large flows
+	MaxFlows:        256,
+}
+
+var flowProfileStorage = &FlowProfile{
+	TCPWeight: 0.85, UDPWeight: 0.14, ICMPWeight: 0.01,
+	DstPorts: []PortWeight{
+		{2049, 0.30}, {3260, 0.30}, {443, 0.25}, {445, 0.15},
+	},
+	SrcPortMin:      1024,
+	SrcPortMax:      65535,
+	BytesMin:        65_536,
+	BytesMax:        5_000_000_000, // 5 GB
+	PktsMin:         64,
+	PktsMax:         4_000_000,
+	DurationMinMs:   5_000,
+	DurationMaxMs:   300_000,
+	ConcurrentFlows: 32,
+	MaxFlows:        256,
+}
+
+// flowProfileMap mirrors deviceProfileMap, mapping resource file names to
+// their corresponding FlowProfile. Must stay in sync with RoundRobinDeviceTypes.
+var flowProfileMap = map[string]*FlowProfile{
+	// Core Routers
+	"asr9k.json":           flowProfileCoreRouter,
+	"cisco_crs_x.json":     flowProfileCoreRouter,
+	"huawei_ne8000.json":   flowProfileCoreRouter,
+	"nokia_7750_sr12.json": flowProfileCoreRouter,
+	"juniper_mx960.json":   flowProfileCoreRouter,
+
+	// Edge Routers
+	"juniper_mx240.json": flowProfileEdgeRouter,
+	"nec_ix3315.json":    flowProfileEdgeRouter,
+	"cisco_ios.json":     flowProfileEdgeRouter,
+
+	// Data Center Switches
+	"cisco_nexus_9500.json": flowProfileDCSwitch,
+	"arista_7280r3.json":    flowProfileDCSwitch,
+
+	// Campus Switches
+	"cisco_catalyst_9500.json": flowProfileCampusSwitch,
+	"extreme_vsp4450.json":     flowProfileCampusSwitch,
+	"dlink_dgs3630.json":       flowProfileCampusSwitch,
+
+	// Firewalls
+	"palo_alto_pa3220.json":        flowProfileFirewall,
+	"fortinet_fortigate_600e.json": flowProfileFirewall,
+	"sonicwall_nsa6700.json":       flowProfileFirewall,
+	"check_point_15600.json":       flowProfileFirewall,
+
+	// Servers
+	"dell_poweredge_r750.json": flowProfileServer,
+	"hpe_proliant_dl380.json":  flowProfileServer,
+	"ibm_power_s922.json":      flowProfileServer,
+	"linux_server.json":        flowProfileServer,
+
+	// GPU Servers
+	"nvidia_dgx_a100.json": flowProfileGPUServer,
+	"nvidia_dgx_h100.json": flowProfileGPUServer,
+	"nvidia_hgx_h200.json": flowProfileGPUServer,
+
+	// Storage Systems
+	"netapp_ontap.json":            flowProfileStorage,
+	"pure_storage_flasharray.json": flowProfileStorage,
+	"dell_emc_unity.json":          flowProfileStorage,
+	"aws_s3_storage.json":          flowProfileStorage,
+}
+
+// GetFlowProfile returns the FlowProfile for the given resource file name.
+// Falls back to flowProfileEdgeRouter if the file is not in the map.
+func GetFlowProfile(resourceFile string) *FlowProfile {
+	if p, ok := flowProfileMap[resourceFile]; ok {
+		return p
+	}
+	return flowProfileEdgeRouter
+}

--- a/go/simulator/flow_profiles.go
+++ b/go/simulator/flow_profiles.go
@@ -256,14 +256,14 @@ var flowProfileMap = map[string]*FlowProfile{
 	// Core Routers
 	"asr9k.json":           flowProfileCoreRouter,
 	"cisco_crs_x.json":     flowProfileCoreRouter,
-	"huawei_ne8000.json":   flowProfileCoreRouter,
 	"nokia_7750_sr12.json": flowProfileCoreRouter,
 	"juniper_mx960.json":   flowProfileCoreRouter,
 
 	// Edge Routers
-	"juniper_mx240.json": flowProfileEdgeRouter,
-	"nec_ix3315.json":    flowProfileEdgeRouter,
-	"cisco_ios.json":     flowProfileEdgeRouter,
+	"juniper_mx240.json":  flowProfileEdgeRouter,
+	"nec_ix3315.json":     flowProfileEdgeRouter,
+	"cisco_ios.json":      flowProfileEdgeRouter,
+	"huawei_ne8000.json":  flowProfileEdgeRouter,
 
 	// Data Center Switches
 	"cisco_nexus_9500.json": flowProfileDCSwitch,

--- a/go/simulator/netflow9.go
+++ b/go/simulator/netflow9.go
@@ -1,0 +1,293 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// NetFlow v9 wire constants (RFC 3954).
+const (
+	nf9Version    = 9
+	nf9TemplateID = 256 // first valid data template ID
+
+	// Field type IDs (RFC 3954, Appendix A)
+	nf9InBytes      = 1
+	nf9InPkts       = 2
+	nf9Protocol     = 4
+	nf9SrcTOS       = 5
+	nf9TCPFlags     = 6
+	nf9L4SrcPort    = 7
+	nf9IPv4SrcAddr  = 8
+	nf9SrcMask      = 9
+	nf9InputSNMP    = 10
+	nf9L4DstPort    = 11
+	nf9IPv4DstAddr  = 12
+	nf9DstMask      = 13
+	nf9OutputSNMP   = 14
+	nf9IPv4NextHop  = 15
+	nf9SrcAS        = 16
+	nf9DstAS        = 17
+	nf9LastSwitched = 21
+	nf9FirstSwitched = 22
+
+	// Derived sizes.
+	nf9HeaderSize   = 20 // bytes — Packet Header (RFC 3954 §5)
+	nf9RecordSize   = 45 // bytes — one data record with the 18-field template below
+	nf9TemplFlowSetSize = 80 // bytes — Template FlowSet (4 hdr + 4 tmpl hdr + 18×4 fields)
+)
+
+// nf9Fields is the ordered list of (fieldType, fieldLength) pairs that define
+// the single template used for all simulated device flow exports.
+// Changing this list requires updating nf9RecordSize and nf9TemplFlowSetSize.
+var nf9Fields = [][2]uint16{
+	{nf9InBytes, 4},
+	{nf9InPkts, 4},
+	{nf9Protocol, 1},
+	{nf9SrcTOS, 1},
+	{nf9TCPFlags, 1},
+	{nf9L4SrcPort, 2},
+	{nf9IPv4SrcAddr, 4},
+	{nf9SrcMask, 1},
+	{nf9InputSNMP, 2},
+	{nf9L4DstPort, 2},
+	{nf9IPv4DstAddr, 4},
+	{nf9DstMask, 1},
+	{nf9OutputSNMP, 2},
+	{nf9IPv4NextHop, 4},
+	{nf9SrcAS, 2},
+	{nf9DstAS, 2},
+	{nf9LastSwitched, 4},
+	{nf9FirstSwitched, 4},
+}
+
+// nf9TemplatBytes is the pre-encoded Template FlowSet, built once at init.
+// It is read-only after init and safe to reference from any goroutine.
+var nf9TemplateBytes []byte
+
+func init() {
+	nf9TemplateBytes = buildNF9Template()
+}
+
+// buildNF9Template encodes the Template FlowSet for nf9Fields.
+// Layout (80 bytes):
+//   FlowSet Header: flowset_id=0 (2B), length=80 (2B)
+//   Template Header: template_id=256 (2B), field_count=18 (2B)
+//   18 × (field_type 2B + field_length 2B)
+func buildNF9Template() []byte {
+	fieldCount := len(nf9Fields)
+	length := 4 + 4 + fieldCount*4 // flowset hdr + tmpl hdr + fields
+	buf := make([]byte, length)
+	pos := 0
+
+	binary.BigEndian.PutUint16(buf[pos:], 0)          // FlowSet ID = 0 (Template)
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], uint16(length)) // FlowSet Length
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], nf9TemplateID)  // Template ID
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], uint16(fieldCount)) // Field Count
+	pos += 2
+
+	for _, f := range nf9Fields {
+		binary.BigEndian.PutUint16(buf[pos:], f[0]) // field type
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], f[1]) // field length
+		pos += 2
+	}
+	return buf
+}
+
+// NetFlow9Encoder encodes FlowRecords into NetFlow v9 UDP payloads (RFC 3954).
+// It is stateless; all variable state (sequence number, uptime) is passed by
+// the caller so the encoder can be shared across goroutines without locking.
+type NetFlow9Encoder struct{}
+
+// EncodePacket serialises a complete NetFlow v9 UDP payload into buf and
+// returns the number of bytes written.
+//
+// Parameters:
+//   domainID        — ObservationDomainID (source_id in v9 header); use the
+//                     device IPv4 address as uint32 for per-device identity.
+//   seqNo           — per-domain sequence number (monotonically increasing).
+//   uptimeMs        — device system uptime in milliseconds at export time.
+//   records         — flow records to include in the Data FlowSet.
+//   includeTemplate — when true, a Template FlowSet is prepended; send on the
+//                     first packet and every templateInterval thereafter.
+//   buf             — caller-supplied output buffer; must be >= 1500 bytes.
+//
+// Returns an error if buf is too small to hold even a single record.
+func (NetFlow9Encoder) EncodePacket(
+	domainID uint32,
+	seqNo uint32,
+	uptimeMs uint32,
+	records []FlowRecord,
+	includeTemplate bool,
+	buf []byte,
+) (int, error) {
+	if len(records) == 0 && !includeTemplate {
+		return 0, nil
+	}
+
+	// Determine how many records actually fit.
+	// Minimum buffer: header + (template if requested) + data FlowSet header
+	overhead := nf9HeaderSize + 4 // hdr + data flowset hdr
+	if includeTemplate {
+		overhead += nf9TemplFlowSetSize
+	}
+	if len(buf) < overhead+nf9RecordSize && len(records) > 0 {
+		return 0, fmt.Errorf("netflow9: buffer too small (%d bytes), need at least %d", len(buf), overhead+nf9RecordSize)
+	}
+
+	// Cap records to what fits in buf.
+	available := len(buf) - overhead
+	maxRecords := available / nf9RecordSize
+	if maxRecords < len(records) {
+		records = records[:maxRecords]
+	}
+
+	// Count field in header = template records (1 if included) + data records.
+	count := len(records)
+	if includeTemplate {
+		count++ // one template "record"
+	}
+
+	pos := 0
+
+	// ── Packet Header (20 bytes) ─────────────────────────────────────
+	binary.BigEndian.PutUint16(buf[pos:], nf9Version) // Version = 9
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], uint16(count)) // Count
+	pos += 2
+	binary.BigEndian.PutUint32(buf[pos:], uptimeMs) // SysUptime (ms)
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], uint32(time.Now().Unix())) // unix_secs
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], seqNo) // SequenceNumber
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], domainID) // SourceId
+	pos += 4
+
+	// ── Template FlowSet (optional, 80 bytes) ────────────────────────
+	if includeTemplate {
+		copy(buf[pos:], nf9TemplateBytes)
+		pos += len(nf9TemplateBytes)
+	}
+
+	if len(records) == 0 {
+		return pos, nil
+	}
+
+	// ── Data FlowSet ─────────────────────────────────────────────────
+	dataFlowSetStart := pos
+	binary.BigEndian.PutUint16(buf[pos:], nf9TemplateID) // FlowSet ID = template ID
+	pos += 2
+	// Length placeholder — filled in after writing records.
+	lengthOffset := pos
+	pos += 2
+
+	for _, r := range records {
+		pos = encodeNF9Record(buf, pos, r)
+	}
+
+	// Pad to 4-byte boundary (RFC 3954 §5.3).
+	dataLen := pos - dataFlowSetStart
+	if rem := dataLen % 4; rem != 0 {
+		padBytes := 4 - rem
+		for i := 0; i < padBytes; i++ {
+			buf[pos] = 0
+			pos++
+		}
+		dataLen += padBytes
+	}
+	binary.BigEndian.PutUint16(buf[lengthOffset:], uint16(dataLen))
+
+	return pos, nil
+}
+
+// encodeNF9Record writes a single flow record into buf at pos, following the
+// field order defined in nf9Fields. Returns the new position.
+func encodeNF9Record(buf []byte, pos int, r FlowRecord) int {
+	// IN_BYTES (4)
+	binary.BigEndian.PutUint32(buf[pos:], uint32(r.Bytes))
+	pos += 4
+	// IN_PKTS (4)
+	binary.BigEndian.PutUint32(buf[pos:], r.Packets)
+	pos += 4
+	// PROTOCOL (1)
+	buf[pos] = r.Protocol
+	pos++
+	// SRC_TOS (1)
+	buf[pos] = r.ToS
+	pos++
+	// TCP_FLAGS (1)
+	buf[pos] = r.TCPFlags
+	pos++
+	// L4_SRC_PORT (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.SrcPort)
+	pos += 2
+	// IPV4_SRC_ADDR (4)
+	src := r.SrcIP.To4()
+	if src == nil {
+		src = []byte{0, 0, 0, 0}
+	}
+	copy(buf[pos:], src)
+	pos += 4
+	// SRC_MASK (1)
+	buf[pos] = r.SrcMask
+	pos++
+	// INPUT_SNMP (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.InIface)
+	pos += 2
+	// L4_DST_PORT (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.DstPort)
+	pos += 2
+	// IPV4_DST_ADDR (4)
+	dst := r.DstIP.To4()
+	if dst == nil {
+		dst = []byte{0, 0, 0, 0}
+	}
+	copy(buf[pos:], dst)
+	pos += 4
+	// DST_MASK (1)
+	buf[pos] = r.DstMask
+	pos++
+	// OUTPUT_SNMP (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.OutIface)
+	pos += 2
+	// IPV4_NEXT_HOP (4)
+	nh := r.NextHop.To4()
+	if nh == nil {
+		nh = []byte{0, 0, 0, 0}
+	}
+	copy(buf[pos:], nh)
+	pos += 4
+	// SRC_AS (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.SrcAS)
+	pos += 2
+	// DST_AS (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.DstAS)
+	pos += 2
+	// LAST_SWITCHED (4)
+	binary.BigEndian.PutUint32(buf[pos:], r.EndMs)
+	pos += 4
+	// FIRST_SWITCHED (4)
+	binary.BigEndian.PutUint32(buf[pos:], r.StartMs)
+	pos += 4
+	return pos
+}

--- a/go/simulator/netflow9.go
+++ b/go/simulator/netflow9.go
@@ -18,6 +18,7 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -150,6 +151,9 @@ func (NetFlow9Encoder) EncodePacket(
 	if includeTemplate {
 		overhead += nf9TemplFlowSetSize
 	}
+	if len(buf) < overhead {
+		return 0, fmt.Errorf("netflow9: buffer too small (%d bytes), need at least %d", len(buf), overhead)
+	}
 	if len(buf) < overhead+nf9RecordSize && len(records) > 0 {
 		return 0, fmt.Errorf("netflow9: buffer too small (%d bytes), need at least %d", len(buf), overhead+nf9RecordSize)
 	}
@@ -223,8 +227,13 @@ func (NetFlow9Encoder) EncodePacket(
 // encodeNF9Record writes a single flow record into buf at pos, following the
 // field order defined in nf9Fields. Returns the new position.
 func encodeNF9Record(buf []byte, pos int, r FlowRecord) int {
-	// IN_BYTES (4)
-	binary.BigEndian.PutUint32(buf[pos:], uint32(r.Bytes))
+	// IN_BYTES (4) — NetFlow v9 field is 4 bytes; clamp to avoid silent wrap for
+	// large flows (GPU/Storage profiles can exceed 4 GB per flow).
+	inBytes := r.Bytes
+	if inBytes > math.MaxUint32 {
+		inBytes = math.MaxUint32
+	}
+	binary.BigEndian.PutUint32(buf[pos:], uint32(inBytes))
 	pos += 4
 	// IN_PKTS (4)
 	binary.BigEndian.PutUint32(buf[pos:], r.Packets)

--- a/go/simulator/netflow9_test.go
+++ b/go/simulator/netflow9_test.go
@@ -1,0 +1,420 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// ── Inline NetFlow v9 decoder (test oracle) ──────────────────────────────────
+//
+// This minimal parser validates that EncodePacket produces correctly-structured
+// RFC 3954 wire bytes without introducing any external test dependency.
+
+type nf9PacketHeader struct {
+	Version    uint16
+	Count      uint16
+	SysUptime  uint32
+	UnixSecs   uint32
+	SequenceNo uint32
+	SourceID   uint32
+}
+
+type nf9TemplateField struct {
+	FieldType   uint16
+	FieldLength uint16
+}
+
+type nf9DecodedTemplate struct {
+	TemplateID uint16
+	Fields     []nf9TemplateField
+}
+
+type nf9DecodedRecord struct {
+	Bytes     uint32
+	Packets   uint32
+	Protocol  uint8
+	ToS       uint8
+	TCPFlags  uint8
+	SrcPort   uint16
+	SrcIP     net.IP
+	SrcMask   uint8
+	InIface   uint16
+	DstPort   uint16
+	DstIP     net.IP
+	DstMask   uint8
+	OutIface  uint16
+	NextHop   net.IP
+	SrcAS     uint16
+	DstAS     uint16
+	LastSw    uint32
+	FirstSw   uint32
+}
+
+type nf9Packet struct {
+	Header    nf9PacketHeader
+	Templates []nf9DecodedTemplate
+	Records   []nf9DecodedRecord
+}
+
+// decodeNF9Packet parses the given bytes into a nf9Packet, returning an error
+// string on any structural violation.
+func decodeNF9Packet(t *testing.T, data []byte) *nf9Packet {
+	t.Helper()
+	if len(data) < nf9HeaderSize {
+		t.Fatalf("packet too short: %d bytes", len(data))
+	}
+
+	pkt := &nf9Packet{}
+	pkt.Header.Version    = binary.BigEndian.Uint16(data[0:])
+	pkt.Header.Count      = binary.BigEndian.Uint16(data[2:])
+	pkt.Header.SysUptime  = binary.BigEndian.Uint32(data[4:])
+	pkt.Header.UnixSecs   = binary.BigEndian.Uint32(data[8:])
+	pkt.Header.SequenceNo = binary.BigEndian.Uint32(data[12:])
+	pkt.Header.SourceID   = binary.BigEndian.Uint32(data[16:])
+
+	pos := nf9HeaderSize
+	for pos < len(data) {
+		if pos+4 > len(data) {
+			break
+		}
+		fsID := binary.BigEndian.Uint16(data[pos:])
+		fsLen := int(binary.BigEndian.Uint16(data[pos+2:]))
+		if fsLen < 4 || pos+fsLen > len(data) {
+			t.Fatalf("invalid FlowSet length %d at offset %d", fsLen, pos)
+		}
+		fsData := data[pos : pos+fsLen]
+		pos += fsLen
+
+		switch {
+		case fsID == 0: // Template FlowSet
+			tmplPos := 4 // skip flowset header
+			for tmplPos+4 <= len(fsData) {
+				tmplID := binary.BigEndian.Uint16(fsData[tmplPos:])
+				fieldCount := int(binary.BigEndian.Uint16(fsData[tmplPos+2:]))
+				tmplPos += 4
+				tmpl := nf9DecodedTemplate{TemplateID: tmplID}
+				for i := 0; i < fieldCount && tmplPos+4 <= len(fsData); i++ {
+					ft := binary.BigEndian.Uint16(fsData[tmplPos:])
+					fl := binary.BigEndian.Uint16(fsData[tmplPos+2:])
+					tmpl.Fields = append(tmpl.Fields, nf9TemplateField{ft, fl})
+					tmplPos += 4
+				}
+				pkt.Templates = append(pkt.Templates, tmpl)
+			}
+
+		case fsID >= 256: // Data FlowSet
+			recPos := 4 // skip flowset header
+			for recPos+nf9RecordSize <= fsLen {
+				r := nf9DecodedRecord{}
+				r.Bytes    = binary.BigEndian.Uint32(fsData[recPos:])
+				r.Packets  = binary.BigEndian.Uint32(fsData[recPos+4:])
+				r.Protocol = fsData[recPos+8]
+				r.ToS      = fsData[recPos+9]
+				r.TCPFlags = fsData[recPos+10]
+				r.SrcPort  = binary.BigEndian.Uint16(fsData[recPos+11:])
+				r.SrcIP    = net.IP(append([]byte{}, fsData[recPos+13:recPos+17]...))
+				r.SrcMask  = fsData[recPos+17]
+				r.InIface  = binary.BigEndian.Uint16(fsData[recPos+18:])
+				r.DstPort  = binary.BigEndian.Uint16(fsData[recPos+20:])
+				r.DstIP    = net.IP(append([]byte{}, fsData[recPos+22:recPos+26]...))
+				r.DstMask  = fsData[recPos+26]
+				r.OutIface = binary.BigEndian.Uint16(fsData[recPos+27:])
+				r.NextHop  = net.IP(append([]byte{}, fsData[recPos+29:recPos+33]...))
+				r.SrcAS    = binary.BigEndian.Uint16(fsData[recPos+33:])
+				r.DstAS    = binary.BigEndian.Uint16(fsData[recPos+35:])
+				r.LastSw   = binary.BigEndian.Uint32(fsData[recPos+37:])
+				r.FirstSw  = binary.BigEndian.Uint32(fsData[recPos+41:])
+				pkt.Records = append(pkt.Records, r)
+				recPos += nf9RecordSize
+			}
+		}
+	}
+	return pkt
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestNF9Template_BuildSize(t *testing.T) {
+	if got := len(nf9TemplateBytes); got != nf9TemplFlowSetSize {
+		t.Errorf("template size = %d, want %d", got, nf9TemplFlowSetSize)
+	}
+}
+
+func TestNF9Template_FieldCount(t *testing.T) {
+	if len(nf9Fields) != 18 {
+		t.Errorf("expected 18 fields, got %d", len(nf9Fields))
+	}
+	// Sum of field lengths must equal nf9RecordSize.
+	total := 0
+	for _, f := range nf9Fields {
+		total += int(f[1])
+	}
+	if total != nf9RecordSize {
+		t.Errorf("sum of field lengths = %d, want %d (nf9RecordSize)", total, nf9RecordSize)
+	}
+}
+
+func TestNF9EncodePacket_HeaderFields(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.1.1", "10.0.2.2", 50000, 443, 6)}
+
+	n, err := enc.EncodePacket(0xC0A80101, 42, 5000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("EncodePacket returned 0 bytes")
+	}
+
+	pkt := decodeNF9Packet(t, buf[:n])
+
+	if pkt.Header.Version != 9 {
+		t.Errorf("version = %d, want 9", pkt.Header.Version)
+	}
+	if pkt.Header.SequenceNo != 42 {
+		t.Errorf("sequence = %d, want 42", pkt.Header.SequenceNo)
+	}
+	if pkt.Header.SysUptime != 5000 {
+		t.Errorf("uptime = %d, want 5000", pkt.Header.SysUptime)
+	}
+	if pkt.Header.SourceID != 0xC0A80101 {
+		t.Errorf("sourceID = %08x, want c0a80101", pkt.Header.SourceID)
+	}
+}
+
+func TestNF9EncodePacket_WithTemplate(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.1.1", "10.0.2.2", 50001, 443, 6)}
+
+	n, err := enc.EncodePacket(1, 1, 1000, records, true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeNF9Packet(t, buf[:n])
+
+	if len(pkt.Templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(pkt.Templates))
+	}
+	tmpl := pkt.Templates[0]
+	if tmpl.TemplateID != nf9TemplateID {
+		t.Errorf("template ID = %d, want %d", tmpl.TemplateID, nf9TemplateID)
+	}
+	if len(tmpl.Fields) != 18 {
+		t.Errorf("template field count = %d, want 18", len(tmpl.Fields))
+	}
+	// Verify first and last field IDs match the nf9Fields table.
+	if tmpl.Fields[0].FieldType != nf9InBytes {
+		t.Errorf("first field type = %d, want %d (IN_BYTES)", tmpl.Fields[0].FieldType, nf9InBytes)
+	}
+	if tmpl.Fields[17].FieldType != nf9FirstSwitched {
+		t.Errorf("last field type = %d, want %d (FIRST_SWITCHED)", tmpl.Fields[17].FieldType, nf9FirstSwitched)
+	}
+}
+
+func TestNF9EncodePacket_RecordValues(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+
+	src := net.ParseIP("192.168.1.10").To4()
+	dst := net.ParseIP("10.20.30.40").To4()
+	r := FlowRecord{
+		SrcIP:    src,
+		DstIP:    dst,
+		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort:  54321,
+		DstPort:  443,
+		Protocol: 6,
+		TCPFlags: 0x18,
+		ToS:      0,
+		Bytes:    9876,
+		Packets:  7,
+		StartMs:  1000,
+		EndMs:    2500,
+		InIface:  3,
+		OutIface: 4,
+		SrcAS:    65001,
+		DstAS:    65002,
+		SrcMask:  24,
+		DstMask:  16,
+	}
+
+	n, err := enc.EncodePacket(0xC0A8010A, 99, 3000, []FlowRecord{r}, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeNF9Packet(t, buf[:n])
+
+	if len(pkt.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(pkt.Records))
+	}
+	got := pkt.Records[0]
+
+	check := func(field string, got, want interface{}) {
+		t.Helper()
+		if got != want {
+			t.Errorf("%s: got %v, want %v", field, got, want)
+		}
+	}
+
+	check("Bytes",    got.Bytes,    uint32(9876))
+	check("Packets",  got.Packets,  uint32(7))
+	check("Protocol", got.Protocol, uint8(6))
+	check("TCPFlags", got.TCPFlags, uint8(0x18))
+	check("SrcPort",  got.SrcPort,  uint16(54321))
+	check("DstPort",  got.DstPort,  uint16(443))
+	check("InIface",  got.InIface,  uint16(3))
+	check("OutIface", got.OutIface, uint16(4))
+	check("SrcAS",    got.SrcAS,    uint16(65001))
+	check("DstAS",    got.DstAS,    uint16(65002))
+	check("SrcMask",  got.SrcMask,  uint8(24))
+	check("DstMask",  got.DstMask,  uint8(16))
+	check("FirstSw",  got.FirstSw,  uint32(1000))
+	check("LastSw",   got.LastSw,   uint32(2500))
+
+	if !got.SrcIP.Equal(src) {
+		t.Errorf("SrcIP: got %v, want %v", got.SrcIP, src)
+	}
+	if !got.DstIP.Equal(dst) {
+		t.Errorf("DstIP: got %v, want %v", got.DstIP, dst)
+	}
+}
+
+func TestNF9EncodePacket_MultipleRecords(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{
+		makeRecord("10.0.0.1", "10.0.0.2", 1001, 443, 6),
+		makeRecord("10.0.0.3", "10.0.0.4", 1002, 80, 6),
+		makeRecord("10.0.0.5", "10.0.0.6", 1003, 53, 17),
+	}
+
+	n, err := enc.EncodePacket(1, 5, 1000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeNF9Packet(t, buf[:n])
+	if len(pkt.Records) != 3 {
+		t.Errorf("expected 3 records, got %d", len(pkt.Records))
+	}
+	if pkt.Records[2].Protocol != 17 {
+		t.Errorf("record[2] protocol = %d, want 17 (UDP)", pkt.Records[2].Protocol)
+	}
+}
+
+func TestNF9EncodePacket_SequenceNumber(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 2000, 443, 6)}
+
+	for seqNo := uint32(0); seqNo < 5; seqNo++ {
+		n, err := enc.EncodePacket(1, seqNo, 1000, records, false, buf)
+		if err != nil {
+			t.Fatalf("seq %d: EncodePacket error: %v", seqNo, err)
+		}
+		pkt := decodeNF9Packet(t, buf[:n])
+		if pkt.Header.SequenceNo != seqNo {
+			t.Errorf("seq %d: decoded sequence = %d", seqNo, pkt.Header.SequenceNo)
+		}
+	}
+}
+
+func TestNF9EncodePacket_Count(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+
+	// Without template: count = number of data records.
+	records := []FlowRecord{
+		makeRecord("10.0.0.1", "10.0.0.2", 3001, 443, 6),
+		makeRecord("10.0.0.3", "10.0.0.4", 3002, 80, 6),
+	}
+	n, _ := enc.EncodePacket(1, 1, 1000, records, false, buf)
+	pkt := decodeNF9Packet(t, buf[:n])
+	if pkt.Header.Count != 2 {
+		t.Errorf("count without template = %d, want 2", pkt.Header.Count)
+	}
+
+	// With template: count = 1 (template) + data records.
+	n, _ = enc.EncodePacket(1, 2, 1000, records, true, buf)
+	pkt = decodeNF9Packet(t, buf[:n])
+	if pkt.Header.Count != 3 {
+		t.Errorf("count with template = %d, want 3", pkt.Header.Count)
+	}
+}
+
+func TestNF9EncodePacket_Alignment(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	// A single 45-byte record: data FlowSet body = 4+45 = 49 bytes, must pad to 52.
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 4001, 443, 6)}
+	n, err := enc.EncodePacket(1, 1, 1000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	// Total = header(20) + data FlowSet padded(52) = 72 bytes, divisible by 4.
+	if n%4 != 0 {
+		t.Errorf("packet length %d is not 4-byte aligned", n)
+	}
+}
+
+func TestNF9EncodePacket_EmptyRecordsTemplateOnly(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(1, 0, 0, nil, true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	// Should produce header + template only.
+	want := nf9HeaderSize + nf9TemplFlowSetSize
+	if n != want {
+		t.Errorf("template-only packet size = %d, want %d", n, want)
+	}
+}
+
+func TestNF9EncodePacket_BufferTooSmall(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	tiny := make([]byte, 10) // far too small
+	_, err := enc.EncodePacket(1, 0, 0, []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 5001, 443, 6)}, false, tiny)
+	if err == nil {
+		t.Error("expected error for too-small buffer, got nil")
+	}
+}
+
+func TestNF9EncodePacket_DomainIDDistinguishesDevices(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 6001, 443, 6)}
+
+	domainA := uint32(0x0A000001) // 10.0.0.1
+	domainB := uint32(0x0A000002) // 10.0.0.2
+
+	nA, _ := enc.EncodePacket(domainA, 1, 1000, records, false, buf)
+	pktA := decodeNF9Packet(t, buf[:nA])
+
+	nB, _ := enc.EncodePacket(domainB, 1, 1000, records, false, buf)
+	pktB := decodeNF9Packet(t, buf[:nB])
+
+	if pktA.Header.SourceID == pktB.Header.SourceID {
+		t.Errorf("expected different SourceIDs (%08x vs %08x)", domainA, domainB)
+	}
+}

--- a/go/simulator/netns.go
+++ b/go/simulator/netns.go
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+//go:build linux
+
 package main
 
 import (

--- a/go/simulator/netns_stub.go
+++ b/go/simulator/netns_stub.go
@@ -1,0 +1,72 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//go:build !linux
+
+// Non-Linux stubs for network namespace machinery.
+// These allow the package to compile on non-Linux hosts so that unit tests for
+// platform-independent code (NetFlow encoders, flow cache, etc.) can run via
+// `go test` without a Linux host. All methods return errNotLinux at runtime.
+package main
+
+import (
+	"errors"
+	"net"
+	"syscall"
+)
+
+var errNotLinux = errors.New("network namespaces require Linux")
+
+const (
+	NETNS_NAME   = "opensim"
+	VETH_HOST    = "veth-sim-host"
+	VETH_NS      = "veth-sim-ns"
+	VETH_HOST_IP = "10.254.0.1"
+	VETH_NS_IP   = "10.254.0.2"
+	VETH_NETMASK = "30"
+)
+
+// NetNamespace is a stub type; all methods return errNotLinux on non-Linux.
+type NetNamespace struct {
+	Name      string
+	NsFd      int
+	OrigNsFd  int
+	Active    bool
+	VethSetup bool
+}
+
+func CreateNetNamespace() (*NetNamespace, error) { return nil, errNotLinux }
+
+func (ns *NetNamespace) Close() error { return nil }
+
+func (ns *NetNamespace) AddRouteForDevices(startIP string, count int, netmask string) error {
+	return errNotLinux
+}
+
+func (ns *NetNamespace) addHostRoute(_ string) error { return errNotLinux }
+
+func (ns *NetNamespace) RemoveRouteForDevices(startIP string, count int, netmask string) {}
+
+func (ns *NetNamespace) ListenUDPInNamespace(addr *net.UDPAddr) (*net.UDPConn, error) {
+	return nil, errNotLinux
+}
+
+func (ns *NetNamespace) ListenTCPInNamespace(network, address string) (net.Listener, error) {
+	return nil, errNotLinux
+}
+
+func setSocketBufferSize(network, address string, c syscall.RawConn) error { return nil }
+
+func incrementIP(_ net.IP) {}

--- a/go/simulator/tun.go
+++ b/go/simulator/tun.go
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+//go:build linux
+
 package main
 
 import (

--- a/go/simulator/tun_stub.go
+++ b/go/simulator/tun_stub.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -35,44 +36,42 @@ func createTunInterfaceInNamespaceViaExec(nsName, tunName string, ip net.IP, net
 func (tun *TunInterface) destroy() error { return nil }
 
 // compareOIDsLexicographically compares two OID strings numerically component
-// by component. Returns negative / zero / positive like strings.Compare.
-// This implementation is portable and identical to the one in tun.go.
+// by component. Returns -1, 0, or 1. Identical to the Linux implementation in
+// tun.go — kept in sync to ensure consistent SNMP GETNEXT ordering on all
+// platforms.
 func compareOIDsLexicographically(oid1, oid2 string) int {
-	parts1 := strings.Split(strings.TrimPrefix(oid1, "."), ".")
-	parts2 := strings.Split(strings.TrimPrefix(oid2, "."), ".")
-
-	minLen := len(parts1)
-	if len(parts2) < minLen {
-		minLen = len(parts2)
+	var parts1, parts2 []string
+	if s := strings.TrimPrefix(oid1, "."); s != "" {
+		parts1 = strings.Split(s, ".")
+	}
+	if s := strings.TrimPrefix(oid2, "."); s != "" {
+		parts2 = strings.Split(s, ".")
 	}
 
-	for i := 0; i < minLen; i++ {
-		n1 := parseOIDComponent(parts1[i])
-		n2 := parseOIDComponent(parts2[i])
-		if n1 < n2 {
-			return -1
+	maxLen := len(parts1)
+	if len(parts2) > maxLen {
+		maxLen = len(parts2)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var val1, val2 int
+		if i < len(parts1) {
+			val1, _ = strconv.Atoi(parts1[i])
 		}
-		if n1 > n2 {
+		if i < len(parts2) {
+			val2, _ = strconv.Atoi(parts2[i])
+		}
+		if val1 < val2 {
+			return -1
+		} else if val1 > val2 {
 			return 1
 		}
 	}
 
 	if len(parts1) < len(parts2) {
 		return -1
-	}
-	if len(parts1) > len(parts2) {
+	} else if len(parts1) > len(parts2) {
 		return 1
 	}
 	return 0
-}
-
-func parseOIDComponent(s string) int {
-	n := 0
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			break
-		}
-		n = n*10 + int(c-'0')
-	}
-	return n
 }

--- a/go/simulator/tun_stub.go
+++ b/go/simulator/tun_stub.go
@@ -1,0 +1,78 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//go:build !linux
+
+// Non-Linux stubs for TUN interface management.
+// The real implementations require Linux kernel TUN/TAP and ioctl.
+package main
+
+import (
+	"net"
+	"strings"
+)
+
+func createTunInterface(name string, ip net.IP, netmask string) (*TunInterface, error) {
+	return nil, errNotLinux
+}
+
+func createTunInterfaceInNamespaceViaExec(nsName, tunName string, ip net.IP, netmask string) (*TunInterface, error) {
+	return nil, errNotLinux
+}
+
+func (tun *TunInterface) destroy() error { return nil }
+
+// compareOIDsLexicographically compares two OID strings numerically component
+// by component. Returns negative / zero / positive like strings.Compare.
+// This implementation is portable and identical to the one in tun.go.
+func compareOIDsLexicographically(oid1, oid2 string) int {
+	parts1 := strings.Split(strings.TrimPrefix(oid1, "."), ".")
+	parts2 := strings.Split(strings.TrimPrefix(oid2, "."), ".")
+
+	minLen := len(parts1)
+	if len(parts2) < minLen {
+		minLen = len(parts2)
+	}
+
+	for i := 0; i < minLen; i++ {
+		n1 := parseOIDComponent(parts1[i])
+		n2 := parseOIDComponent(parts2[i])
+		if n1 < n2 {
+			return -1
+		}
+		if n1 > n2 {
+			return 1
+		}
+	}
+
+	if len(parts1) < len(parts2) {
+		return -1
+	}
+	if len(parts1) > len(parts2) {
+		return 1
+	}
+	return 0
+}
+
+func parseOIDComponent(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/go/simulator/web_routes_stub.go
+++ b/go/simulator/web_routes_stub.go
@@ -1,0 +1,24 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//go:build !linux
+
+// Non-Linux stubs for Linux-specific route-script generation helpers.
+// The full implementations live in web_routes_linux.go (auto-excluded on non-Linux).
+package main
+
+func generateDebianRouteSection(_ map[string]bool) string  { return "" }
+func generateRHELRouteSection(_ map[string]bool) string    { return "" }
+func generateSUSERouteSection(_ map[string]bool) string    { return "" }


### PR DESCRIPTION
## Summary

Phase 1 of labmonkeys-space/l8opensim#31 — standalone encoding layer with no device integration yet.

- **`flow_profiles.go`** — `FlowProfile` struct with weighted protocol/port/byte/packet sampling; 8 per-device-category profiles covering all 28 `RoundRobinDeviceTypes`; `GetFlowProfile()` with edge-router fallback
- **`flow_cache.go`** — `FlowRecord` (18-field canonical flow), `FlowCache` with active/inactive timeout aging (mirrors real router behaviour), `syntheticFlow()` generator driven by profile sampling
- **`netflow9.go`** — stateless `NetFlow9Encoder`; pre-computed 80-byte Template FlowSet; `EncodePacket()` with optional template prepend, 4-byte padding (RFC 3954 §5.3), caller-supplied buffer
- **Build fix** — `netns.go` and `tun.go` tagged `//go:build linux`; three `_stub.go` files added so `go test ./simulator/` runs on macOS without a Linux host
- **Code-review patches** — IN_BYTES saturation clamp (GPU/Storage >4 GB flows), `endMs` overflow guard, TOCTOU fix in `GenerateFlows`, destination IP range fix, buffer guard for template-only path, `compareOIDsLexicographically` stub alignment, `huawei_ne8000` moved to Edge Router

Phase 2 (device integration) is in #33.

## Test plan

- [ ] `go test ./simulator/ -run "TestFlowCache|TestFlowProfile|TestGetFlow|TestNF9" -v` — 26 tests, all PASS
- [ ] `go test ./simulator/ -v` — all existing tests still PASS (no regressions)
- [ ] `CGO_ENABLED=0 GOOS=linux go build -o /dev/null ./simulator/` — clean Linux cross-compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)