### PR TITLE
feat(netflow9): phase 2 — wire FlowExporter into DeviceSimulator

### DIFF
--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -250,6 +250,13 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			device.metricsCycler.InitGPUMetrics(int64(i), profile.GPU)
 			device.metricsCycler.InitIfCounters(deviceResources, int64(i)^0x4843_0000)
 
+			// Initialize flow exporter if flow export is enabled.
+			if sm.flowActive {
+				flowProfile := GetFlowProfile(deviceResourceFile)
+				device.flowExporter = NewFlowExporter(device, flowProfile,
+					sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
+			}
+
 			// Cache the dynamic values using atomic for lock-free access
 			device.cachedSysName.Store(sysNameValue)
 			device.cachedSysLocation.Store(sysLocationValue)
@@ -470,6 +477,13 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	device.metricsCycler = NewMetricsCycler(int64(deviceIndex), profile)
 	device.metricsCycler.InitGPUMetrics(int64(deviceIndex), profile.GPU)
 	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex)^0x4843_0000)
+
+	// Initialize flow exporter if flow export is enabled.
+	if sm.flowActive {
+		flowProfile := GetFlowProfile(resourceFile)
+		device.flowExporter = NewFlowExporter(device, flowProfile,
+			sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
+	}
 
 	// Cache the dynamic values using atomic for lock-free access
 	device.cachedSysName.Store(sysNameValue)

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -251,7 +251,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			device.metricsCycler.InitIfCounters(deviceResources, int64(i)^0x4843_0000)
 
 			// Initialize flow exporter if flow export is enabled.
-			if sm.flowActive {
+			if sm.flowActive.Load() {
 				flowProfile := GetFlowProfile(deviceResourceFile)
 				device.flowExporter = NewFlowExporter(device, flowProfile,
 					sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
@@ -479,7 +479,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex)^0x4843_0000)
 
 	// Initialize flow exporter if flow export is enabled.
-	if sm.flowActive {
+	if sm.flowActive.Load() {
 		flowProfile := GetFlowProfile(resourceFile)
 		device.flowExporter = NewFlowExporter(device, flowProfile,
 			sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -1,0 +1,222 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FlowEncoder is the protocol-agnostic interface satisfied by both NetFlow v9
+// and IPFIX encoders. uptimeMs is the device uptime in milliseconds at export
+// time; IPFIX encoders may ignore it (IPFIX uses absolute timestamps).
+type FlowEncoder interface {
+	EncodePacket(domainID uint32, seqNo uint32, uptimeMs uint32,
+		records []FlowRecord, includeTemplate bool, buf []byte) (int, error)
+}
+
+// FlowExporter is owned by one DeviceSimulator. It ties the FlowCache and
+// encoder together and is driven by the shared SimulatorManager ticker goroutine.
+// It has no goroutines of its own — see SimulatorManager.startFlowTicker.
+type FlowExporter struct {
+	cache            *FlowCache
+	profile          *FlowProfile
+	rng              *rand.Rand
+	seqNo            uint32
+	domainID         uint32        // device IPv4 as uint32 (RFC 7011 §3.1)
+	startTime        time.Time     // reference point for SysUptime
+	lastTempl        time.Time     // last template transmission time
+	templateInterval time.Duration
+}
+
+// NewFlowExporter creates a FlowExporter for device, using profile to drive
+// synthetic flow generation. The RNG is seeded from the device's domainID so
+// each device produces distinct but deterministic traffic patterns.
+func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeout, inactiveTimeout, templateInterval time.Duration) *FlowExporter {
+	var domainID uint32
+	if ip4 := device.IP.To4(); ip4 != nil {
+		domainID = binary.BigEndian.Uint32(ip4)
+	}
+	return &FlowExporter{
+		cache:            NewFlowCache(activeTimeout, inactiveTimeout, profile.MaxFlows),
+		profile:          profile,
+		rng:              rand.New(rand.NewSource(int64(domainID))),
+		domainID:         domainID,
+		startTime:        time.Now(),
+		templateInterval: templateInterval,
+	}
+}
+
+// Tick is called by the shared SimulatorManager ticker goroutine on every
+// flowTickInterval. It replenishes the flow cache to ConcurrentFlows, expires
+// aged records, and emits one or more UDP datagrams to collectorAddr.
+//
+// bufPool must supply []byte slices of at least 1500 bytes.
+// Write errors are ignored (best-effort delivery; collector may be down).
+func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPConn, collectorAddr *net.UDPAddr, bufPool *sync.Pool) {
+	uptimeMs := uint32(now.Sub(fe.startTime).Milliseconds())
+	deviceIP := domainIDtoIP(fe.domainID)
+
+	// Replenish cache to the configured ConcurrentFlows level.
+	fe.cache.GenerateFlows(fe.profile, deviceIP, fe.rng, now, uptimeMs)
+
+	// Collect all records that crossed an active or inactive timeout boundary.
+	expired := fe.cache.Expire(now)
+
+	sendTemplate := fe.seqNo == 0 || now.Sub(fe.lastTempl) >= fe.templateInterval
+	if len(expired) == 0 && !sendTemplate {
+		return
+	}
+
+	buf := bufPool.Get().([]byte)
+	defer bufPool.Put(buf)
+
+	// Paginate: send as many records as fit in each 1500-byte UDP datagram.
+	// With a 20-byte packet header, 80-byte template, and 45 bytes per record,
+	// one 1500-byte datagram carries up to 30 records. Most ticks produce fewer.
+	for {
+		overhead := nf9HeaderSize + 4 // NF9 packet header + data FlowSet header
+		if sendTemplate {
+			overhead += nf9TemplFlowSetSize
+		}
+		var batch []FlowRecord
+		if len(buf) >= overhead+nf9RecordSize {
+			cap := (len(buf) - overhead) / nf9RecordSize
+			if cap >= len(expired) {
+				batch = expired
+				expired = nil
+			} else {
+				batch = expired[:cap]
+				expired = expired[cap:]
+			}
+		}
+
+		if len(batch) == 0 && !sendTemplate {
+			break
+		}
+
+		n, err := encoder.EncodePacket(fe.domainID, fe.seqNo, uptimeMs, batch, sendTemplate, buf)
+		if err != nil || n == 0 {
+			break
+		}
+
+		conn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
+		fe.seqNo++
+		if sendTemplate {
+			fe.lastTempl = now
+			sendTemplate = false
+		}
+
+		if len(expired) == 0 {
+			break
+		}
+	}
+}
+
+// domainIDtoIP converts a uint32 ObservationDomainID back to a net.IP.
+func domainIDtoIP(id uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, id)
+	return ip
+}
+
+// InitFlowExport opens a shared UDP socket, selects an encoder, and starts the
+// shared ticker goroutine. Call once after NewSimulatorManagerWithOptions.
+//
+// collectorAddr is "host:port" (e.g. "192.168.1.100:2055").
+// protocol is "netflow9" (the only supported value for Phase 2).
+func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activeTimeout, inactiveTimeout, templateInterval, tickInterval time.Duration) error {
+	addr, err := net.ResolveUDPAddr("udp4", collectorAddr)
+	if err != nil {
+		return fmt.Errorf("flow export: invalid collector address %q: %w", collectorAddr, err)
+	}
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		return fmt.Errorf("flow export: failed to open UDP socket: %w", err)
+	}
+
+	var enc FlowEncoder
+	switch strings.ToLower(protocol) {
+	case "netflow9", "nf9", "":
+		enc = NetFlow9Encoder{}
+	default:
+		conn.Close()
+		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9)", protocol)
+	}
+
+	sm.flowConn = conn
+	sm.flowCollectorAddr = addr
+	sm.flowEncoder = enc
+	sm.flowActiveTimeout = activeTimeout
+	sm.flowInactiveTimeout = inactiveTimeout
+	sm.flowTemplateInterval = templateInterval
+	sm.flowTickInterval = tickInterval
+	sm.flowBufPool.New = func() interface{} {
+		buf := make([]byte, 1500)
+		return buf
+	}
+	sm.flowStopCh = make(chan struct{})
+	sm.flowActive = true
+
+	log.Printf("Flow export: %s → %s (protocol: %s, tick: %s, active-timeout: %s)",
+		conn.LocalAddr(), collectorAddr, protocol, tickInterval, activeTimeout)
+
+	sm.startFlowTicker()
+	return nil
+}
+
+// startFlowTicker launches a single background goroutine that calls Tick on
+// every active device's FlowExporter at flowTickInterval. The goroutine exits
+// when flowStopCh is closed.
+func (sm *SimulatorManager) startFlowTicker() {
+	go func() {
+		ticker := time.NewTicker(sm.flowTickInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case now := <-ticker.C:
+				sm.tickAllFlowExporters(now)
+			case <-sm.flowStopCh:
+				return
+			}
+		}
+	}()
+}
+
+// tickAllFlowExporters calls Tick on every device that has a FlowExporter.
+// It takes a read lock to snapshot the device list, then releases it before
+// calling Tick to avoid holding the lock during I/O.
+func (sm *SimulatorManager) tickAllFlowExporters(now time.Time) {
+	sm.mu.RLock()
+	exporters := make([]*FlowExporter, 0, len(sm.devices))
+	for _, d := range sm.devices {
+		if d.flowExporter != nil {
+			exporters = append(exporters, d.flowExporter)
+		}
+	}
+	sm.mu.RUnlock()
+
+	for _, fe := range exporters {
+		fe.Tick(now, sm.flowEncoder, sm.flowConn, sm.flowCollectorAddr, &sm.flowBufPool)
+	}
+}

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -145,6 +145,10 @@ func domainIDtoIP(id uint32) net.IP {
 // collectorAddr is "host:port" (e.g. "192.168.1.100:2055").
 // protocol is "netflow9" (the only supported value for Phase 2).
 func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activeTimeout, inactiveTimeout, templateInterval, tickInterval time.Duration) error {
+	if sm.flowActive.Load() {
+		return fmt.Errorf("flow export: already active; call Shutdown() before re-initializing")
+	}
+
 	addr, err := net.ResolveUDPAddr("udp4", collectorAddr)
 	if err != nil {
 		return fmt.Errorf("flow export: invalid collector address %q: %w", collectorAddr, err)
@@ -176,7 +180,8 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 		return buf
 	}
 	sm.flowStopCh = make(chan struct{})
-	sm.flowActive = true
+	sm.flowStopOnce = sync.Once{}
+	sm.flowActive.Store(true)
 
 	log.Printf("Flow export: %s → %s (protocol: %s, tick: %s, active-timeout: %s)",
 		conn.LocalAddr(), collectorAddr, protocol, tickInterval, activeTimeout)
@@ -189,7 +194,9 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 // every active device's FlowExporter at flowTickInterval. The goroutine exits
 // when flowStopCh is closed.
 func (sm *SimulatorManager) startFlowTicker() {
+	sm.flowWg.Add(1)
 	go func() {
+		defer sm.flowWg.Done()
 		ticker := time.NewTicker(sm.flowTickInterval)
 		defer ticker.Stop()
 		for {
@@ -214,9 +221,17 @@ func (sm *SimulatorManager) tickAllFlowExporters(now time.Time) {
 			exporters = append(exporters, d.flowExporter)
 		}
 	}
+	// Snapshot shared transport fields under the lock to avoid racing with Shutdown.
+	conn := sm.flowConn
+	collectorAddr := sm.flowCollectorAddr
+	encoder := sm.flowEncoder
 	sm.mu.RUnlock()
 
+	if conn == nil {
+		return // flow export was shut down between tick and snapshot
+	}
+
 	for _, fe := range exporters {
-		fe.Tick(now, sm.flowEncoder, sm.flowConn, sm.flowCollectorAddr, &sm.flowBufPool)
+		fe.Tick(now, encoder, conn, collectorAddr, &sm.flowBufPool)
 	}
 }

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -163,9 +163,11 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 	switch strings.ToLower(protocol) {
 	case "netflow9", "nf9", "":
 		enc = NetFlow9Encoder{}
+	case "ipfix", "ipfix10":
+		enc = IPFIXEncoder{}
 	default:
 		conn.Close()
-		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9)", protocol)
+		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9, ipfix)", protocol)
 	}
 
 	sm.flowConn = conn

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -1,0 +1,349 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// testUDPListener opens an ephemeral loopback UDP socket, returning the
+// listener and a channel that delivers raw packet bytes as they arrive.
+// The goroutine exits when the listener is closed.
+func testUDPListener(t *testing.T) (*net.UDPConn, <-chan []byte) {
+	t.Helper()
+	ln, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	ch := make(chan []byte, 64)
+	go func() {
+		defer close(ch)
+		buf := make([]byte, 2048)
+		for {
+			n, _, err := ln.ReadFromUDP(buf)
+			if err != nil {
+				return // listener closed
+			}
+			pkt := make([]byte, n)
+			copy(pkt, buf[:n])
+			ch <- pkt
+		}
+	}()
+	return ln, ch
+}
+
+// testSender opens an ephemeral UDP socket for sending.
+func testSender(t *testing.T) *net.UDPConn {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		t.Fatalf("ListenUDP (sender): %v", err)
+	}
+	return conn
+}
+
+// testDevice builds a minimal DeviceSimulator with the given IPv4 address.
+func testDevice(ipStr string) *DeviceSimulator {
+	return &DeviceSimulator{IP: net.ParseIP(ipStr).To4()}
+}
+
+// testPool returns a sync.Pool supplying 1500-byte buffers.
+func testPool() *sync.Pool {
+	return &sync.Pool{New: func() interface{} { return make([]byte, 1500) }}
+}
+
+// receivePacket reads one packet from ch with a short deadline.
+// Returns nil if nothing arrives within 200 ms.
+func receivePacket(ch <-chan []byte) []byte {
+	select {
+	case pkt := <-ch:
+		return pkt
+	case <-time.After(200 * time.Millisecond):
+		return nil
+	}
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestNewFlowExporter_DomainID(t *testing.T) {
+	device := testDevice("10.0.0.1")
+	fe := NewFlowExporter(device, flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
+
+	// domainID must be the device IPv4 encoded as big-endian uint32.
+	if fe.domainID != 0x0A000001 {
+		t.Errorf("domainID = %08x, want 0a000001", fe.domainID)
+	}
+	if fe.cache == nil {
+		t.Error("cache is nil")
+	}
+	if fe.rng == nil {
+		t.Error("rng is nil")
+	}
+}
+
+func TestNewFlowExporter_DifferentDevicesDifferentDomainIDs(t *testing.T) {
+	feA := NewFlowExporter(testDevice("10.0.0.1"), flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
+	feB := NewFlowExporter(testDevice("10.0.0.2"), flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
+
+	if feA.domainID == feB.domainID {
+		t.Errorf("expected different domainIDs for different devices, both got %08x", feA.domainID)
+	}
+}
+
+func TestDomainIDtoIP_RoundTrip(t *testing.T) {
+	cases := []string{"10.0.0.1", "192.168.1.100", "172.16.0.1"}
+	for _, c := range cases {
+		original := net.ParseIP(c).To4()
+		device := &DeviceSimulator{IP: original}
+		fe := NewFlowExporter(device, flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
+		recovered := domainIDtoIP(fe.domainID)
+		if !recovered.Equal(original) {
+			t.Errorf("%s: domainIDtoIP(%08x) = %v, want %v", c, fe.domainID, recovered, original)
+		}
+	}
+}
+
+// TestFlowExporter_Tick_TemplateOnFirstCall verifies that Tick sends a
+// template-only NF9 packet on the first call (seqNo == 0) even when no flows
+// have expired yet. This satisfies the RFC 3954 requirement to send the
+// template before any data records.
+func TestFlowExporter_Tick_TemplateOnFirstCall(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+
+	conn := testSender(t)
+	defer conn.Close()
+
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	// Large timeouts so nothing expires during the test.
+	fe := NewFlowExporter(testDevice("10.1.2.3"), flowProfileEdgeRouter,
+		10*time.Minute, 5*time.Minute, 10*time.Minute)
+
+	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+
+	pkt := receivePacket(ch)
+	if pkt == nil {
+		t.Fatal("no UDP packet received on first Tick (expected template)")
+	}
+
+	// Decode and verify it is a valid NF9 packet containing a template.
+	decoded := decodeNF9Packet(t, pkt)
+	if decoded.Header.Version != 9 {
+		t.Errorf("version = %d, want 9", decoded.Header.Version)
+	}
+	if len(decoded.Templates) != 1 {
+		t.Errorf("template count = %d, want 1", len(decoded.Templates))
+	}
+	// seqNo should have advanced.
+	if fe.seqNo != 1 {
+		t.Errorf("seqNo after first Tick = %d, want 1", fe.seqNo)
+	}
+}
+
+// TestFlowExporter_Tick_NoSendWithoutExpiredFlows verifies that Tick skips
+// packet encoding when no flows have expired and the template interval has
+// not elapsed (i.e., seqNo > 0 and lastTempl is fresh).
+func TestFlowExporter_Tick_NoSendWhenIdle(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+
+	conn := testSender(t)
+	defer conn.Close()
+
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	fe := NewFlowExporter(testDevice("10.1.2.4"), flowProfileEdgeRouter,
+		10*time.Minute, 5*time.Minute, 10*time.Minute)
+
+	now := time.Now()
+
+	// First Tick sends template (seqNo=0).
+	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	receivePacket(ch) // drain
+
+	// Second Tick immediately after — no flows expired, template fresh.
+	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+
+	pkt := receivePacket(ch)
+	if pkt != nil {
+		t.Error("expected no packet on idle Tick, but one was received")
+	}
+}
+
+// TestFlowExporter_Tick_SendsFlowsWhenExpired pre-populates the cache with
+// flows at a past createdAt so they are immediately expired, then calls Tick
+// and verifies that flow records are received by the collector.
+func TestFlowExporter_Tick_SendsFlowsWhenExpired(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+
+	conn := testSender(t)
+	defer conn.Close()
+
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	// Very short timeouts so manually-inserted flows are expired immediately.
+	fe := NewFlowExporter(testDevice("10.1.2.5"), flowProfileEdgeRouter,
+		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
+
+	// Insert 3 flows directly into the cache, timestamped far in the past.
+	past := time.Now().Add(-1 * time.Hour)
+	for i := 0; i < 3; i++ {
+		fe.cache.Add(FlowRecord{
+			SrcIP:   net.ParseIP("10.0.0.1").To4(),
+			DstIP:   net.ParseIP("10.0.0.2").To4(),
+			NextHop: net.IPv4(0, 0, 0, 0).To4(),
+			SrcPort: uint16(1000 + i),
+			DstPort: 443,
+			Protocol: 6,
+			Bytes:   1024,
+			Packets: 10,
+		}, past)
+	}
+
+	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+
+	pkt := receivePacket(ch)
+	if pkt == nil {
+		t.Fatal("no packet received after Tick with expired flows")
+	}
+	decoded := decodeNF9Packet(t, pkt)
+	if len(decoded.Records) != 3 {
+		t.Errorf("expected 3 flow records, got %d", len(decoded.Records))
+	}
+}
+
+// TestFlowExporter_Tick_TemplateRetransmit verifies that the template is
+// re-sent after templateInterval has elapsed since the last transmission.
+func TestFlowExporter_Tick_TemplateRetransmit(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+
+	conn := testSender(t)
+	defer conn.Close()
+
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	fe := NewFlowExporter(testDevice("10.1.2.6"), flowProfileEdgeRouter,
+		10*time.Minute, 5*time.Minute, 60*time.Second)
+
+	now := time.Now()
+
+	// First Tick: sends template.
+	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	pkt1 := receivePacket(ch)
+	if pkt1 == nil {
+		t.Fatal("expected template on first Tick")
+	}
+
+	// Second Tick: template interval has not elapsed — no send.
+	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	if pkt := receivePacket(ch); pkt != nil {
+		t.Error("unexpected packet before template interval elapsed")
+	}
+
+	// Simulate template interval elapsed by advancing lastTempl back.
+	fe.lastTempl = now.Add(-61 * time.Second)
+
+	// Third Tick: template should be retransmitted.
+	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	pkt3 := receivePacket(ch)
+	if pkt3 == nil {
+		t.Fatal("expected template retransmission after interval elapsed")
+	}
+	decoded := decodeNF9Packet(t, pkt3)
+	if len(decoded.Templates) != 1 {
+		t.Errorf("expected 1 template on retransmission, got %d", len(decoded.Templates))
+	}
+}
+
+// TestFlowExporter_Tick_Pagination verifies that when more records expire than
+// fit in a single 1500-byte UDP datagram, multiple packets are sent.
+func TestFlowExporter_Tick_Pagination(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+
+	conn := testSender(t)
+	defer conn.Close()
+
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	// Use a large MaxFlows to allow many concurrent entries.
+	profile := &FlowProfile{
+		TCPWeight: 1.0, UDPWeight: 0, ICMPWeight: 0,
+		DstPorts:        []PortWeight{{443, 1.0}},
+		SrcPortMin:      1024, SrcPortMax: 65535,
+		BytesMin:        100, BytesMax: 200,
+		PktsMin:         1, PktsMax: 2,
+		DurationMinMs:   100, DurationMaxMs: 200,
+		ConcurrentFlows: 100,
+		MaxFlows:        256,
+	}
+
+	fe := NewFlowExporter(testDevice("10.1.2.7"), profile,
+		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
+
+	// Insert 80 distinct flows all with past timestamps so they expire immediately.
+	past := time.Now().Add(-1 * time.Hour)
+	for i := 0; i < 80; i++ {
+		fe.cache.Add(FlowRecord{
+			SrcIP:    net.ParseIP("10.0.0.1").To4(),
+			DstIP:    net.ParseIP("10.0.0.2").To4(),
+			NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+			SrcPort:  uint16(1024 + i),
+			DstPort:  443,
+			Protocol: 6,
+			Bytes:    100,
+			Packets:  1,
+		}, past)
+	}
+
+	if got := fe.cache.Len(); got != 80 {
+		t.Fatalf("expected 80 cache entries, got %d", got)
+	}
+
+	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+
+	// Collect all received packets.
+	var packets [][]byte
+	for {
+		pkt := receivePacket(ch)
+		if pkt == nil {
+			break
+		}
+		packets = append(packets, pkt)
+	}
+
+	if len(packets) < 2 {
+		t.Errorf("expected ≥2 packets for 80 records, got %d", len(packets))
+	}
+
+	// Count total records across all packets.
+	total := 0
+	for _, pkt := range packets {
+		decoded := decodeNF9Packet(t, pkt)
+		total += len(decoded.Records)
+	}
+	if total != 80 {
+		t.Errorf("total records across all packets = %d, want 80", total)
+	}
+}

--- a/go/simulator/ipfix.go
+++ b/go/simulator/ipfix.go
@@ -1,0 +1,317 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"time"
+)
+
+// IPFIX wire constants (RFC 7011).
+const (
+	ipfixVersion       = 10  // IPFIX version number
+	ipfixTemplateID    = 256 // first valid data template ID (≥256)
+	ipfixSetIDTemplate = 2   // Template Set ID (RFC 7011 §3.4.1)
+
+	// IANA Information Element IDs (RFC 7012 / IANA IPFIX IE registry).
+	// These map 1-to-1 with the NF9 field IDs 1–17; the timestamp fields
+	// use absolute epoch milliseconds (IEs 152/153) instead of NF9's
+	// uptime-relative FIRST_SWITCHED/LAST_SWITCHED.
+	ipfixOctetDeltaCount          = 1   // octetDeltaCount       (≈ NF9 IN_BYTES)
+	ipfixPacketDeltaCount         = 2   // packetDeltaCount      (≈ NF9 IN_PKTS)
+	ipfixProtocolIdentifier       = 4   // protocolIdentifier    (≈ NF9 PROTOCOL)
+	ipfixIPClassOfService         = 5   // ipClassOfService      (≈ NF9 SRC_TOS)
+	ipfixTCPControlBits           = 6   // tcpControlBits        (≈ NF9 TCP_FLAGS)
+	ipfixSourceTransportPort      = 7   // sourceTransportPort   (≈ NF9 L4_SRC_PORT)
+	ipfixSourceIPv4Address        = 8   // sourceIPv4Address     (≈ NF9 IPV4_SRC_ADDR)
+	ipfixSourceIPv4PrefixLength   = 9   // sourceIPv4PrefixLength(≈ NF9 SRC_MASK)
+	ipfixIngressInterface         = 10  // ingressInterface      (≈ NF9 INPUT_SNMP)
+	ipfixDestinationTransportPort = 11  // destinationTransportPort (≈ NF9 L4_DST_PORT)
+	ipfixDestinationIPv4Address   = 12  // destinationIPv4Address(≈ NF9 IPV4_DST_ADDR)
+	ipfixDestIPv4PrefixLength     = 13  // destinationIPv4PrefixLength (≈ NF9 DST_MASK)
+	ipfixEgressInterface          = 14  // egressInterface       (≈ NF9 OUTPUT_SNMP)
+	ipfixIPNextHopIPv4Address     = 15  // ipNextHopIPv4Address  (≈ NF9 IPV4_NEXT_HOP)
+	ipfixBGPSourceAsNumber        = 16  // bgpSourceAsNumber     (≈ NF9 SRC_AS)
+	ipfixBGPDestinationAsNumber   = 17  // bgpDestinationAsNumber(≈ NF9 DST_AS)
+	ipfixFlowStartMilliseconds    = 152 // flowStartMilliseconds (absolute epoch ms, 8B)
+	ipfixFlowEndMilliseconds      = 153 // flowEndMilliseconds   (absolute epoch ms, 8B)
+
+	// Derived sizes.
+	ipfixHeaderSize   = 16 // bytes — IPFIX Message Header (RFC 7011 §3.1)
+	ipfixRecordSize   = 53 // bytes — one data record with the 18-field template below
+	ipfixTemplSetSize = 80 // bytes — Template Set (4 set-hdr + 4 tmpl-hdr + 18×4 fields)
+)
+
+// ipfixFields is the ordered list of (ieID, ieLength) pairs that define the
+// single template used for all simulated device IPFIX exports.
+// Changing this list requires updating ipfixRecordSize and ipfixTemplSetSize.
+var ipfixFields = [][2]uint16{
+	{ipfixOctetDeltaCount, 4},
+	{ipfixPacketDeltaCount, 4},
+	{ipfixProtocolIdentifier, 1},
+	{ipfixIPClassOfService, 1},
+	{ipfixTCPControlBits, 1},
+	{ipfixSourceTransportPort, 2},
+	{ipfixSourceIPv4Address, 4},
+	{ipfixSourceIPv4PrefixLength, 1},
+	{ipfixIngressInterface, 2},
+	{ipfixDestinationTransportPort, 2},
+	{ipfixDestinationIPv4Address, 4},
+	{ipfixDestIPv4PrefixLength, 1},
+	{ipfixEgressInterface, 2},
+	{ipfixIPNextHopIPv4Address, 4},
+	{ipfixBGPSourceAsNumber, 2},
+	{ipfixBGPDestinationAsNumber, 2},
+	{ipfixFlowStartMilliseconds, 8},
+	{ipfixFlowEndMilliseconds, 8},
+}
+
+// ipfixTemplateSetBytes is the pre-encoded Template Set, built once at init.
+// It is read-only after init and safe to reference from any goroutine.
+var ipfixTemplateSetBytes []byte
+
+func init() {
+	ipfixTemplateSetBytes = buildIPFIXTemplateSet()
+}
+
+// buildIPFIXTemplateSet encodes the Template Set for ipfixFields.
+// Layout (80 bytes):
+//
+//	Set Header:      set_id=2 (2B), length=80 (2B)
+//	Template Header: template_id=256 (2B), field_count=18 (2B)
+//	18 × (IE_id 2B + IE_length 2B)
+func buildIPFIXTemplateSet() []byte {
+	fieldCount := len(ipfixFields)
+	length := 4 + 4 + fieldCount*4 // set hdr + tmpl hdr + fields
+	buf := make([]byte, length)
+	pos := 0
+
+	binary.BigEndian.PutUint16(buf[pos:], ipfixSetIDTemplate) // Set ID = 2
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], uint16(length)) // Set Length
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], ipfixTemplateID) // Template ID
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], uint16(fieldCount)) // Field Count
+	pos += 2
+
+	for _, f := range ipfixFields {
+		binary.BigEndian.PutUint16(buf[pos:], f[0]) // IE ID
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], f[1]) // IE Length
+		pos += 2
+	}
+	return buf
+}
+
+// IPFIXEncoder encodes FlowRecords into IPFIX UDP payloads (RFC 7011).
+// It is stateless; all variable state is passed by the caller so the encoder
+// can be shared across goroutines without locking.
+//
+// Key differences from NetFlow9Encoder:
+//   - Message header is 16 bytes (no SysUptime field; uses Export Time instead)
+//   - Template Set uses Set ID 2 (NF9 uses 0)
+//   - Timestamps are absolute epoch milliseconds (IE 152/153, 8 bytes each)
+//     rather than device-uptime-relative milliseconds
+//   - The Length header field covers the entire message in bytes (NF9 uses FlowSet count)
+type IPFIXEncoder struct{}
+
+// EncodePacket serialises a complete IPFIX UDP payload into buf and returns
+// the number of bytes written.
+//
+// Parameters:
+//
+//	domainID        — ObservationDomainID (RFC 7011 §3.1); encode the device
+//	                  IPv4 address as uint32 for per-device identity at the collector.
+//	seqNo           — per-domain sequence number (monotonically increasing).
+//	uptimeMs        — device system uptime in milliseconds at export time; used
+//	                  to convert per-flow uptime-relative StartMs/EndMs to absolute
+//	                  epoch milliseconds for flowStartMilliseconds/flowEndMilliseconds.
+//	records         — flow records to include in the Data Set.
+//	includeTemplate — when true, a Template Set is prepended; send on the first
+//	                  packet and every templateInterval thereafter.
+//	buf             — caller-supplied output buffer; must be ≥ 1500 bytes.
+//
+// Returns an error if buf is too small to hold even a single record.
+func (IPFIXEncoder) EncodePacket(
+	domainID uint32,
+	seqNo uint32,
+	uptimeMs uint32,
+	records []FlowRecord,
+	includeTemplate bool,
+	buf []byte,
+) (int, error) {
+	if len(records) == 0 && !includeTemplate {
+		return 0, nil
+	}
+
+	// Compute absolute device-start epoch so per-record uptime-relative times
+	// can be converted to absolute epoch milliseconds for the IPFIX wire format.
+	nowMs := time.Now().UnixMilli()
+	deviceStartMs := nowMs - int64(uptimeMs)
+
+	// Minimum required buffer size.
+	overhead := ipfixHeaderSize + 4 // msg header + data Set header
+	if includeTemplate {
+		overhead += ipfixTemplSetSize
+	}
+	if len(buf) < overhead {
+		return 0, fmt.Errorf("ipfix: buffer too small (%d bytes), need at least %d", len(buf), overhead)
+	}
+	if len(buf) < overhead+ipfixRecordSize && len(records) > 0 {
+		return 0, fmt.Errorf("ipfix: buffer too small (%d bytes), need at least %d", len(buf), overhead+ipfixRecordSize)
+	}
+
+	// Cap records to what fits in buf.
+	available := len(buf) - overhead
+	maxRecords := available / ipfixRecordSize
+	if maxRecords < len(records) {
+		records = records[:maxRecords]
+	}
+
+	pos := 0
+
+	// ── Message Header (16 bytes, RFC 7011 §3.1) ──────────────────────────────
+	binary.BigEndian.PutUint16(buf[pos:], ipfixVersion) // Version = 10
+	pos += 2
+	// Total length placeholder — filled in after all sets are encoded.
+	lengthOffset := pos
+	pos += 2
+	binary.BigEndian.PutUint32(buf[pos:], uint32(nowMs/1000)) // Export Time (unix_secs)
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], seqNo) // Sequence Number
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], domainID) // Observation Domain ID
+	pos += 4
+
+	// ── Template Set (optional, 80 bytes) ─────────────────────────────────────
+	if includeTemplate {
+		copy(buf[pos:], ipfixTemplateSetBytes)
+		pos += len(ipfixTemplateSetBytes)
+	}
+
+	if len(records) == 0 {
+		binary.BigEndian.PutUint16(buf[lengthOffset:], uint16(pos))
+		return pos, nil
+	}
+
+	// ── Data Set ──────────────────────────────────────────────────────────────
+	dataSetStart := pos
+	binary.BigEndian.PutUint16(buf[pos:], ipfixTemplateID) // Set ID = template ID
+	pos += 2
+	// Data Set length placeholder — filled in after writing records.
+	dataLenOffset := pos
+	pos += 2
+
+	for _, r := range records {
+		pos = encodeIPFIXRecord(buf, pos, r, deviceStartMs)
+	}
+
+	// Pad to 4-byte boundary (RFC 7011 §3.3.1).
+	dataLen := pos - dataSetStart
+	if rem := dataLen % 4; rem != 0 {
+		padBytes := 4 - rem
+		for i := 0; i < padBytes; i++ {
+			buf[pos] = 0
+			pos++
+		}
+		dataLen += padBytes
+	}
+	binary.BigEndian.PutUint16(buf[dataLenOffset:], uint16(dataLen))
+
+	// Fill total message length.
+	binary.BigEndian.PutUint16(buf[lengthOffset:], uint16(pos))
+
+	return pos, nil
+}
+
+// encodeIPFIXRecord writes a single flow record into buf at pos, following
+// the field order defined in ipfixFields. Returns the new position.
+func encodeIPFIXRecord(buf []byte, pos int, r FlowRecord, deviceStartMs int64) int {
+	// octetDeltaCount (4) — clamp uint64 to avoid silent wrap for large flows.
+	inBytes := r.Bytes
+	if inBytes > math.MaxUint32 {
+		inBytes = math.MaxUint32
+	}
+	binary.BigEndian.PutUint32(buf[pos:], uint32(inBytes))
+	pos += 4
+	// packetDeltaCount (4)
+	binary.BigEndian.PutUint32(buf[pos:], r.Packets)
+	pos += 4
+	// protocolIdentifier (1)
+	buf[pos] = r.Protocol
+	pos++
+	// ipClassOfService (1)
+	buf[pos] = r.ToS
+	pos++
+	// tcpControlBits (1)
+	buf[pos] = r.TCPFlags
+	pos++
+	// sourceTransportPort (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.SrcPort)
+	pos += 2
+	// sourceIPv4Address (4)
+	src := r.SrcIP.To4()
+	if src == nil {
+		src = []byte{0, 0, 0, 0}
+	}
+	copy(buf[pos:], src)
+	pos += 4
+	// sourceIPv4PrefixLength (1)
+	buf[pos] = r.SrcMask
+	pos++
+	// ingressInterface (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.InIface)
+	pos += 2
+	// destinationTransportPort (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.DstPort)
+	pos += 2
+	// destinationIPv4Address (4)
+	dst := r.DstIP.To4()
+	if dst == nil {
+		dst = []byte{0, 0, 0, 0}
+	}
+	copy(buf[pos:], dst)
+	pos += 4
+	// destinationIPv4PrefixLength (1)
+	buf[pos] = r.DstMask
+	pos++
+	// egressInterface (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.OutIface)
+	pos += 2
+	// ipNextHopIPv4Address (4)
+	nh := r.NextHop.To4()
+	if nh == nil {
+		nh = []byte{0, 0, 0, 0}
+	}
+	copy(buf[pos:], nh)
+	pos += 4
+	// bgpSourceAsNumber (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.SrcAS)
+	pos += 2
+	// bgpDestinationAsNumber (2)
+	binary.BigEndian.PutUint16(buf[pos:], r.DstAS)
+	pos += 2
+	// flowStartMilliseconds (8) — absolute epoch ms
+	binary.BigEndian.PutUint64(buf[pos:], uint64(deviceStartMs+int64(r.StartMs)))
+	pos += 8
+	// flowEndMilliseconds (8) — absolute epoch ms
+	binary.BigEndian.PutUint64(buf[pos:], uint64(deviceStartMs+int64(r.EndMs)))
+	pos += 8
+	return pos
+}

--- a/go/simulator/ipfix_test.go
+++ b/go/simulator/ipfix_test.go
@@ -1,0 +1,477 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// ── Inline IPFIX decoder (test oracle) ──────────────────────────────────────
+//
+// This minimal parser validates that IPFIXEncoder.EncodePacket produces
+// correctly-structured RFC 7011 wire bytes without introducing any external
+// test dependency.
+
+type ipfixMsgHeader struct {
+	Version          uint16
+	Length           uint16
+	ExportTime       uint32
+	SequenceNumber   uint32
+	ObsDomainID      uint32
+}
+
+type ipfixTemplateField struct {
+	IEID     uint16
+	IELength uint16
+}
+
+type ipfixDecodedTemplate struct {
+	TemplateID uint16
+	Fields     []ipfixTemplateField
+}
+
+type ipfixDecodedRecord struct {
+	Bytes    uint32
+	Packets  uint32
+	Protocol uint8
+	ToS      uint8
+	TCPFlags uint8
+	SrcPort  uint16
+	SrcIP    net.IP
+	SrcMask  uint8
+	InIface  uint16
+	DstPort  uint16
+	DstIP    net.IP
+	DstMask  uint8
+	OutIface uint16
+	NextHop  net.IP
+	SrcAS    uint16
+	DstAS    uint16
+	StartMs  uint64 // absolute epoch ms
+	EndMs    uint64 // absolute epoch ms
+}
+
+type ipfixPacket struct {
+	Header    ipfixMsgHeader
+	Templates []ipfixDecodedTemplate
+	Records   []ipfixDecodedRecord
+}
+
+// decodeIPFIXPacket parses the given bytes into an ipfixPacket using only the
+// single 18-field template defined in ipfixFields.
+func decodeIPFIXPacket(t *testing.T, data []byte) *ipfixPacket {
+	t.Helper()
+	if len(data) < ipfixHeaderSize {
+		t.Fatalf("ipfix: packet too short: %d bytes", len(data))
+	}
+
+	pkt := &ipfixPacket{}
+	pkt.Header.Version        = binary.BigEndian.Uint16(data[0:])
+	pkt.Header.Length         = binary.BigEndian.Uint16(data[2:])
+	pkt.Header.ExportTime     = binary.BigEndian.Uint32(data[4:])
+	pkt.Header.SequenceNumber = binary.BigEndian.Uint32(data[8:])
+	pkt.Header.ObsDomainID    = binary.BigEndian.Uint32(data[12:])
+
+	pos := ipfixHeaderSize
+	for pos < len(data) {
+		if pos+4 > len(data) {
+			break
+		}
+		setID  := binary.BigEndian.Uint16(data[pos:])
+		setLen := int(binary.BigEndian.Uint16(data[pos+2:]))
+		if setLen < 4 || pos+setLen > len(data) {
+			t.Fatalf("ipfix: invalid Set length %d at offset %d", setLen, pos)
+		}
+		setData := data[pos : pos+setLen]
+		pos += setLen
+
+		switch {
+		case setID == ipfixSetIDTemplate: // Template Set
+			tmplPos := 4 // skip Set header
+			for tmplPos+4 <= len(setData) {
+				tmplID     := binary.BigEndian.Uint16(setData[tmplPos:])
+				fieldCount := int(binary.BigEndian.Uint16(setData[tmplPos+2:]))
+				tmplPos += 4
+				tmpl := ipfixDecodedTemplate{TemplateID: tmplID}
+				for i := 0; i < fieldCount && tmplPos+4 <= len(setData); i++ {
+					ieID  := binary.BigEndian.Uint16(setData[tmplPos:])
+					ieLen := binary.BigEndian.Uint16(setData[tmplPos+2:])
+					tmpl.Fields = append(tmpl.Fields, ipfixTemplateField{ieID, ieLen})
+					tmplPos += 4
+				}
+				pkt.Templates = append(pkt.Templates, tmpl)
+			}
+
+		case setID >= 256: // Data Set
+			recPos := 4 // skip Set header
+			for recPos+ipfixRecordSize <= setLen {
+				r := ipfixDecodedRecord{}
+				r.Bytes    = binary.BigEndian.Uint32(setData[recPos:])
+				r.Packets  = binary.BigEndian.Uint32(setData[recPos+4:])
+				r.Protocol = setData[recPos+8]
+				r.ToS      = setData[recPos+9]
+				r.TCPFlags = setData[recPos+10]
+				r.SrcPort  = binary.BigEndian.Uint16(setData[recPos+11:])
+				r.SrcIP    = net.IP(append([]byte{}, setData[recPos+13:recPos+17]...))
+				r.SrcMask  = setData[recPos+17]
+				r.InIface  = binary.BigEndian.Uint16(setData[recPos+18:])
+				r.DstPort  = binary.BigEndian.Uint16(setData[recPos+20:])
+				r.DstIP    = net.IP(append([]byte{}, setData[recPos+22:recPos+26]...))
+				r.DstMask  = setData[recPos+26]
+				r.OutIface = binary.BigEndian.Uint16(setData[recPos+27:])
+				r.NextHop  = net.IP(append([]byte{}, setData[recPos+29:recPos+33]...))
+				r.SrcAS    = binary.BigEndian.Uint16(setData[recPos+33:])
+				r.DstAS    = binary.BigEndian.Uint16(setData[recPos+35:])
+				r.StartMs  = binary.BigEndian.Uint64(setData[recPos+37:])
+				r.EndMs    = binary.BigEndian.Uint64(setData[recPos+45:])
+				pkt.Records = append(pkt.Records, r)
+				recPos += ipfixRecordSize
+			}
+		}
+	}
+	return pkt
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestIPFIXTemplate_BuildSize(t *testing.T) {
+	if got := len(ipfixTemplateSetBytes); got != ipfixTemplSetSize {
+		t.Errorf("template set size = %d, want %d", got, ipfixTemplSetSize)
+	}
+}
+
+func TestIPFIXTemplate_FieldCount(t *testing.T) {
+	if len(ipfixFields) != 18 {
+		t.Errorf("expected 18 fields, got %d", len(ipfixFields))
+	}
+	// Sum of field lengths must equal ipfixRecordSize.
+	total := 0
+	for _, f := range ipfixFields {
+		total += int(f[1])
+	}
+	if total != ipfixRecordSize {
+		t.Errorf("sum of IE lengths = %d, want %d (ipfixRecordSize)", total, ipfixRecordSize)
+	}
+}
+
+func TestIPFIXEncodePacket_HeaderFields(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.1.1", "10.0.2.2", 50000, 443, 6)}
+
+	n, err := enc.EncodePacket(0xC0A80101, 42, 5000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("EncodePacket returned 0 bytes")
+	}
+
+	pkt := decodeIPFIXPacket(t, buf[:n])
+
+	if pkt.Header.Version != 10 {
+		t.Errorf("version = %d, want 10", pkt.Header.Version)
+	}
+	if pkt.Header.SequenceNumber != 42 {
+		t.Errorf("sequence = %d, want 42", pkt.Header.SequenceNumber)
+	}
+	if pkt.Header.ObsDomainID != 0xC0A80101 {
+		t.Errorf("observationDomainID = %08x, want c0a80101", pkt.Header.ObsDomainID)
+	}
+	// Length must equal n.
+	if int(pkt.Header.Length) != n {
+		t.Errorf("message length field = %d, want %d", pkt.Header.Length, n)
+	}
+	// Export time must be a recent unix timestamp (within ±5 seconds of now).
+	nowSecs := uint32(time.Now().Unix())
+	if pkt.Header.ExportTime < nowSecs-5 || pkt.Header.ExportTime > nowSecs+5 {
+		t.Errorf("export time %d is not close to current unix_secs %d", pkt.Header.ExportTime, nowSecs)
+	}
+}
+
+func TestIPFIXEncodePacket_WithTemplate(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.1.1", "10.0.2.2", 50001, 443, 6)}
+
+	n, err := enc.EncodePacket(1, 1, 1000, records, true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeIPFIXPacket(t, buf[:n])
+
+	if len(pkt.Templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(pkt.Templates))
+	}
+	tmpl := pkt.Templates[0]
+	if tmpl.TemplateID != ipfixTemplateID {
+		t.Errorf("template ID = %d, want %d", tmpl.TemplateID, ipfixTemplateID)
+	}
+	if len(tmpl.Fields) != 18 {
+		t.Errorf("template field count = %d, want 18", len(tmpl.Fields))
+	}
+	// Verify first and last IE IDs.
+	if tmpl.Fields[0].IEID != ipfixOctetDeltaCount {
+		t.Errorf("first IE ID = %d, want %d (octetDeltaCount)", tmpl.Fields[0].IEID, ipfixOctetDeltaCount)
+	}
+	if tmpl.Fields[17].IEID != ipfixFlowEndMilliseconds {
+		t.Errorf("last IE ID = %d, want %d (flowEndMilliseconds)", tmpl.Fields[17].IEID, ipfixFlowEndMilliseconds)
+	}
+}
+
+func TestIPFIXEncodePacket_SetID(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(1, 0, 0, nil, true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	// First Set after the 16-byte header must be a Template Set (ID=2).
+	if len(buf[:n]) < ipfixHeaderSize+2 {
+		t.Fatal("packet too short to read first Set ID")
+	}
+	setID := binary.BigEndian.Uint16(buf[ipfixHeaderSize:])
+	if setID != ipfixSetIDTemplate {
+		t.Errorf("first Set ID = %d, want %d (Template Set)", setID, ipfixSetIDTemplate)
+	}
+}
+
+func TestIPFIXEncodePacket_RecordValues(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+
+	src := net.ParseIP("192.168.1.10").To4()
+	dst := net.ParseIP("10.20.30.40").To4()
+	const uptimeMs = uint32(60000) // 60 seconds of simulated uptime
+	r := FlowRecord{
+		SrcIP:    src,
+		DstIP:    dst,
+		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort:  54321,
+		DstPort:  443,
+		Protocol: 6,
+		TCPFlags: 0x18,
+		ToS:      0,
+		Bytes:    9876,
+		Packets:  7,
+		StartMs:  1000,
+		EndMs:    2500,
+		InIface:  3,
+		OutIface: 4,
+		SrcAS:    65001,
+		DstAS:    65002,
+		SrcMask:  24,
+		DstMask:  16,
+	}
+
+	n, err := enc.EncodePacket(0xC0A8010A, 99, uptimeMs, []FlowRecord{r}, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeIPFIXPacket(t, buf[:n])
+
+	if len(pkt.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(pkt.Records))
+	}
+	got := pkt.Records[0]
+
+	check := func(field string, got, want interface{}) {
+		t.Helper()
+		if got != want {
+			t.Errorf("%s: got %v, want %v", field, got, want)
+		}
+	}
+
+	check("Bytes",    got.Bytes,    uint32(9876))
+	check("Packets",  got.Packets,  uint32(7))
+	check("Protocol", got.Protocol, uint8(6))
+	check("TCPFlags", got.TCPFlags, uint8(0x18))
+	check("SrcPort",  got.SrcPort,  uint16(54321))
+	check("DstPort",  got.DstPort,  uint16(443))
+	check("InIface",  got.InIface,  uint16(3))
+	check("OutIface", got.OutIface, uint16(4))
+	check("SrcAS",    got.SrcAS,    uint16(65001))
+	check("DstAS",    got.DstAS,    uint16(65002))
+	check("SrcMask",  got.SrcMask,  uint8(24))
+	check("DstMask",  got.DstMask,  uint8(16))
+
+	if !got.SrcIP.Equal(src) {
+		t.Errorf("SrcIP: got %v, want %v", got.SrcIP, src)
+	}
+	if !got.DstIP.Equal(dst) {
+		t.Errorf("DstIP: got %v, want %v", got.DstIP, dst)
+	}
+}
+
+func TestIPFIXEncodePacket_AbsoluteTimestamps(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+
+	const uptimeMs = uint32(30000) // 30 seconds of simulated uptime
+	r := FlowRecord{
+		SrcIP:    net.ParseIP("10.0.0.1").To4(),
+		DstIP:    net.ParseIP("10.0.0.2").To4(),
+		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort:  1000, DstPort: 443, Protocol: 6,
+		Bytes: 500, Packets: 5,
+		StartMs: 1000,  // 1000 ms after device start
+		EndMs:   5000,  // 5000 ms after device start
+	}
+
+	beforeMs := time.Now().UnixMilli()
+	n, err := enc.EncodePacket(1, 0, uptimeMs, []FlowRecord{r}, false, buf)
+	afterMs := time.Now().UnixMilli()
+
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeIPFIXPacket(t, buf[:n])
+	if len(pkt.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(pkt.Records))
+	}
+	rec := pkt.Records[0]
+
+	// Compute expected epoch range for flowStartMilliseconds.
+	// deviceStartMs = [beforeMs..afterMs] - uptimeMs
+	// flowStartMs   = deviceStartMs + r.StartMs
+	loStart := uint64(beforeMs-int64(uptimeMs)) + uint64(r.StartMs)
+	hiStart := uint64(afterMs-int64(uptimeMs)) + uint64(r.StartMs)
+	if rec.StartMs < loStart || rec.StartMs > hiStart {
+		t.Errorf("flowStartMilliseconds %d outside expected range [%d, %d]",
+			rec.StartMs, loStart, hiStart)
+	}
+
+	loEnd := uint64(beforeMs-int64(uptimeMs)) + uint64(r.EndMs)
+	hiEnd := uint64(afterMs-int64(uptimeMs)) + uint64(r.EndMs)
+	if rec.EndMs < loEnd || rec.EndMs > hiEnd {
+		t.Errorf("flowEndMilliseconds %d outside expected range [%d, %d]",
+			rec.EndMs, loEnd, hiEnd)
+	}
+
+	// Sanity check: timestamps must be in year 2020+ (epoch ms > 1.58×10¹²)
+	const year2020Ms = uint64(1577836800000)
+	if rec.StartMs < year2020Ms {
+		t.Errorf("flowStartMilliseconds %d predates 2020-01-01 — looks like relative uptime, not absolute epoch", rec.StartMs)
+	}
+	if rec.EndMs <= rec.StartMs {
+		t.Errorf("flowEndMilliseconds %d ≤ flowStartMilliseconds %d", rec.EndMs, rec.StartMs)
+	}
+}
+
+func TestIPFIXEncodePacket_MultipleRecords(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{
+		makeRecord("10.0.0.1", "10.0.0.2", 1001, 443, 6),
+		makeRecord("10.0.0.3", "10.0.0.4", 1002, 80, 6),
+		makeRecord("10.0.0.5", "10.0.0.6", 1003, 53, 17),
+	}
+
+	n, err := enc.EncodePacket(1, 5, 1000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+
+	pkt := decodeIPFIXPacket(t, buf[:n])
+	if len(pkt.Records) != 3 {
+		t.Errorf("expected 3 records, got %d", len(pkt.Records))
+	}
+	if pkt.Records[2].Protocol != 17 {
+		t.Errorf("record[2] protocol = %d, want 17 (UDP)", pkt.Records[2].Protocol)
+	}
+}
+
+func TestIPFIXEncodePacket_Alignment(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	// A single 53-byte record: data Set body = 4+53 = 57 bytes, must pad to 60.
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 4001, 443, 6)}
+	n, err := enc.EncodePacket(1, 1, 1000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	if n%4 != 0 {
+		t.Errorf("packet length %d is not 4-byte aligned", n)
+	}
+}
+
+func TestIPFIXEncodePacket_EmptyRecordsTemplateOnly(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(1, 0, 0, nil, true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	// Should produce header + template set only.
+	want := ipfixHeaderSize + ipfixTemplSetSize
+	if n != want {
+		t.Errorf("template-only packet size = %d, want %d", n, want)
+	}
+}
+
+func TestIPFIXEncodePacket_BufferTooSmall(t *testing.T) {
+	enc := IPFIXEncoder{}
+	tiny := make([]byte, 10)
+	_, err := enc.EncodePacket(1, 0, 0, []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 5001, 443, 6)}, false, tiny)
+	if err == nil {
+		t.Error("expected error for too-small buffer, got nil")
+	}
+}
+
+func TestIPFIXEncodePacket_DomainIDDistinguishesDevices(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 6001, 443, 6)}
+
+	domainA := uint32(0x0A000001) // 10.0.0.1
+	domainB := uint32(0x0A000002) // 10.0.0.2
+
+	nA, _ := enc.EncodePacket(domainA, 1, 1000, records, false, buf)
+	pktA := decodeIPFIXPacket(t, buf[:nA])
+
+	nB, _ := enc.EncodePacket(domainB, 1, 1000, records, false, buf)
+	pktB := decodeIPFIXPacket(t, buf[:nB])
+
+	if pktA.Header.ObsDomainID == pktB.Header.ObsDomainID {
+		t.Errorf("expected different ObservationDomainIDs (%08x vs %08x)", domainA, domainB)
+	}
+}
+
+func TestIPFIXEncodePacket_LengthFieldMatchesPayload(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{
+		makeRecord("10.0.0.1", "10.0.0.2", 1001, 443, 6),
+		makeRecord("10.0.0.3", "10.0.0.4", 1002, 80, 6),
+	}
+
+	for _, includeTempl := range []bool{false, true} {
+		n, err := enc.EncodePacket(1, 1, 1000, records, includeTempl, buf)
+		if err != nil {
+			t.Fatalf("EncodePacket error: %v", err)
+		}
+		msgLen := int(binary.BigEndian.Uint16(buf[2:]))
+		if msgLen != n {
+			t.Errorf("includeTemplate=%v: Length field %d != actual bytes %d", includeTempl, msgLen, n)
+		}
+	}
+}

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -318,6 +318,15 @@ func (sm *SimulatorManager) Shutdown() error {
 	log.Println("Shutting down simulator manager...")
 	startTime := time.Now()
 
+	// Stop the flow ticker goroutine and close the shared UDP socket.
+	if sm.flowActive && sm.flowStopCh != nil {
+		close(sm.flowStopCh)
+	}
+	if sm.flowConn != nil {
+		sm.flowConn.Close()
+		sm.flowConn = nil
+	}
+
 	if sm.useNamespace && sm.netNamespace != nil {
 		// Fast path: when using a namespace, deleting it instantly destroys all
 		// TUN interfaces inside it. No need to delete them one by one.

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -319,8 +319,12 @@ func (sm *SimulatorManager) Shutdown() error {
 	startTime := time.Now()
 
 	// Stop the flow ticker goroutine and close the shared UDP socket.
-	if sm.flowActive && sm.flowStopCh != nil {
-		close(sm.flowStopCh)
+	// flowStopOnce ensures close(flowStopCh) is safe on repeated Shutdown() calls.
+	// flowWg.Wait() ensures the ticker goroutine has exited before we close flowConn,
+	// eliminating the data race between WriteTo and conn.Close()/nil.
+	if sm.flowActive.Load() {
+		sm.flowStopOnce.Do(func() { close(sm.flowStopCh) })
+		sm.flowWg.Wait()
 	}
 	if sm.flowConn != nil {
 		sm.flowConn.Close()

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -104,7 +104,7 @@ func main() {
 
 		// Flow export flags
 		flowCollector        = flag.String("flow-collector", "", "NetFlow/IPFIX collector address (host:port, e.g. 192.168.1.100:2055); disables flow export when empty")
-		flowProtocol         = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default)")
+		flowProtocol         = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default), ipfix")
 		flowActiveSecs       = flag.Int("flow-active-timeout", 30, "Active flow timeout in seconds (default: 30)")
 		flowInactiveSecs     = flag.Int("flow-inactive-timeout", 15, "Inactive flow timeout in seconds (default: 15)")
 		flowTemplateIntervalSecs = flag.Int("flow-template-interval", 60, "Template retransmission interval in seconds (default: 60)")

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -101,6 +101,14 @@ func main() {
 		showHelp        = flag.Bool("help", false, "Show this help message")
 		ifScenario      = flag.Int("if-scenario", 2, "Interface state scenario: 1=all-shutdown, 2=all-normal (default), 3=all-failure, 4=pct-failure")
 		ifFailurePct    = flag.Int("if-failure-pct", 10, "Percentage of interfaces with oper-down (used with -if-scenario 4, 0–100)")
+
+		// Flow export flags
+		flowCollector        = flag.String("flow-collector", "", "NetFlow/IPFIX collector address (host:port, e.g. 192.168.1.100:2055); disables flow export when empty")
+		flowProtocol         = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default)")
+		flowActiveSecs       = flag.Int("flow-active-timeout", 30, "Active flow timeout in seconds (default: 30)")
+		flowInactiveSecs     = flag.Int("flow-inactive-timeout", 15, "Inactive flow timeout in seconds (default: 15)")
+		flowTemplateIntervalSecs = flag.Int("flow-template-interval", 60, "Template retransmission interval in seconds (default: 60)")
+		flowTickSecs         = flag.Int("flow-tick-interval", 5, "Flow ticker interval in seconds (default: 5)")
 	)
 
 	flag.Parse()
@@ -168,6 +176,21 @@ func main() {
 		err = manager.LoadResources("resources/cisco_ios.json")
 		if err != nil {
 			log.Fatalf("Failed to load any resources: %v", err)
+		}
+	}
+
+	// Enable flow export if a collector address was provided.
+	if *flowCollector != "" {
+		err := manager.InitFlowExport(
+			*flowCollector,
+			*flowProtocol,
+			time.Duration(*flowActiveSecs)*time.Second,
+			time.Duration(*flowInactiveSecs)*time.Second,
+			time.Duration(*flowTemplateIntervalSecs)*time.Second,
+			time.Duration(*flowTickSecs)*time.Second,
+		)
+		if err != nil {
+			log.Fatalf("Failed to initialize flow export: %v", err)
 		}
 	}
 

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -177,13 +177,15 @@ type SimulatorManager struct {
 	flowConn             *net.UDPConn
 	flowCollectorAddr    *net.UDPAddr
 	flowEncoder          FlowEncoder
-	flowBufPool          sync.Pool // supplies []byte(1500); set via flowBufPool.New
-	flowActive           bool
+	flowBufPool          sync.Pool     // supplies []byte(1500); set via flowBufPool.New
+	flowActive           atomic.Bool   // true after InitFlowExport; safe for concurrent reads
 	flowTickInterval     time.Duration
 	flowActiveTimeout    time.Duration
 	flowInactiveTimeout  time.Duration
 	flowTemplateInterval time.Duration
-	flowStopCh           chan struct{} // closed by Shutdown to stop the ticker goroutine
+	flowStopCh           chan struct{}  // closed by Shutdown to stop the ticker goroutine
+	flowStopOnce         sync.Once     // ensures flowStopCh is closed exactly once
+	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before closing flowConn
 
 	mu              sync.RWMutex
 }

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -80,6 +81,7 @@ type DeviceSimulator struct {
 	cachedSysName     atomic.Value // Stores string
 	cachedSysLocation atomic.Value // Stores string
 	metricsCycler *MetricsCycler   // Per-device cycling CPU/memory metrics
+	flowExporter  *FlowExporter   // NetFlow/IPFIX exporter (nil if flow export disabled)
 	netNamespace  *NetNamespace   // Network namespace (nil if using root namespace)
 	running      bool
 	mu           sync.RWMutex
@@ -170,6 +172,18 @@ type SimulatorManager struct {
 	isCreatingDevices    atomic.Value      // bool - true when device creation is in progress
 	deviceCreateProgress atomic.Value      // int - number of devices created so far
 	deviceCreateTotal    atomic.Value      // int - total number of devices to create
+
+	// Flow export state (nil/zero when disabled; set by InitFlowExport)
+	flowConn             *net.UDPConn
+	flowCollectorAddr    *net.UDPAddr
+	flowEncoder          FlowEncoder
+	flowBufPool          sync.Pool // supplies []byte(1500); set via flowBufPool.New
+	flowActive           bool
+	flowTickInterval     time.Duration
+	flowActiveTimeout    time.Duration
+	flowInactiveTimeout  time.Duration
+	flowTemplateInterval time.Duration
+	flowStopCh           chan struct{} // closed by Shutdown to stop the ticker goroutine
 
 	mu              sync.RWMutex
 }


### PR DESCRIPTION
## Summary

Phase 2 of labmonkeys-space/l8opensim#31 — wires the Phase 1 encoding layer into every simulated device. Depends on #32.

- **`flow_exporter.go`** — `FlowEncoder` interface (satisfied by `NetFlow9Encoder`, extensible for IPFIX in Phase 3); `FlowExporter` struct owned by each `DeviceSimulator` with `Tick()` for the expire→encode→send cycle; correct NF9 pagination (multiple UDP datagrams when >30 records expire at once); `InitFlowExport()` opens a single shared UDP socket and starts one shared ticker goroutine (goroutine count stays bounded regardless of device count); `tickAllFlowExporters()` drives all devices
- **`types.go`** — `flowExporter *FlowExporter` on `DeviceSimulator`; 10 flow config fields on `SimulatorManager` (shared `*net.UDPConn`, `FlowEncoder`, `sync.Pool` buffer pool, active/inactive/template/tick timeouts, `flowStopCh`)
- **`device.go`** — `FlowExporter` initialised in both sequential and parallel device creation paths when `sm.flowActive`; uses `GetFlowProfile(resourceFile)` for per-category traffic patterns
- **`manager.go`** — `Shutdown()` closes the ticker goroutine and UDP socket
- **`simulator.go`** — 6 new CLI flags: `-flow-collector`, `-flow-protocol`, `-flow-active-timeout`, `-flow-inactive-timeout`, `-flow-template-interval`, `-flow-tick-interval`

### Usage

```bash
sudo ./simulator \
  -auto-start-ip 192.168.100.1 -auto-count 100 \
  -flow-collector 10.0.0.5:2055 \
  -flow-protocol netflow9 \
  -flow-active-timeout 30 \
  -flow-inactive-timeout 15
```

## Test plan

- [ ] `go test ./simulator/ -run TestFlowExporter -v` — 8 new tests, all PASS
- [ ] `go test ./simulator/ -v` — all 34 tests PASS (no regressions)
- [ ] `CGO_ENABLED=0 GOOS=linux go build -o /dev/null ./simulator/` — clean Linux cross-compile
- [ ] Point `-flow-collector` at a local `nfdump -l` or OpenNMS Telemetryd and verify flows appear within 2× active timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)