### PR TITLE
feat(flow): Phase 4 — /api/v1/flows/status endpoint and cumulative counters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,14 @@ sudo ./simulator [flags]
 -snmpv3-priv <proto>    # none | des | aes128
 -no-namespace           # Disable network namespace isolation
 
+# Flow export flags (NetFlow v9 / IPFIX)
+-flow-collector <host:port>       # Enable flow export to this UDP collector
+-flow-protocol <proto>            # netflow9 (default) | ipfix
+-flow-tick <duration>             # How often to emit flows (default: 10s)
+-flow-active-timeout <duration>   # Active flow expiry timeout (default: 5m)
+-flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 1m)
+-flow-template-interval <dur>     # Re-send template every N ticks (default: 10m)
+
 # Tests
 cd go
 go test ./...
@@ -59,7 +67,9 @@ docker build --no-cache --platform=linux/amd64 -t saichler/opensim-web:latest .
 
 **Network infrastructure:** `tun.go` creates TUN interfaces, `netns.go` manages the `opensim` network namespace, `prealloc.go` does parallel pre-allocation of TUN interfaces (configurable worker count 100–200) for fast scaling.
 
-**Web API:** `web.go` (route setup) + `api.go` (handlers) + `web_routes*.go` (Linux route script generation). Serves device CRUD, CSV export, system stats.
+**Web API:** `web.go` (route setup) + `api.go` (handlers) + `web_routes*.go` (Linux route script generation). Serves device CRUD, CSV export, system stats, and flow export status (`GET /api/v1/flows/status`).
+
+**Flow export:** `flow_exporter.go` (FlowExporter, FlowEncoder interface, SimulatorManager integration) + `netflow9.go` (NetFlow9Encoder, RFC 3954) + `ipfix.go` (IPFIXEncoder, RFC 7011). One shared UDP socket and ticker goroutine; per-device FlowExporter owns a FlowCache. Protocols: `netflow9` (20B header, 45B/record) and `ipfix` (16B header, 53B/record, absolute epoch-ms timestamps).
 
 **Resource loading:** `resources.go` loads and caches the 341 JSON files at startup. Each device type directory has split JSON files for SNMP, SSH, and REST responses that are merged at load time.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A powerful, scalable network and infrastructure simulator that provides realisti
 - **Linux Server Simulation**: Comprehensive Ubuntu server with 36+ SSH commands
 - **CDP & LLDP Support**: Cisco Discovery Protocol and LLDP for network topology discovery
 - **World Cities**: Device sysLocation populated from 98 world cities datasets for realistic geographic distribution
+- **Flow Export**: Per-device NetFlow v9 (RFC 3954) and IPFIX (RFC 7011) export to any UDP collector; protocol-aware batch pagination, template refresh, and a `/api/v1/flows/status` endpoint with cumulative counters
 - **Layer 8 Integration**: Optional L8 vnet overlay with HTTPS web proxy for distributed deployment
 
 ## Quick Start
@@ -89,6 +90,12 @@ Options:
   -no-namespace               Disable network namespace isolation (use root namespace)
   -if-scenario int            Interface state scenario: 1=all-shutdown, 2=all-normal (default), 3=all-failure, 4=pct-failure
   -if-failure-pct int         Percentage of interfaces with oper-down (used with -if-scenario 4, 0–100, default: 10)
+  -flow-collector string      Enable flow export to this UDP collector (e.g., 192.168.1.10:2055)
+  -flow-protocol string       Flow export protocol: netflow9 (default) | ipfix
+  -flow-tick duration         How often to emit flows (default: 10s)
+  -flow-active-timeout dur    Active flow expiry timeout (default: 5m)
+  -flow-inactive-timeout dur  Inactive flow expiry timeout (default: 1m)
+  -flow-template-interval dur Re-send template every N seconds (default: 10m)
   -help                       Show help message
 ```
 
@@ -146,6 +153,60 @@ snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.2.2.1.8   # ifOperStatus
 snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.2.2.1.7   # ifAdminStatus
 ```
 
+## Flow Export (NetFlow v9 / IPFIX)
+
+OpenSim can emit synthetic flow telemetry to any NetFlow v9 (RFC 3954) or IPFIX (RFC 7011) collector. Each simulated device generates realistic flows that reflect its role (edge router, data-center switch, firewall, etc.) and exports them over a single shared UDP socket.
+
+### Starting flow export
+
+```bash
+# Export NetFlow v9 to a local collector on port 2055
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -flow-collector 192.168.1.10:2055
+
+# Use IPFIX instead
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -flow-collector 192.168.1.10:4739 -flow-protocol ipfix
+
+# Faster ticks for high-fidelity testing
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 10 \
+  -flow-collector 127.0.0.1:9999 -flow-tick 1s
+```
+
+### Protocol details
+
+| Protocol | Version field | Template ID | Record size | Timestamps |
+|----------|--------------|-------------|-------------|------------|
+| NetFlow v9 | `9` | FlowSet ID 0 | 45 B/record | SysUptime-relative ms (FIRST/LAST_SWITCHED) |
+| IPFIX | `10` | Set ID 2 | 53 B/record | Absolute epoch ms (IE 152/153) |
+
+Both protocols use the same 18-field template (bytes, packets, protocol, ToS, TCP flags, src/dst ports, src/dst IPv4, src/dst mask, ingress/egress interface, next-hop, src/dst AS, timestamps).
+
+### Flow status API
+
+```bash
+curl http://localhost:8080/api/v1/flows/status
+```
+
+```json
+{
+  "success": true,
+  "message": "Success",
+  "data": {
+    "enabled": true,
+    "protocol": "ipfix",
+    "collector": "192.168.1.10:4739",
+    "total_flows_exported": 1824300,
+    "total_packets_sent": 91215,
+    "total_bytes_sent": 136823040,
+    "devices_exporting": 100,
+    "last_template_send": "2026-04-16T10:35:00Z"
+  }
+}
+```
+
+When flow export is disabled the response is `{"enabled": false}`.
+
 ## Web Interface
 
 Access the web UI at `http://localhost:8080/` for:
@@ -172,6 +233,7 @@ Access the web UI at `http://localhost:8080/` for:
 | `/api/v1/resources` | GET | List available device resource types |
 | `/api/v1/status` | GET | Manager status |
 | `/api/v1/system-stats` | GET | System stats (file descriptors, memory) |
+| `/api/v1/flows/status` | GET | Flow export status and cumulative counters |
 | `/health` | GET | Health check endpoint |
 
 ### Create Devices

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,31 @@
+
+## Deferred from: code review of technical-netflow-v9-ipfix-l8opensim-research-2026-04-16 PR #33 (2026-04-16)
+
+## Deferred from: code review of Phase 3 ipfix.go (2026-04-16)
+
+- **IPFIX sequence number counts datagrams not records** — RFC 7011 §3.1 requires SeqNo to advance by number of Data Records in the message, not by 1 per datagram. Same as NF9 encoder; simulation-grade tolerable. [`flow_exporter.go:121`]
+- **IE field widths narrower than IANA defaults** — tcpControlBits 1B (IANA: 2B); ingressInterface/egressInterface 2B (IANA: 4B); bgpSourceAsNumber/bgpDestinationAsNumber 2B (IANA: 4B). Collectors decode correctly via template advertisement; conscious NF9 parity trade-off. [`ipfix.go:ipfixFields`]
+- **`octetDeltaCount` (IE 1) 4B instead of IANA `unsigned64` 8B** — same decision as NF9 IN_BYTES; values >4 GB clamped. GPU/Storage profiles can exceed 4 GB. [`ipfix.go:encodeIPFIXRecord`]
+- **`EndMs < StartMs` propagates to IPFIX wire** — pre-existing in `flow_cache.go`; `FlowCache.Add()` sets EndMs unconditionally without inversion guard. Violates RFC 7011 §3.7 on the wire. [`flow_cache.go:105`]
+
+## Deferred from: code review of technical-netflow-v9-ipfix-l8opensim-research-2026-04-16 PR #33 (2026-04-16)
+
+- **`/api/v1/flows/status` endpoint** — Phase 2 spec table listed it in `api.go`, but Phase 4 acceptance table is authoritative. Handler would be skeletal without per-device stats counters; belongs in Phase 4 Polish alongside perf benchmarks and docs. [`api.go`, `web.go`]
+- **~45–90 MB heap overhead at 30k devices** — Each `FlowCache` allocates per-device memory. Pre-existing design trade-off between realism and memory. Consider lazy init or smaller profiles if scale-to-30k becomes a priority. [`flow_cache.go`, `flow_exporter.go`]
+- **`FlowEncoder.EncodePacket` extra `uptimeMs` parameter** — IPFIX encoders can ignore it; conscious decision for NF9/IPFIX parity in the shared interface. Revisit if adding more protocol encoders that find the param confusing. [`flow_exporter.go:33–35`]
+- **`NewFlowExporter` per-device timeout params** — Redundant with `SimulatorManager` fields; harmless but could be simplified. [`flow_exporter.go:54`]
+- **`FlowExporter.templateInterval` per-device field** — Minor memory overhead (~240 kB at 30k devices); central `SimulatorManager.flowTemplateInterval` already exists. [`flow_exporter.go:48`]
+- **`InitFlowExport` does not propagate `templateInterval` change to live devices** — Runtime reconfiguration won't affect already-running exporters. Relevant only if hot-reconfiguration is added later. [`flow_exporter.go:147`]
+
+## Deferred from: code review of Phase 4 flows/status endpoint (2026-04-17)
+
+- **`flowProtocol`/`flowCollectorStr` unprotected strings** — These plain `string` fields are written by `InitFlowExport` and read by `GetFlowStatus` without any lock. Currently safe because the atomic happens-before chain (`flowActive.Store` after writes, `flowActive.Load` before reads) provides ordering, and the re-init guard prevents concurrent writes. Becomes a real race if Shutdown/re-init is enabled. Should be protected by `sm.mu` when re-init is allowed. [`types.go:179-180`, `flow_exporter.go:309-310`]
+- **Counter gate couples three independent atomics** — `if totalPackets > 0` gates all three counter updates in `tickAllFlowExporters`. Invariant holds today (PacketsSent incremented before RecordsSent), but future refactoring could silently drop record counts. Consider updating counters independently. [`flow_exporter.go:276-280`]
+- **`flowStatLastTmpl` unconditional Store is non-monotonic** — `tickAllFlowExporters` calls `sm.flowStatLastTmpl.Store(lastTemplMs)` without a compare-and-swap. Safe today (single ticker goroutine), but would roll the timestamp back if a second ticker were ever started. Use an atomic CAS loop if concurrent tickers are added. [`flow_exporter.go:281-283`]
+- **Silent record drop on `EncodePacket` error** — When `EncodePacket` returns an error, remaining `expired` records in the current pagination loop are discarded without incrementing counters or logging. Pre-existing behaviour from earlier phases. [`flow_exporter.go:139-141`]
+- **`cap` variable shadows built-in `cap()` function** — In `Tick()`, `cap := (len(buf) - overhead) / recSize` shadows the built-in. Pre-existing, not introduced by this diff. Will surface under `go vet -shadow`. [`flow_exporter.go:125`]
+- **HTTP 200 returned for both enabled and disabled flow status** — `flowStatusHandler` returns `{"success":true, "data":{"enabled":false}}` with HTTP 200 when flow export is off. Consistent with the project's existing API pattern but non-RESTful. Low priority; document the behaviour. [`web.go:90-93`]
+
+## Deferred from: code review of technical-netflow-v9-ipfix-l8opensim-research-2026-04-16 (2026-04-16)
+
+- **Phase 2 goroutine will have no shutdown channel** — `DeviceSimulator` has no `stopCh chan struct{}` or `context.Context`. A FlowExporter goroutine wired in Phase 2 will leak after `device.Stop()`, keeping the device's FlowCache and UDP socket alive. Add `stopCh chan struct{}` to `DeviceSimulator` and close it in `Stop()` before Phase 2 goroutines are launched. [`types.go`, `device.go`]

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -40,6 +40,16 @@ type FlowEncoder interface {
 	PacketSizes() (baseOverhead int, templateSize int, recordSize int)
 }
 
+// FlowTickStats holds per-tick export counters returned by Tick.
+// tickAllFlowExporters sums these across all devices and adds them to the
+// cumulative atomic counters on SimulatorManager.
+type FlowTickStats struct {
+	PacketsSent    uint64
+	BytesSent      uint64
+	RecordsSent    uint64
+	LastTemplateMs int64 // unix ms of the most-recent template send this tick; 0 if none
+}
+
 // FlowExporter is owned by one DeviceSimulator. It ties the FlowCache and
 // encoder together and is driven by the shared SimulatorManager ticker goroutine.
 // It has no goroutines of its own — see SimulatorManager.startFlowTicker.
@@ -78,7 +88,9 @@ func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeou
 //
 // bufPool must supply []byte slices of at least 1500 bytes.
 // Write errors are ignored (best-effort delivery; collector may be down).
-func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPConn, collectorAddr *net.UDPAddr, bufPool *sync.Pool) {
+// The returned FlowTickStats are summed by tickAllFlowExporters into the
+// cumulative atomic counters on SimulatorManager.
+func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPConn, collectorAddr *net.UDPAddr, bufPool *sync.Pool) FlowTickStats {
 	uptimeMs := uint32(now.Sub(fe.startTime).Milliseconds())
 	deviceIP := domainIDtoIP(fe.domainID)
 
@@ -90,11 +102,13 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 
 	sendTemplate := fe.seqNo == 0 || now.Sub(fe.lastTempl) >= fe.templateInterval
 	if len(expired) == 0 && !sendTemplate {
-		return
+		return FlowTickStats{}
 	}
 
 	buf := bufPool.Get().([]byte)
 	defer bufPool.Put(buf)
+
+	var stats FlowTickStats
 
 	// Paginate: send as many records as fit in each 1500-byte UDP datagram.
 	// Capacity depends on the active encoder's protocol (NF9: 45B/record,
@@ -128,9 +142,13 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 		}
 
 		conn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
+		stats.PacketsSent++
+		stats.BytesSent += uint64(n)
+		stats.RecordsSent += uint64(len(batch))
 		fe.seqNo++
 		if sendTemplate {
 			fe.lastTempl = now
+			stats.LastTemplateMs = now.UnixMilli()
 			sendTemplate = false
 		}
 
@@ -138,6 +156,7 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 			break
 		}
 	}
+	return stats
 }
 
 // domainIDtoIP converts a uint32 ObservationDomainID back to a net.IP.
@@ -180,6 +199,8 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 
 	sm.flowConn = conn
 	sm.flowCollectorAddr = addr
+	sm.flowCollectorStr = collectorAddr
+	sm.flowProtocol = strings.ToLower(protocol)
 	sm.flowEncoder = enc
 	sm.flowActiveTimeout = activeTimeout
 	sm.flowInactiveTimeout = inactiveTimeout
@@ -241,7 +262,56 @@ func (sm *SimulatorManager) tickAllFlowExporters(now time.Time) {
 		return // flow export was shut down between tick and snapshot
 	}
 
+	var totalPackets, totalBytes, totalRecords uint64
+	var lastTemplMs int64
 	for _, fe := range exporters {
-		fe.Tick(now, encoder, conn, collectorAddr, &sm.flowBufPool)
+		s := fe.Tick(now, encoder, conn, collectorAddr, &sm.flowBufPool)
+		totalPackets += s.PacketsSent
+		totalBytes += s.BytesSent
+		totalRecords += s.RecordsSent
+		if s.LastTemplateMs > lastTemplMs {
+			lastTemplMs = s.LastTemplateMs
+		}
+	}
+	if totalPackets > 0 {
+		sm.flowStatPackets.Add(totalPackets)
+		sm.flowStatBytes.Add(totalBytes)
+		sm.flowStatRecords.Add(totalRecords)
+	}
+	if lastTemplMs > 0 {
+		sm.flowStatLastTmpl.Store(lastTemplMs)
+	}
+}
+
+// GetFlowStatus returns a snapshot of the current flow export state and
+// cumulative counters. Returns {Enabled: false} when flow export is off.
+func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
+	if !sm.flowActive.Load() {
+		return FlowStatus{Enabled: false}
+	}
+
+	sm.mu.RLock()
+	devicesExporting := 0
+	for _, d := range sm.devices {
+		if d.flowExporter != nil {
+			devicesExporting++
+		}
+	}
+	sm.mu.RUnlock()
+
+	var lastTemplate string
+	if ms := sm.flowStatLastTmpl.Load(); ms > 0 {
+		lastTemplate = time.UnixMilli(ms).UTC().Format(time.RFC3339)
+	}
+
+	return FlowStatus{
+		Enabled:            true,
+		Protocol:           sm.flowProtocol,
+		Collector:          sm.flowCollectorStr,
+		TotalFlowsExported: sm.flowStatRecords.Load(),
+		TotalPacketsSent:   sm.flowStatPackets.Load(),
+		TotalBytesSent:     sm.flowStatBytes.Load(),
+		DevicesExporting:   devicesExporting,
+		LastTemplateSend:   lastTemplate,
 	}
 }

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -187,11 +187,14 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 	}
 
 	var enc FlowEncoder
+	var canonicalProtocol string
 	switch strings.ToLower(protocol) {
 	case "netflow9", "nf9", "":
 		enc = NetFlow9Encoder{}
+		canonicalProtocol = "netflow9"
 	case "ipfix", "ipfix10":
 		enc = IPFIXEncoder{}
+		canonicalProtocol = "ipfix"
 	default:
 		conn.Close()
 		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9, ipfix)", protocol)
@@ -200,7 +203,7 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 	sm.flowConn = conn
 	sm.flowCollectorAddr = addr
 	sm.flowCollectorStr = collectorAddr
-	sm.flowProtocol = strings.ToLower(protocol)
+	sm.flowProtocol = canonicalProtocol
 	sm.flowEncoder = enc
 	sm.flowActiveTimeout = activeTimeout
 	sm.flowInactiveTimeout = inactiveTimeout
@@ -301,7 +304,7 @@ func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
 
 	var lastTemplate string
 	if ms := sm.flowStatLastTmpl.Load(); ms > 0 {
-		lastTemplate = time.UnixMilli(ms).UTC().Format(time.RFC3339)
+		lastTemplate = time.UnixMilli(ms).UTC().Format(time.RFC3339Nano)
 	}
 
 	return FlowStatus{

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -457,3 +457,127 @@ func TestFlowExporter_Tick_Pagination(t *testing.T) {
 		t.Errorf("total records across all packets = %d, want 80", total)
 	}
 }
+
+// TestFlowTickStats_Counters verifies that Tick() returns non-zero PacketsSent,
+// BytesSent, and RecordsSent when there are records to export.
+func TestFlowTickStats_Counters(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+	conn := testSender(t)
+	defer conn.Close()
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	fe := NewFlowExporter(testDevice("10.0.0.3"), flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
+
+	// Pre-populate 5 expired records.
+	past := time.Now().Add(-2 * time.Minute)
+	for i := 0; i < 5; i++ {
+		fe.cache.Add(FlowRecord{
+			SrcIP:    net.ParseIP("10.1.0.1").To4(),
+			DstIP:    net.ParseIP("10.2.0.1").To4(),
+			NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+			SrcPort:  uint16(1000 + i),
+			DstPort:  80,
+			Protocol: 6,
+			Bytes:    500,
+			Packets:  5,
+		}, past)
+	}
+
+	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	// Drain sent packets so the listener goroutine can exit cleanly.
+	receivePacket(ch)
+
+	if stats.PacketsSent == 0 {
+		t.Error("PacketsSent = 0, want >0")
+	}
+	if stats.BytesSent == 0 {
+		t.Error("BytesSent = 0, want >0")
+	}
+	if stats.RecordsSent != 5 {
+		t.Errorf("RecordsSent = %d, want 5", stats.RecordsSent)
+	}
+	// seqNo == 0 on first call, so a template must have been sent.
+	if stats.LastTemplateMs == 0 {
+		t.Error("LastTemplateMs = 0 on first Tick, want non-zero")
+	}
+}
+
+// TestFlowTickStats_NoRecordsNoTemplate verifies that Tick() returns zero stats
+// when there is nothing to export and no template is due.
+func TestFlowTickStats_NoRecordsNoTemplate(t *testing.T) {
+	ln, _ := testUDPListener(t)
+	defer ln.Close()
+	conn := testSender(t)
+	defer conn.Close()
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	fe := NewFlowExporter(testDevice("10.0.0.4"), flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Minute)
+
+	// Advance past the first (seqNo==0) template send so the next call has no template due.
+	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	// Second tick with empty cache and no template interval elapsed → zero stats.
+	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+
+	if stats.PacketsSent != 0 || stats.BytesSent != 0 || stats.RecordsSent != 0 || stats.LastTemplateMs != 0 {
+		t.Errorf("expected zero stats on idle tick, got %+v", stats)
+	}
+}
+
+// TestGetFlowStatus_Disabled verifies that GetFlowStatus returns {Enabled:false}
+// when flow export has not been initialised.
+func TestGetFlowStatus_Disabled(t *testing.T) {
+	sm := &SimulatorManager{devices: make(map[string]*DeviceSimulator)}
+	status := sm.GetFlowStatus()
+	if status.Enabled {
+		t.Error("expected Enabled=false when flow export is off")
+	}
+	if status.Protocol != "" || status.Collector != "" {
+		t.Errorf("expected empty Protocol/Collector when disabled, got %+v", status)
+	}
+}
+
+// TestGetFlowStatus_Enabled verifies that GetFlowStatus reflects the values set
+// by InitFlowExport and the cumulative counters updated by tickAllFlowExporters.
+func TestGetFlowStatus_Enabled(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+
+	collectorStr := ln.LocalAddr().String()
+	sm := NewSimulatorManagerWithOptions(false)
+	err := sm.InitFlowExport(collectorStr, "netflow9", 30*time.Second, 15*time.Second, 60*time.Second, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("InitFlowExport: %v", err)
+	}
+	defer sm.Shutdown()
+
+	// Add a device with a flow exporter.
+	device := testDevice("10.5.0.1")
+	device.flowExporter = NewFlowExporter(device, flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
+	sm.mu.Lock()
+	sm.devices["10.5.0.1"] = device
+	sm.mu.Unlock()
+
+	// Wait for at least one tick cycle to deliver packets.
+	receivePacket(ch)
+
+	status := sm.GetFlowStatus()
+	if !status.Enabled {
+		t.Error("expected Enabled=true after InitFlowExport")
+	}
+	if status.Protocol != "netflow9" {
+		t.Errorf("Protocol = %q, want \"netflow9\"", status.Protocol)
+	}
+	if status.Collector != collectorStr {
+		t.Errorf("Collector = %q, want %q", status.Collector, collectorStr)
+	}
+	if status.DevicesExporting != 1 {
+		t.Errorf("DevicesExporting = %d, want 1", status.DevicesExporting)
+	}
+	if status.TotalPacketsSent == 0 {
+		t.Error("TotalPacketsSent = 0, want >0 after at least one tick")
+	}
+	if status.LastTemplateSend == "" {
+		t.Error("LastTemplateSend is empty, want a non-empty RFC3339 timestamp")
+	}
+}

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -558,10 +558,18 @@ func TestGetFlowStatus_Enabled(t *testing.T) {
 	sm.devices["10.5.0.1"] = device
 	sm.mu.Unlock()
 
-	// Wait for at least one tick cycle to deliver packets.
-	receivePacket(ch)
-
-	status := sm.GetFlowStatus()
+	// Poll until TotalPacketsSent is updated. receivePacket() synchronises on
+	// UDP arrival, which races the atomic Add in tickAllFlowExporters — use a
+	// short polling loop to fence the counter reliably.
+	deadline := time.Now().Add(2 * time.Second)
+	var status FlowStatus
+	for time.Now().Before(deadline) {
+		receivePacket(ch)
+		status = sm.GetFlowStatus()
+		if status.TotalPacketsSent > 0 {
+			break
+		}
+	}
 	if !status.Enabled {
 		t.Error("expected Enabled=true after InitFlowExport")
 	}

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -325,6 +325,7 @@ func (sm *SimulatorManager) Shutdown() error {
 	if sm.flowActive.Load() {
 		sm.flowStopOnce.Do(func() { close(sm.flowStopCh) })
 		sm.flowWg.Wait()
+		sm.flowActive.Store(false)
 	}
 	if sm.flowConn != nil {
 		sm.flowConn.Close()

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -191,7 +191,7 @@ type SimulatorManager struct {
 
 	// Flow export cumulative counters (updated atomically by tickAllFlowExporters).
 	flowStatPackets  atomic.Uint64 // total UDP datagrams sent since InitFlowExport
-	flowStatBytes    atomic.Uint64 // total encoded payload bytes sent since InitFlowExport
+	flowStatBytes    atomic.Uint64 // total bytes written to UDP (headers + records + padding) since InitFlowExport
 	flowStatRecords  atomic.Uint64 // total flow records exported since InitFlowExport
 	flowStatLastTmpl atomic.Int64  // unix milliseconds of the most recent template transmission
 
@@ -288,9 +288,9 @@ type FlowStatus struct {
 	Enabled            bool   `json:"enabled"`
 	Protocol           string `json:"protocol,omitempty"`
 	Collector          string `json:"collector,omitempty"`
-	TotalFlowsExported uint64 `json:"total_flows_exported,omitempty"`
-	TotalPacketsSent   uint64 `json:"total_packets_sent,omitempty"`
-	TotalBytesSent     uint64 `json:"total_bytes_sent,omitempty"`
-	DevicesExporting   int    `json:"devices_exporting,omitempty"`
+	TotalFlowsExported uint64 `json:"total_flows_exported"`
+	TotalPacketsSent   uint64 `json:"total_packets_sent"`
+	TotalBytesSent     uint64 `json:"total_bytes_sent"`
+	DevicesExporting   int    `json:"devices_exporting"`
 	LastTemplateSend   string `json:"last_template_send,omitempty"`
 }

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -176,6 +176,8 @@ type SimulatorManager struct {
 	// Flow export state (nil/zero when disabled; set by InitFlowExport)
 	flowConn             *net.UDPConn
 	flowCollectorAddr    *net.UDPAddr
+	flowCollectorStr     string        // original "host:port" string for status reporting
+	flowProtocol         string        // normalised protocol name ("netflow9" or "ipfix")
 	flowEncoder          FlowEncoder
 	flowBufPool          sync.Pool     // supplies []byte(1500); set via flowBufPool.New
 	flowActive           atomic.Bool   // true after InitFlowExport; safe for concurrent reads
@@ -186,6 +188,12 @@ type SimulatorManager struct {
 	flowStopCh           chan struct{}  // closed by Shutdown to stop the ticker goroutine
 	flowStopOnce         sync.Once     // ensures flowStopCh is closed exactly once
 	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before closing flowConn
+
+	// Flow export cumulative counters (updated atomically by tickAllFlowExporters).
+	flowStatPackets  atomic.Uint64 // total UDP datagrams sent since InitFlowExport
+	flowStatBytes    atomic.Uint64 // total encoded payload bytes sent since InitFlowExport
+	flowStatRecords  atomic.Uint64 // total flow records exported since InitFlowExport
+	flowStatLastTmpl atomic.Int64  // unix milliseconds of the most recent template transmission
 
 	mu              sync.RWMutex
 }
@@ -273,4 +281,16 @@ type ManagerStatus struct {
 	DeviceCreateTotal    int  `json:"device_create_total"`
 	TotalDevices         int  `json:"total_devices"`
 	RunningDevices       int  `json:"running_devices"`
+}
+
+// FlowStatus is the JSON body returned by GET /api/v1/flows/status.
+type FlowStatus struct {
+	Enabled            bool   `json:"enabled"`
+	Protocol           string `json:"protocol,omitempty"`
+	Collector          string `json:"collector,omitempty"`
+	TotalFlowsExported uint64 `json:"total_flows_exported,omitempty"`
+	TotalPacketsSent   uint64 `json:"total_packets_sent,omitempty"`
+	TotalBytesSent     uint64 `json:"total_bytes_sent,omitempty"`
+	DevicesExporting   int    `json:"devices_exporting,omitempty"`
+	LastTemplateSend   string `json:"last_template_send,omitempty"`
 }

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -87,6 +87,11 @@ func systemStatsHandler(w http.ResponseWriter, r *http.Request) {
 	sendDataResponse(w, stats)
 }
 
+func flowStatusHandler(w http.ResponseWriter, r *http.Request) {
+	status := manager.GetFlowStatus()
+	sendDataResponse(w, status)
+}
+
 func deleteDeviceHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	deviceID := vars["id"]
@@ -245,6 +250,7 @@ func setupRoutes() *mux.Router {
 	api.HandleFunc("/resources", listResourcesHandler).Methods("GET")
 	api.HandleFunc("/status", statusHandler).Methods("GET")
 	api.HandleFunc("/system-stats", systemStatsHandler).Methods("GET")
+	api.HandleFunc("/flows/status", flowStatusHandler).Methods("GET")
 	api.HandleFunc("/debug/pprof-memory", pprofMemoryHandler).Methods("GET")
 	api.HandleFunc("/debug/cpu-profile", cpuProfileHandler).Methods("GET")
 


### PR DESCRIPTION
## Summary

- **`FlowTickStats` struct** — `Tick()` now returns per-tick counters (`PacketsSent`, `BytesSent`, `RecordsSent`, `LastTemplateMs`) instead of `void`
- **Cumulative atomic counters** on `SimulatorManager` (`flowStatPackets`, `flowStatBytes`, `flowStatRecords`, `flowStatLastTmpl`) updated by `tickAllFlowExporters` on every tick
- **`GET /api/v1/flows/status`** — new endpoint returning `FlowStatus` JSON with enabled flag, protocol, collector, all four counters, devices currently exporting, and last template send timestamp (RFC3339 UTC)
- **`CLAUDE.md` / `README.md`** — documented all `-flow-*` CLI flags, added a _Flow Export_ section with protocol comparison table and API example

## Response shape

```json
{
  "enabled": true,
  "protocol": "ipfix",
  "collector": "192.168.1.10:4739",
  "total_flows_exported": 1824300,
  "total_packets_sent": 91215,
  "total_bytes_sent": 136823040,
  "devices_exporting": 100,
  "last_template_send": "2026-04-16T10:35:00Z"
}
```

Returns `{"enabled": false}` when flow export is off.

## Test plan

- [x] `TestFlowTickStats_Counters` — verifies non-zero stats on a tick with 5 records
- [x] `TestFlowTickStats_NoRecordsNoTemplate` — verifies zero stats on idle tick
- [x] `TestGetFlowStatus_Disabled` — `Enabled=false` before `InitFlowExport`
- [x] `TestGetFlowStatus_Enabled` — correct protocol/collector/counters after first tick
- [x] Full test suite: `go test ./simulator/... -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)