### PR TITLE
feat(netns): install FORWARD ACCEPT rule so per-device flow egress actually leaves the ns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ sudo ./simulator [flags]
 -flow-active-timeout <duration>   # Active flow expiry timeout (default: 5m)
 -flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 1m)
 -flow-template-interval <dur>     # Re-send template every N ticks (default: 10m)
--flow-source-per-device           # Bind per-device UDP socket so src IP = device IP (default: true; requires ns route to collector — see issue #36)
+-flow-source-per-device           # Bind per-device UDP socket so src IP = device IP (default: true)
 
 # Tests
 cd go
@@ -81,6 +81,7 @@ docker build --no-cache --platform=linux/amd64 -t saichler/opensim-web:latest .
 - **Buffer pool** — reduces GC pressure on SNMP request handling
 - **Shared SSH/TLS keys** across all devices — avoids per-device key generation overhead
 - **Network namespace isolation** (`opensim` namespace) — prevents systemd-networkd interference
+- **Per-device flow egress** — `setupVethPair` installs a `FORWARD -i veth-sim-host -j ACCEPT` iptables rule so that per-device flow exporters can send UDP out of the ns through the host's routing table (Docker-present hosts default FORWARD to drop). Rule is removed in `NetNamespace.Close`. The simulator image includes `iptables` for this reason. On the downstream flow collector, `rp_filter` may need to be relaxed (`net.ipv4.conf.*.rp_filter=0` or `2`) to accept packets with 10.42.0.0/16 source IPs.
 
 ### Device types
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /simulator ./simul
 
 FROM alpine:3.21
 
-RUN apk add --no-cache iproute2
+RUN apk add --no-cache iproute2 iptables
 
 WORKDIR /app
 

--- a/go/simulator/netns.go
+++ b/go/simulator/netns.go
@@ -154,9 +154,37 @@ func (ns *NetNamespace) setupVethPair() error {
 		log.Printf("Warning: failed to add default route in namespace: %v", err)
 	}
 
+	// Allow forwarding of traffic originating in the namespace. Hosts with
+	// Docker installed (common) default the FORWARD chain policy to drop, so
+	// the kernel silently drops packets leaving the ns on their way to any
+	// non-local destination — notably the flow collector when per-device
+	// source IP mode is enabled. The rule is harmless on ACCEPT-policy hosts.
+	ns.addForwardAcceptRule()
+
 	log.Printf("Veth pair configured: %s (%s) <-> %s (%s)", VETH_HOST, VETH_HOST_IP, VETH_NS, VETH_NS_IP)
 
 	return nil
+}
+
+// addForwardAcceptRule inserts a FORWARD ACCEPT rule matching traffic arriving
+// on the host side of the veth pair. Best-effort: logs on failure but does not
+// abort veth setup, since many deployments either don't need the rule (no
+// forwarded egress from the ns) or have it managed externally.
+func (ns *NetNamespace) addForwardAcceptRule() {
+	cmd := exec.Command("iptables", "-I", "FORWARD", "1", "-i", VETH_HOST, "-j", "ACCEPT")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		log.Printf("Warning: failed to install FORWARD ACCEPT rule for %s (iptables missing?): %v, output: %s",
+			VETH_HOST, err, string(output))
+		return
+	}
+	log.Printf("Installed FORWARD ACCEPT rule for %s (enables per-device egress from namespace)", VETH_HOST)
+}
+
+// removeForwardAcceptRule deletes the rule installed by addForwardAcceptRule.
+// Safe to call when the rule is absent (e.g. if the install failed) — iptables
+// simply returns non-zero and we swallow it.
+func (ns *NetNamespace) removeForwardAcceptRule() {
+	exec.Command("iptables", "-D", "FORWARD", "-i", VETH_HOST, "-j", "ACCEPT").Run()
 }
 
 // AddRouteToNamespace adds a route on the host to reach IPs inside the namespace
@@ -260,6 +288,7 @@ func (ns *NetNamespace) Close() error {
 
 	// Delete veth pair (deleting one end deletes both)
 	if ns.VethSetup {
+		ns.removeForwardAcceptRule()
 		exec.Command("ip", "link", "delete", VETH_HOST).Run()
 		ns.VethSetup = false
 	}


### PR DESCRIPTION
## Summary

- `setupVethPair` now installs `iptables -I FORWARD 1 -i veth-sim-host -j ACCEPT` after configuring the veth pair; `NetNamespace.Close` removes it before deleting the veth.
- Dockerfile adds the `iptables` package so the binary can install the rule at runtime.
- Rule is scoped to the simulator's own veth interface (`veth-sim-host`) — cannot affect unrelated traffic, harmless on hosts whose FORWARD policy is already ACCEPT.

Closes #36. Together with #38 (merged), per-device flow source IPs now actually reach the collector.

## Why

Diagnosed on the lab netsim: with PR #38 merged and `-flow-source-per-device=true`, the in-ns routing is already correct (`default via 10.254.0.1 dev veth-sim-ns`) and `rp_filter` is permissive — but Docker on the host sets `FORWARD: policy drop`, and the only ACCEPT paths in that chain are the Docker-internal chains which don't match `veth-sim-host`. So the kernel silently drops every UDP packet leaving the ns.

Confirmed with a manual `iptables -I FORWARD 1 -i veth-sim-host -j ACCEPT`:

```
# from inside opensim ns, nc -u -s 10.42.0.1 192.0.2.133 9999
$ tcpdump -n -i any 'udp and port 9999' on minion
15:11:26.941227 enp3s0 In  IP 10.42.0.1.38259 > 192.0.2.133.9999: UDP, length 10
```

Source IP `10.42.0.1` preserved all the way to the collector.

## Test plan

- [x] `go test -race ./...` — full suite green
- [x] `CGO_ENABLED=0 GOOS=linux go build ./simulator` — cross-build OK
- [x] Manual validation on lab netsim (see transcript above)
- [ ] End-to-end once a new `:rc` image publishes:
  - Redeploy netsim with the image from this PR
  - Confirm `tcpdump` at minion shows 10 distinct `10.42.0.x` source IPs
  - Confirm `/rest/flows/exporters` on OpenNMS Core returns per-device entries (instead of `[]`)
  - Confirm Flow UI attributes flows to the simulated device nodes

## Rollback

`iptables -D FORWARD -i veth-sim-host -j ACCEPT` (also runs automatically on `NetNamespace.Close`).

## Related

- Epic #31
- #38 (per-device UDP socket binding, merged) — functionally paired with this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)