### PR TITLE
feat(device): embed slugified device type in device ID and sysName

### DIFF
--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -182,8 +182,9 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			copy(currentIP, sm.currentIP)
 			deviceID := makeDeviceID(currentIP, typeSlug)
 
-			// Check if device already exists
-			_, exists := sm.devices[deviceID]
+			// Check IP (not deviceID) so re-invocations with a different
+			// resource file still detect the collision.
+			_, exists := sm.deviceIPs[currentIP.String()]
 			sm.mu.RUnlock()
 
 			if exists {
@@ -294,6 +295,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			// Add device to map with a write lock
 			sm.mu.Lock()
 			sm.devices[deviceID] = device
+			sm.deviceIPs[currentIP.String()] = struct{}{}
 			sm.incrementIP()
 			sm.mu.Unlock()
 
@@ -389,9 +391,10 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 		}
 		deviceID := makeDeviceID(deviceIP, slugifyDeviceType(deviceResourceFile))
 
-		// Check if device already exists
+		// Check IP (not deviceID) so the duplicate check stays robust against
+		// the device-ID format including a resource-type slug.
 		sm.mu.RLock()
-		_, exists := sm.devices[deviceID]
+		_, exists := sm.deviceIPs[deviceIP.String()]
 		sm.mu.RUnlock()
 
 		if exists {
@@ -519,6 +522,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	// Add device to map with a write lock
 	sm.mu.Lock()
 	sm.devices[deviceID] = device
+	sm.deviceIPs[deviceIP.String()] = struct{}{}
 	sm.mu.Unlock()
 
 	return true

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -25,6 +25,17 @@ import (
 	"time"
 )
 
+// makeDeviceID builds a device ID from an IP and an optional device-type slug.
+// When slug is empty the ID is just the IP; otherwise it is "<ip>-<slug>"
+// (e.g. "10.0.0.1-cisco-catalyst-9500"). The "device-" prefix is intentionally
+// omitted so the ID reflects the device identity directly.
+func makeDeviceID(ip net.IP, typeSlug string) string {
+	if typeSlug == "" {
+		return ip.String()
+	}
+	return fmt.Sprintf("%s-%s", ip.String(), typeSlug)
+}
+
 func (sm *SimulatorManager) CreateDevices(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, roundRobin bool, category string, snmpPort int) error {
 	return sm.CreateDevicesWithOptions(startIP, count, netmask, resourceFile, v3Config, true, 0, roundRobin, category, snmpPort)
 }
@@ -155,11 +166,21 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 	} else {
 		// No pre-allocation - create devices sequentially (original logic)
 		for i := 0; i < count; i++ {
+			// Select resources first so the device-type slug is available for the device ID
+			deviceResources := resources
+			deviceResourceFile := resourceFile
+			if roundRobin && len(roundRobinResources) > 0 {
+				rrIndex := i % len(roundRobinResources)
+				deviceResources = roundRobinResources[rrIndex]
+				deviceResourceFile = roundRobinResourceFiles[rrIndex]
+			}
+			typeSlug := slugifyDeviceType(deviceResourceFile)
+
 			// Get current IP with a read lock
 			sm.mu.RLock()
 			currentIP := make(net.IP, len(sm.currentIP))
 			copy(currentIP, sm.currentIP)
-			deviceID := fmt.Sprintf("device-%s", currentIP.String())
+			deviceID := makeDeviceID(currentIP, typeSlug)
 
 			// Check if device already exists
 			_, exists := sm.devices[deviceID]
@@ -215,16 +236,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			copy(deviceIP, currentIP)
 
 			sysLocationValue := getRandomCity()
-			sysNameValue := getRandomDeviceName()
-
-			// Select resources based on round robin or single type
-			deviceResources := resources
-			deviceResourceFile := resourceFile
-			if roundRobin && len(roundRobinResources) > 0 {
-				rrIndex := i % len(roundRobinResources)
-				deviceResources = roundRobinResources[rrIndex]
-				deviceResourceFile = roundRobinResourceFiles[rrIndex]
-			}
+			sysNameValue := getRandomDeviceName(typeSlug)
 
 			device := &DeviceSimulator{
 				ID:           deviceID,
@@ -366,7 +378,16 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 
 	for i := 0; i < count; i++ {
 		deviceIP := deviceIPs[i]
-		deviceID := fmt.Sprintf("device-%s", deviceIP.String())
+
+		// Select resources first so the device-type slug is available for the device ID
+		deviceResources := resources
+		deviceResourceFile := resourceFile
+		if roundRobin && len(roundRobinResources) > 0 {
+			rrIndex := i % len(roundRobinResources)
+			deviceResources = roundRobinResources[rrIndex]
+			deviceResourceFile = roundRobinResourceFiles[rrIndex]
+		}
+		deviceID := makeDeviceID(deviceIP, slugifyDeviceType(deviceResourceFile))
 
 		// Check if device already exists
 		sm.mu.RLock()
@@ -375,15 +396,6 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 
 		if exists {
 			continue
-		}
-
-		// Select resources based on round robin or single type
-		deviceResources := resources
-		deviceResourceFile := resourceFile
-		if roundRobin && len(roundRobinResources) > 0 {
-			rrIndex := i % len(roundRobinResources)
-			deviceResources = roundRobinResources[rrIndex]
-			deviceResourceFile = roundRobinResourceFiles[rrIndex]
 		}
 
 		wg.Add(1)
@@ -451,7 +463,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	}
 
 	sysLocationValue := getRandomCity()
-	sysNameValue := getRandomDeviceName()
+	sysNameValue := getRandomDeviceName(slugifyDeviceType(resourceFile))
 
 	device := &DeviceSimulator{
 		ID:           deviceID,

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -45,6 +45,7 @@ func NewSimulatorManagerWithOptions(useNamespace bool) *SimulatorManager {
 
 	sm := &SimulatorManager{
 		devices:          make(map[string]*DeviceSimulator),
+		deviceIPs:        make(map[string]struct{}),
 		nextTunIndex:     0,
 		resourcesCache:   make(map[string]*DeviceResources),
 		tunInterfacePool: make(map[string]*TunInterface),
@@ -263,6 +264,7 @@ func (sm *SimulatorManager) DeleteDevice(deviceID string) error {
 	}
 
 	delete(sm.devices, deviceID)
+	delete(sm.deviceIPs, device.IP.String())
 	return nil
 }
 
@@ -301,8 +303,9 @@ func (sm *SimulatorManager) DeleteAllDevices() error {
 		}
 	}
 
-	// Clear the devices map and pre-allocated pool
+	// Clear the devices map, IP set, and pre-allocated pool
 	sm.devices = make(map[string]*DeviceSimulator)
+	sm.deviceIPs = make(map[string]struct{})
 	sm.tunPoolMutex.Lock()
 	sm.tunInterfacePool = make(map[string]*TunInterface)
 	sm.tunPoolMutex.Unlock()

--- a/go/simulator/names.go
+++ b/go/simulator/names.go
@@ -18,7 +18,20 @@ package main
 import (
 	"fmt"
 	mathrand "math/rand"
+	"strings"
 )
+
+// slugifyDeviceType turns a resource filename (e.g. "cisco_catalyst_9500.json")
+// into a lowercase slug suitable for use in device IDs and sysName values
+// (e.g. "cisco-catalyst-9500"). Returns "" when resourceFile is empty.
+func slugifyDeviceType(resourceFile string) string {
+	if resourceFile == "" {
+		return ""
+	}
+	name := strings.TrimSuffix(resourceFile, ".json")
+	name = strings.ReplaceAll(name, "_", "-")
+	return strings.ToLower(name)
+}
 
 // Global lists for generating random device names
 var devicePrefixes = []string{
@@ -53,8 +66,10 @@ var mythNames = []string{
 	"ORION", "ANDROMEDA", "CASSIOPEIA", "VEGA", "ALTAIR", "SIRIUS", "RIGEL", "BETELGEUSE", "POLARIS", "ANTARES",
 }
 
-// getRandomDeviceName generates a random device name using various patterns
-func getRandomDeviceName() string {
+// getRandomDeviceName generates a random device name using various patterns.
+// When typeSlug is non-empty it is appended as a suffix (e.g. "-cisco-catalyst-9500").
+// The result is always lowercase.
+func getRandomDeviceName(typeSlug string) string {
 
 	// Choose a random pattern for the device name
 	patterns := []func() string{
@@ -103,6 +118,8 @@ func getRandomDeviceName() string {
 	// Select a random pattern and generate the name
 	pattern := patterns[mathrand.Intn(len(patterns))]
 	name := pattern()
-	// log.Printf("Generated device name: %s", name)
-	return name
+	if typeSlug != "" {
+		name = name + "-" + typeSlug
+	}
+	return strings.ToLower(name)
 }

--- a/go/simulator/names.go
+++ b/go/simulator/names.go
@@ -18,19 +18,36 @@ package main
 import (
 	"fmt"
 	mathrand "math/rand"
+	"path/filepath"
 	"strings"
 )
 
 // slugifyDeviceType turns a resource filename (e.g. "cisco_catalyst_9500.json")
-// into a lowercase slug suitable for use in device IDs and sysName values
-// (e.g. "cisco-catalyst-9500"). Returns "" when resourceFile is empty.
+// into a lowercase, URL-/hostname-safe slug (e.g. "cisco-catalyst-9500").
+// Any character outside [a-z0-9-] becomes '-', consecutive hyphens collapse,
+// and leading/trailing hyphens are trimmed. Returns "" when resourceFile is
+// empty or the result would be empty.
 func slugifyDeviceType(resourceFile string) string {
 	if resourceFile == "" {
 		return ""
 	}
-	name := strings.TrimSuffix(resourceFile, ".json")
-	name = strings.ReplaceAll(name, "_", "-")
-	return strings.ToLower(name)
+	name := strings.ToLower(filepath.Base(resourceFile))
+	name = strings.TrimSuffix(name, ".json")
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	result := b.String()
+	for strings.Contains(result, "--") {
+		result = strings.ReplaceAll(result, "--", "-")
+	}
+	return strings.Trim(result, "-")
 }
 
 // Global lists for generating random device names

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -149,6 +149,12 @@ type APIServer struct {
 // Manager for all simulated devices
 type SimulatorManager struct {
 	devices         map[string]*DeviceSimulator
+	// deviceIPs tracks IPs currently bound to a device so that duplicate
+	// detection stays robust against changes to the device-ID format. Without
+	// it, two concurrent calls that target the same IP with different
+	// resource files would both pass the `sm.devices[deviceID]` lookup (the
+	// IDs differ by slug) and race to bind the same TUN and SNMP/SSH ports.
+	deviceIPs       map[string]struct{}
 	currentIP       net.IP
 	nextTunIndex    int
 	deviceResources *DeviceResources


### PR DESCRIPTION
## Summary
- Device IDs now embed the device-type slug: `device-10.0.0.1` → `10.0.0.1-cisco-catalyst-9500`. Falls back to `10.0.0.1` when no resource file is selected.
- Generated `sysName` values gain the same slug as a suffix and are fully lowercased: `CORE-RTR-01` → `core-rtr-01-cisco-catalyst-9500`.
- Rationale: makes the device type visible in the API/UI/SNMP without a separate lookup.

## Breaking change
Device IDs no longer carry the `device-` prefix. External tooling that parses or constructs IDs like `device-<ip>` must be updated. The bundled web UI treats the ID as an opaque string and is unaffected.

## Implementation
- `slugifyDeviceType()` in `names.go` — strips `.json`, replaces `_`→`-`, lowercases.
- `makeDeviceID()` in `device.go` — composes `<ip>-<slug>` (or just `<ip>` when the slug is empty).
- `getRandomDeviceName()` now takes a `typeSlug` parameter and always returns lowercase.
- Sequential and parallel device-creation paths select resources before constructing the device ID so the slug is available at both sites.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` (simulator + integration) passes
- [ ] Manual: boot the simulator with `-auto-start-ip` and a single `-resource` file, confirm device ID and SNMP `sysName` contain the slug
- [ ] Manual: boot with `-round-robin` across categories, confirm each device's ID / sysName reflects its assigned type