### PR TITLE
feat(flow): bind per-device UDP socket so exporter IP matches device IP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ sudo ./simulator [flags]
 -flow-active-timeout <duration>   # Active flow expiry timeout (default: 5m)
 -flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 1m)
 -flow-template-interval <dur>     # Re-send template every N ticks (default: 10m)
+-flow-source-per-device           # Bind per-device UDP socket so src IP = device IP (default: true; requires ns route to collector — see issue #36)
 
 # Tests
 cd go

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -268,6 +268,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 				flowProfile := GetFlowProfile(deviceResourceFile)
 				device.flowExporter = NewFlowExporter(device, flowProfile,
 					sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
+				sm.openFlowConnForDevice(device)
 			}
 
 			// Cache the dynamic values using atomic for lock-free access
@@ -498,6 +499,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 		flowProfile := GetFlowProfile(resourceFile)
 		device.flowExporter = NewFlowExporter(device, flowProfile,
 			sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
+		sm.openFlowConnForDevice(device)
 	}
 
 	// Cache the dynamic values using atomic for lock-free access
@@ -631,6 +633,10 @@ func (d *DeviceSimulator) Stop() error {
 		}
 	}
 
+	if d.flowExporter != nil {
+		d.flowExporter.Close() //nolint:errcheck
+	}
+
 	// Only destroy TUN interface if it's not pre-allocated and not part of bulk deletion
 	// Individual device stops will close the file descriptor but not delete the interface
 	// Bulk deletion handles the actual interface removal
@@ -666,6 +672,9 @@ func (d *DeviceSimulator) stopListenersOnly() {
 	}
 	if d.apiServer != nil {
 		d.apiServer.Stop()
+	}
+	if d.flowExporter != nil {
+		d.flowExporter.Close() //nolint:errcheck
 	}
 	if d.tunIface != nil {
 		d.tunIface.destroy() // Close FD only, no ip link delete

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -53,6 +53,12 @@ type FlowTickStats struct {
 // FlowExporter is owned by one DeviceSimulator. It ties the FlowCache and
 // encoder together and is driven by the shared SimulatorManager ticker goroutine.
 // It has no goroutines of its own — see SimulatorManager.startFlowTicker.
+//
+// The optional per-device conn (set by the device lifecycle when
+// flowSourcePerDevice is enabled) lets each exporter send UDP packets with
+// a source IP matching the simulated device, so collectors like OpenNMS
+// Telemetryd can attribute flows to the correct node. When conn is nil,
+// Tick falls back to the shared SimulatorManager socket.
 type FlowExporter struct {
 	cache            *FlowCache
 	profile          *FlowProfile
@@ -62,6 +68,7 @@ type FlowExporter struct {
 	startTime        time.Time     // reference point for SysUptime
 	lastTempl        time.Time     // last template transmission time
 	templateInterval time.Duration
+	conn             *net.UDPConn  // per-device UDP socket; nil = use shared conn
 }
 
 // NewFlowExporter creates a FlowExporter for device, using profile to drive
@@ -82,9 +89,24 @@ func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeou
 	}
 }
 
+// Close releases the per-device UDP socket, if one was opened. Safe to call
+// on a nil or already-closed FlowExporter; safe to call multiple times.
+func (fe *FlowExporter) Close() error {
+	if fe == nil || fe.conn == nil {
+		return nil
+	}
+	err := fe.conn.Close()
+	fe.conn = nil
+	return err
+}
+
 // Tick is called by the shared SimulatorManager ticker goroutine on every
 // flowTickInterval. It replenishes the flow cache to ConcurrentFlows, expires
 // aged records, and emits one or more UDP datagrams to collectorAddr.
+//
+// When fe.conn is non-nil (per-device mode) it is used for the WriteTo; the
+// passed-in conn is the shared fallback used when the per-device socket
+// could not be opened or per-device mode is disabled.
 //
 // bufPool must supply []byte slices of at least 1500 bytes.
 // Write errors are ignored (best-effort delivery; collector may be down).
@@ -93,6 +115,17 @@ func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeou
 func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPConn, collectorAddr *net.UDPAddr, bufPool *sync.Pool) FlowTickStats {
 	uptimeMs := uint32(now.Sub(fe.startTime).Milliseconds())
 	deviceIP := domainIDtoIP(fe.domainID)
+
+	// Prefer the per-device socket (source IP = device IP) when set; fall back
+	// to the shared SimulatorManager socket so callers that don't use
+	// per-device binding (tests, ns-disabled deployments) still work.
+	writeConn := fe.conn
+	if writeConn == nil {
+		writeConn = conn
+	}
+	if writeConn == nil {
+		return FlowTickStats{}
+	}
 
 	// Replenish cache to the configured ConcurrentFlows level.
 	fe.cache.GenerateFlows(fe.profile, deviceIP, fe.rng, now, uptimeMs)
@@ -141,7 +174,7 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 			break
 		}
 
-		conn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
+		writeConn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
 		stats.PacketsSent++
 		stats.BytesSent += uint64(n)
 		stats.RecordsSent += uint64(len(batch))
@@ -159,6 +192,41 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 	return stats
 }
 
+// SetFlowSourcePerDevice toggles per-device UDP source IP binding. When true,
+// each device opens its own UDP socket inside the opensim namespace bound to
+// the device's IP, so collectors see per-device exporter IPs rather than the
+// container host IP. Must be called before InitFlowExport.
+func (sm *SimulatorManager) SetFlowSourcePerDevice(enabled bool) {
+	sm.flowSourcePerDevice = enabled
+}
+
+// openFlowConnForDevice opens a per-device UDP socket bound to the device's
+// IP (ephemeral source port) and assigns it to device.flowExporter.conn.
+// Silently falls through to the shared socket when:
+//   - per-device mode is disabled,
+//   - namespace isolation is off (device.netNamespace == nil),
+//   - or the bind fails (typically because the opensim ns has no route to
+//     the collector — see issue #36).
+//
+// Best-effort: a failed per-device bind logs once and the exporter keeps
+// working via the shared socket.
+func (sm *SimulatorManager) openFlowConnForDevice(device *DeviceSimulator) {
+	if !sm.flowSourcePerDevice || device.flowExporter == nil {
+		return
+	}
+	if device.netNamespace == nil {
+		return
+	}
+	addr := &net.UDPAddr{IP: device.IP, Port: 0}
+	conn, err := device.netNamespace.ListenUDPInNamespace(addr)
+	if err != nil {
+		log.Printf("flow export: device %s per-device bind failed, falling back to shared socket: %v", device.IP, err)
+		return
+	}
+	conn.SetWriteBuffer(65536)
+	device.flowExporter.conn = conn
+}
+
 // domainIDtoIP converts a uint32 ObservationDomainID back to a net.IP.
 func domainIDtoIP(id uint32) net.IP {
 	ip := make(net.IP, 4)
@@ -171,6 +239,8 @@ func domainIDtoIP(id uint32) net.IP {
 //
 // collectorAddr is "host:port" (e.g. "192.168.1.100:2055").
 // protocol is "netflow9" (the only supported value for Phase 2).
+//
+// Call SetFlowSourcePerDevice beforehand to enable per-device source IP binding.
 func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activeTimeout, inactiveTimeout, templateInterval, tickInterval time.Duration) error {
 	if sm.flowActive.Load() {
 		return fmt.Errorf("flow export: already active; call Shutdown() before re-initializing")

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -68,7 +69,11 @@ type FlowExporter struct {
 	startTime        time.Time     // reference point for SysUptime
 	lastTempl        time.Time     // last template transmission time
 	templateInterval time.Duration
-	conn             *net.UDPConn  // per-device UDP socket; nil = use shared conn
+	// conn is the per-device UDP socket (nil = use shared conn). atomic.Pointer
+	// so Tick (ticker goroutine) and Close (device-shutdown paths) can read and
+	// clear it without racing. Callers must use Load/Store/Swap — never touch
+	// the field by address.
+	conn atomic.Pointer[net.UDPConn]
 }
 
 // NewFlowExporter creates a FlowExporter for device, using profile to drive
@@ -90,14 +95,18 @@ func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeou
 }
 
 // Close releases the per-device UDP socket, if one was opened. Safe to call
-// on a nil or already-closed FlowExporter; safe to call multiple times.
+// on a nil or already-closed FlowExporter; safe to call multiple times and
+// concurrently with Tick (Swap atomically claims the conn so only one caller
+// ever observes it non-nil).
 func (fe *FlowExporter) Close() error {
-	if fe == nil || fe.conn == nil {
+	if fe == nil {
 		return nil
 	}
-	err := fe.conn.Close()
-	fe.conn = nil
-	return err
+	conn := fe.conn.Swap(nil)
+	if conn == nil {
+		return nil
+	}
+	return conn.Close()
 }
 
 // Tick is called by the shared SimulatorManager ticker goroutine on every
@@ -119,7 +128,8 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 	// Prefer the per-device socket (source IP = device IP) when set; fall back
 	// to the shared SimulatorManager socket so callers that don't use
 	// per-device binding (tests, ns-disabled deployments) still work.
-	writeConn := fe.conn
+	// atomic Load pairs with Swap in Close — Tick never observes a torn pointer.
+	writeConn := fe.conn.Load()
 	if writeConn == nil {
 		writeConn = conn
 	}
@@ -224,7 +234,7 @@ func (sm *SimulatorManager) openFlowConnForDevice(device *DeviceSimulator) {
 		return
 	}
 	conn.SetWriteBuffer(65536)
-	device.flowExporter.conn = conn
+	device.flowExporter.conn.Store(conn)
 }
 
 // domainIDtoIP converts a uint32 ObservationDomainID back to a net.IP.

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -618,7 +618,7 @@ func TestFlowExporter_Tick_PrefersPerDeviceConn(t *testing.T) {
 
 	fe := NewFlowExporter(testDevice("10.9.9.9"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 10*time.Minute)
-	fe.conn = perDevice
+	fe.conn.Store(perDevice)
 
 	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, testPool())
 
@@ -628,6 +628,58 @@ func TestFlowExporter_Tick_PrefersPerDeviceConn(t *testing.T) {
 	}
 	if stats.PacketsSent == 0 {
 		t.Error("stats.PacketsSent == 0, want ≥1")
+	}
+}
+
+// TestFlowExporter_Tick_CloseRace drives Tick and Close concurrently to
+// catch races on fe.conn. Meant to be run under `go test -race`; without
+// atomic.Pointer the old implementation would trip the race detector here.
+func TestFlowExporter_Tick_CloseRace(t *testing.T) {
+	ln, _ := testUDPListener(t)
+	defer ln.Close()
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	fe := NewFlowExporter(testDevice("10.9.9.11"), flowProfileEdgeRouter,
+		10*time.Minute, 5*time.Minute, 10*time.Minute)
+
+	perDevice, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	fe.conn.Store(perDevice)
+
+	fallback, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP (fallback): %v", err)
+	}
+	defer fallback.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pool := testPool()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				fe.Tick(time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, pool)
+			}
+		}
+	}()
+
+	// Let Tick run for a bit, then close concurrently.
+	time.Sleep(10 * time.Millisecond)
+	if err := fe.Close(); err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+	close(stop)
+	wg.Wait()
+
+	if fe.conn.Load() != nil {
+		t.Error("fe.conn should be nil after Close")
 	}
 }
 
@@ -650,14 +702,14 @@ func TestFlowExporter_Close_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListenUDP: %v", err)
 	}
-	fe.conn = conn
+	fe.conn.Store(conn)
 	if err := fe.Close(); err != nil {
 		t.Errorf("first Close returned error: %v", err)
 	}
 	if err := fe.Close(); err != nil {
 		t.Errorf("second Close returned error: %v", err)
 	}
-	if fe.conn != nil {
+	if fe.conn.Load() != nil {
 		t.Error("fe.conn should be nil after Close")
 	}
 }

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -589,3 +589,75 @@ func TestGetFlowStatus_Enabled(t *testing.T) {
 		t.Error("LastTemplateSend is empty, want a non-empty RFC3339 timestamp")
 	}
 }
+
+// TestFlowExporter_Tick_PrefersPerDeviceConn verifies that Tick uses fe.conn
+// (the per-device socket) when set, ignoring the fallback conn parameter.
+// This underpins the per-device source-IP mode: each device's flows leave
+// via its own socket bound to the device IP.
+func TestFlowExporter_Tick_PrefersPerDeviceConn(t *testing.T) {
+	// Collector that receives the packets.
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	// Per-device socket bound to loopback — this is what Tick should use.
+	perDevice, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP (per-device): %v", err)
+	}
+	defer perDevice.Close()
+
+	// Fallback conn that we explicitly close — if Tick mistakenly uses it,
+	// WriteTo would fail and no packet would arrive. If Tick correctly
+	// prefers fe.conn, the closed fallback is never touched.
+	fallback, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP (fallback): %v", err)
+	}
+	fallback.Close()
+
+	fe := NewFlowExporter(testDevice("10.9.9.9"), flowProfileEdgeRouter,
+		10*time.Minute, 5*time.Minute, 10*time.Minute)
+	fe.conn = perDevice
+
+	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, testPool())
+
+	pkt := receivePacket(ch)
+	if pkt == nil {
+		t.Fatal("no packet received — Tick did not use per-device conn")
+	}
+	if stats.PacketsSent == 0 {
+		t.Error("stats.PacketsSent == 0, want ≥1")
+	}
+}
+
+// TestFlowExporter_Close_Idempotent verifies that Close is safe on nil and
+// repeat invocations — required because both DeviceSimulator.Stop and
+// DeviceSimulator.stopListenersOnly call Close during shutdown paths.
+func TestFlowExporter_Close_Idempotent(t *testing.T) {
+	var nilFE *FlowExporter
+	if err := nilFE.Close(); err != nil {
+		t.Errorf("Close on nil exporter returned error: %v", err)
+	}
+
+	fe := NewFlowExporter(testDevice("10.9.9.10"), flowProfileEdgeRouter,
+		time.Second, time.Second, time.Minute)
+	if err := fe.Close(); err != nil {
+		t.Errorf("Close without conn returned error: %v", err)
+	}
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	fe.conn = conn
+	if err := fe.Close(); err != nil {
+		t.Errorf("first Close returned error: %v", err)
+	}
+	if err := fe.Close(); err != nil {
+		t.Errorf("second Close returned error: %v", err)
+	}
+	if fe.conn != nil {
+		t.Error("fe.conn should be nil after Close")
+	}
+}

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -109,6 +109,7 @@ func main() {
 		flowInactiveSecs     = flag.Int("flow-inactive-timeout", 15, "Inactive flow timeout in seconds (default: 15)")
 		flowTemplateIntervalSecs = flag.Int("flow-template-interval", 60, "Template retransmission interval in seconds (default: 60)")
 		flowTickSecs         = flag.Int("flow-tick-interval", 5, "Flow ticker interval in seconds (default: 5)")
+		flowSourcePerDevice  = flag.Bool("flow-source-per-device", true, "Bind a per-device UDP socket inside the opensim namespace so flow packets use the device's IP as the source address (default: true). Requires the opensim ns to have a route to the collector; set to false to use a single shared socket from the host namespace")
 	)
 
 	flag.Parse()
@@ -181,6 +182,7 @@ func main() {
 
 	// Enable flow export if a collector address was provided.
 	if *flowCollector != "" {
+		manager.SetFlowSourcePerDevice(*flowSourcePerDevice)
 		err := manager.InitFlowExport(
 			*flowCollector,
 			*flowProtocol,

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -191,6 +191,7 @@ type SimulatorManager struct {
 	flowActiveTimeout    time.Duration
 	flowInactiveTimeout  time.Duration
 	flowTemplateInterval time.Duration
+	flowSourcePerDevice  bool // bind per-device UDP socket in opensim ns so src IP = device IP
 	flowStopCh           chan struct{}  // closed by Shutdown to stop the ticker goroutine
 	flowStopOnce         sync.Once     // ensures flowStopCh is closed exactly once
 	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before closing flowConn


### PR DESCRIPTION
## Summary

- Each `FlowExporter` can own a per-device `*net.UDPConn` bound to the simulated device's IP inside the `opensim` namespace, so collectors see per-device source IPs instead of the shared container host IP.
- New flag `-flow-source-per-device` (default `true`) toggles the behaviour; escape hatch kept for deployments whose ns can't route to the collector.
- Falls back transparently to the shared socket when namespace isolation is off or the per-device bind fails, so existing tests and `-no-namespace` deployments are unchanged.

Closes #37. Functionally blocked on #36 (opensim ns needs a default route + host-side SNAT exemption before the per-device source IP actually reaches collectors end-to-end).

## Why

Diagnosed in the lab today: `netflow-2026-04` has 300k+ flow docs from `192.0.2.134` (netsim host), but `/rest/flows/exporters` returns `[]` because Telemetryd can't match that host IP to any provisioned node. OpenNMS Flow UI shows nothing under the 10 simulated device nodes. With this change, each simulated device acts as its own exporter (matching the nodes already in the inventory).

## Design notes

- Minimal, additive: `Tick` keeps its current signature and prefers `fe.conn` when set, falls back to the shared conn otherwise.
- Reuses the existing `NetNamespace.ListenUDPInNamespace` primitive (same pattern SNMP server uses).
- Closes per-device conns in both `DeviceSimulator.Stop` and `stopListenersOnly` (fast-shutdown path).
- `SetWriteBuffer(65536)` matches the SNMP server's socket-buffer policy — avoids 30k × rmem_default kernel memory blowup at scale.

## Test plan

- [x] `go test ./...` — full suite green (darwin + `CGO_ENABLED=0 GOOS=linux go build` cross-compile)
- [x] New unit tests
  - `TestFlowExporter_Tick_PrefersPerDeviceConn` — Tick uses `fe.conn` when set, never touches the fallback
  - `TestFlowExporter_Close_Idempotent` — nil-safe, double-close-safe (both teardown paths call it)
- [ ] End-to-end lab validation — requires #36 merged first
  - 10 devices → minion → ES: confirm `host` field shows 10 distinct `10.42.0.x` IPs
  - `/rest/flows/exporters` returns per-device entries
  - OpenNMS Flow UI attributes flows to the simulated device nodes

## Related

- Epic #31 (flow export)
- Depends on #36 for end-to-end functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)