### PR TITLE
feat(flow): add sFlow v5 export support with counter samples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,13 @@ sudo ./simulator [flags]
 -snmpv3-priv <proto>    # none | des | aes128
 -no-namespace           # Disable network namespace isolation
 
-# Flow export flags (NetFlow v5 / v9 / IPFIX)
+# Flow export flags (NetFlow v5 / v9 / IPFIX / sFlow v5)
 -flow-collector <host:port>       # Enable flow export to this UDP collector
--flow-protocol <proto>            # netflow9 (default) | ipfix | netflow5
+-flow-protocol <proto>            # netflow9 (default) | ipfix | netflow5 | sflow (alias: sflow5)
 -flow-tick <duration>             # How often to emit flows (default: 10s)
 -flow-active-timeout <duration>   # Active flow expiry timeout (default: 5m)
 -flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 1m)
--flow-template-interval <dur>     # Re-send template every N ticks (default: 10m; ignored under netflow5)
+-flow-template-interval <dur>     # Re-send template every N ticks (default: 10m; ignored under netflow5/sflow)
 -flow-source-per-device           # Bind per-device UDP socket so src IP = device IP (default: true)
 
 # Tests
@@ -70,7 +70,16 @@ docker build --no-cache --platform=linux/amd64 -t saichler/opensim-web:latest .
 
 **Web API:** `web.go` (route setup) + `api.go` (handlers) + `web_routes*.go` (Linux route script generation). Serves device CRUD, CSV export, system stats, and flow export status (`GET /api/v1/flows/status`).
 
-**Flow export:** `flow_exporter.go` (FlowExporter, FlowEncoder interface, SimulatorManager integration) + `netflow9.go` (NetFlow9Encoder, RFC 3954) + `ipfix.go` (IPFIXEncoder, RFC 7011) + `netflow5.go` (NetFlow5Encoder, Cisco v5: 24B header, 48B/record, IPv4-only, 30-record datagram cap, no templates). One shared UDP socket and ticker goroutine; per-device FlowExporter owns a FlowCache. Protocols: `netflow9` (20B header, 45B/record), `ipfix` (16B header, 53B/record, absolute epoch-ms timestamps), and `netflow5` (24B header, 48B/record, SysUptime-relative timestamps like v9, IPv4-only with non-IPv4 records filtered one-shot-logged, 32-bit ASNs clamped to AS_TRANS `0xFFFF`, `-flow-template-interval` is a silent no-op because v5 has no template mechanism).
+**Flow export:** `flow_exporter.go` (FlowExporter, FlowEncoder interface, SimulatorManager integration) + `netflow9.go` (NetFlow9Encoder, RFC 3954) + `ipfix.go` (IPFIXEncoder, RFC 7011) + `netflow5.go` (NetFlow5Encoder, Cisco v5: 24B header, 48B/record, IPv4-only, 30-record datagram cap, no templates) + `sflow.go` (SFlowEncoder, sFlow v5 per sflow_version_5.txt: 28B XDR datagram header, variable-length flow_sample records carrying sampled_header=IPv4+UDP/TCP synthesized from the FlowRecord 5-tuple, no template mechanism). One shared UDP socket and ticker goroutine; per-device FlowExporter owns a FlowCache. Protocols:
+
+| Protocol   | Header | Record size    | Template? | Timestamps         | IPv6 records | Notes |
+|------------|--------|----------------|-----------|--------------------|--------------|-------|
+| `netflow5` | 24B    | 48B fixed      | none      | SysUptime-relative | filtered     | 30-record datagram cap; 32-bit ASNs clamp to `0xFFFF` (AS_TRANS); `-flow-template-interval` is a silent no-op |
+| `netflow9` | 20B    | 45B fixed      | yes       | SysUptime-relative | filtered     | Single 18-field template, ID 256 |
+| `ipfix`    | 16B    | 53B fixed      | yes       | absolute epoch ms  | filtered     | Template Set ID 2, IE-based fields |
+| `sflow`    | 28B    | variable (~100B typical) | none (self-describing) | uptime + flow_sample sampling_rate | filtered (IPv4 agent only) | Synthetic sampling_rate = `10 × FlowProfile.ConcurrentFlows` (see `SyntheticSamplingRateMultiplier`); emits flow_sample (type 1) + Phase-2 counters_sample (type 2) per tick. **sFlow output is synthetic — the simulator does not observe real packet streams.** Agent identity = device IPv4; `-flow-source-per-device` makes the UDP source IP match `agent_address`. |
+
+The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-size encoders return 0 (NetFlow5/9, IPFIX), variable-length encoders (sFlow) return a worst-case per-record byte bound that `FlowExporter.Tick` uses for MTU-safe pagination.
 
 **Resource loading:** `resources.go` loads and caches the 341 JSON files at startup. Each device type directory has split JSON files for SNMP, SSH, and REST responses that are merged at load time.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A powerful, scalable network and infrastructure simulator that provides realisti
 - **Linux Server Simulation**: Comprehensive Ubuntu server with 36+ SSH commands
 - **CDP & LLDP Support**: Cisco Discovery Protocol and LLDP for network topology discovery
 - **World Cities**: Device sysLocation populated from 98 world cities datasets for realistic geographic distribution
-- **Flow Export**: Per-device NetFlow v9 (RFC 3954) and IPFIX (RFC 7011) export to any UDP collector; protocol-aware batch pagination, template refresh, and a `/api/v1/flows/status` endpoint with cumulative counters
+- **Flow Export**: Per-device NetFlow v5 (Cisco), NetFlow v9 (RFC 3954), IPFIX (RFC 7011), and sFlow v5 (sflow_version_5.txt) export to any UDP collector; protocol-aware batch pagination, template refresh (v9/IPFIX), and a `/api/v1/flows/status` endpoint with cumulative counters. sFlow output is synthesised from `FlowCache` records — the simulator does not observe real packet streams
 - **Layer 8 Integration**: Optional L8 vnet overlay with HTTPS web proxy for distributed deployment
 
 ## Quick Start
@@ -91,7 +91,7 @@ Options:
   -if-scenario int            Interface state scenario: 1=all-shutdown, 2=all-normal (default), 3=all-failure, 4=pct-failure
   -if-failure-pct int         Percentage of interfaces with oper-down (used with -if-scenario 4, 0–100, default: 10)
   -flow-collector string      Enable flow export to this UDP collector (e.g., 192.168.1.10:2055)
-  -flow-protocol string       Flow export protocol: netflow9 (default) | ipfix
+  -flow-protocol string       Flow export protocol: netflow9 (default) | ipfix | netflow5 | sflow (alias: sflow5)
   -flow-tick-interval int     Flow ticker interval in seconds (default: 5)
   -flow-active-timeout int    Active flow timeout in seconds (default: 30)
   -flow-inactive-timeout int  Inactive flow timeout in seconds (default: 15)
@@ -154,9 +154,11 @@ snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.2.2.1.8   # ifOperStatus
 snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.2.2.1.7   # ifAdminStatus
 ```
 
-## Flow Export (NetFlow v9 / IPFIX)
+## Flow Export (NetFlow v5 / v9 / IPFIX / sFlow v5)
 
-OpenSim can emit synthetic flow telemetry to any NetFlow v9 (RFC 3954) or IPFIX (RFC 7011) collector. Each simulated device generates realistic flows that reflect its role (edge router, data-center switch, firewall, etc.).
+OpenSim can emit synthetic flow telemetry to any NetFlow v5 (Cisco), NetFlow v9 (RFC 3954), IPFIX (RFC 7011), or sFlow v5 (sflow_version_5.txt) collector. Each simulated device generates realistic flows that reflect its role (edge router, data-center switch, firewall, etc.).
+
+**sFlow caveat:** sFlow is a packet-sampling protocol built for real devices that observe real traffic. OpenSim has no packet stream to sample — sFlow output is synthesised from the same `FlowCache` records the other protocols consume, re-wrapped as `FLOW_SAMPLE` records with a fixed, synthetic `sampling_rate` of `10 × FlowProfile.ConcurrentFlows`. Collectors that multiply sample rate by captured packet count to estimate link utilisation will produce plausibly-shaped numbers that do not reflect any real traffic. Use sFlow mode for collector-plumbing validation, not for link-volume benchmarks.
 
 By default (`-flow-source-per-device=true`), each device binds its own UDP socket inside the `opensim` namespace so the collector observes flow packets with the **device's IP as the source address**, not the simulator host's. This makes per-device attribution work out of the box on collectors that key on the exporter source IP (e.g. OpenNMS, Elastiflow, nfcapd). Set the flag to `false` to fall back to a single shared socket bound in the host namespace.
 
@@ -170,6 +172,10 @@ sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
 # Use IPFIX instead
 sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
   -flow-collector 192.168.1.10:4739 -flow-protocol ipfix
+
+# Use sFlow v5 (default UDP port 6343)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -flow-collector 192.168.1.10:6343 -flow-protocol sflow
 
 # Faster ticks for high-fidelity testing (integer seconds)
 sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 10 \
@@ -205,12 +211,16 @@ If the collector doesn't see flows:
 
 ### Protocol details
 
-| Protocol | Version field | Template ID | Record size | Timestamps |
-|----------|--------------|-------------|-------------|------------|
-| NetFlow v9 | `9` | FlowSet ID 0 | 45 B/record | SysUptime-relative ms (FIRST/LAST_SWITCHED) |
-| IPFIX | `10` | Set ID 2 | 53 B/record | Absolute epoch ms (IE 152/153) |
+| Protocol   | Version field | Template ID       | Record size             | Timestamps                           |
+|------------|---------------|-------------------|-------------------------|--------------------------------------|
+| NetFlow v5 | `5`           | n/a (no template) | 48 B/record (30 max)    | SysUptime-relative ms (First/Last)   |
+| NetFlow v9 | `9`           | FlowSet ID 0      | 45 B/record             | SysUptime-relative ms (FIRST/LAST_SWITCHED) |
+| IPFIX      | `10`          | Set ID 2          | 53 B/record             | Absolute epoch ms (IE 152/153)       |
+| sFlow v5   | `5` (XDR)     | n/a (self-describing) | ~100 B/record typical (variable) | uptime (ms) + `sampling_rate` per sample |
 
-Both protocols use the same 18-field template (bytes, packets, protocol, ToS, TCP flags, src/dst ports, src/dst IPv4, src/dst mask, ingress/egress interface, next-hop, src/dst AS, timestamps).
+NetFlow v5/v9 and IPFIX all use the same 18-field template (bytes, packets, protocol, ToS, TCP flags, src/dst ports, src/dst IPv4, src/dst mask, ingress/egress interface, next-hop, src/dst AS, timestamps) — v5 bakes this into a fixed 48-byte on-wire record and has no template mechanism at all, so `-flow-template-interval` is a silent no-op under both v5 and sFlow.
+
+sFlow v5 emits one `FLOW_SAMPLE` per `FlowRecord` with a `sampled_header` flow-record carrying a synthesised IPv4+UDP/TCP header derived from the 5-tuple. On every tick it also emits `COUNTERS_SAMPLE` records (Phase 2) for each interface's `if_counters`, a processor sample, and a memory sample. `sampling_rate` is fixed at `10 × FlowProfile.ConcurrentFlows` — see the caveat above.
 
 ### Flow status API
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ If the collector doesn't see flows:
 
 NetFlow v5/v9 and IPFIX all use the same 18-field template (bytes, packets, protocol, ToS, TCP flags, src/dst ports, src/dst IPv4, src/dst mask, ingress/egress interface, next-hop, src/dst AS, timestamps) — v5 bakes this into a fixed 48-byte on-wire record and has no template mechanism at all, so `-flow-template-interval` is a silent no-op under both v5 and sFlow.
 
-sFlow v5 emits one `FLOW_SAMPLE` per `FlowRecord` with a `sampled_header` flow-record carrying a synthesised IPv4+UDP/TCP header derived from the 5-tuple. On every tick it also emits `COUNTERS_SAMPLE` records (Phase 2) for each interface's `if_counters`, a processor sample, and a memory sample. `sampling_rate` is fixed at `10 × FlowProfile.ConcurrentFlows` — see the caveat above.
+sFlow v5 emits one `FLOW_SAMPLE` per `FlowRecord` with a `sampled_header` flow-record carrying a synthesised IPv4+UDP/TCP header derived from the 5-tuple. On every tick it also emits `COUNTERS_SAMPLE` records (Phase 2): one per interface carrying that interface's `if_counters` record (with `source_id = ifIndex` so collectors such as OpenNMS Telemetryd can key by ds_index), plus one device-wide sample carrying a `processor_information` record (format 1001) whose standard `total_memory` / `free_memory` fields convey the device's memory totals. `sampling_rate` is fixed at `10 × FlowProfile.ConcurrentFlows` — see the caveat above.
 
 ### Flow status API
 

--- a/go/simulator/counter_source.go
+++ b/go/simulator/counter_source.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"encoding/binary"
+	"strconv"
 	"time"
 )
 
@@ -25,11 +26,18 @@ import (
 // counter-record format tag (enterprise 0), Body is the XDR-encoded counter
 // body without the 8-byte record header.
 //
+// SourceID is the sFlow data source identifier that groups records into
+// counters_sample records on the wire:
+//   - For per-interface records (if_counters) it is the ifIndex
+//     (ds_class=0, ds_index=ifIndex encoded as 0<<24 | ifIndex).
+//   - For device-wide records (processor_information, memory etc.) it is 0.
+//
 // Protocol-specific encoding of this record into the target wire format is
 // owned by the encoder (see sflow.go EncodeCounterDatagram).
 type CounterRecord struct {
-	Format uint32
-	Body   []byte
+	Format   uint32
+	SourceID uint32
+	Body     []byte
 }
 
 // CounterSource produces CounterRecord snapshots at the given time. Sources
@@ -64,10 +72,14 @@ func NewInterfaceCounterSource(c *IfCounterCycler) *InterfaceCounterSource {
 }
 
 // Snapshot returns one if_counters CounterRecord per known interface, with
-// ifHCInOctets / ifHCOutOctets sourced from the cycler's sine-wave math. The
-// remaining fields (ifInUcastPkts etc.) are synthesized from the octet
-// counters using a coarse 500-byte average packet size — adequate for
-// collector smoke tests, not for graphing accuracy.
+// ifHCInOctets / ifHCOutOctets sourced from the cycler's sine-wave math. Each
+// record is tagged with SourceID = ifIndex so EncodeCounterDatagram emits one
+// counters_sample per interface (collectors such as OpenNMS Telemetryd key
+// if_counters by ds_index).
+//
+// The remaining if_counters fields (ifInUcastPkts etc.) are synthesized from
+// the octet counters using a coarse 500-byte average packet size — adequate
+// for collector smoke tests, not for graphing accuracy.
 func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 	if s == nil || s.cycler == nil {
 		return nil
@@ -82,8 +94,8 @@ func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 		if slot < 0 || slot >= len(s.cycler.ifSpeedBps) {
 			continue
 		}
-		inStr := s.cycler.GetHCOctets(hcInOIDPrefix + itoa(ifIndex))
-		outStr := s.cycler.GetHCOctets(hcOutOIDPrefix + itoa(ifIndex))
+		inStr := s.cycler.GetHCOctets(hcInOIDPrefix + strconv.Itoa(ifIndex))
+		outStr := s.cycler.GetHCOctets(hcOutOIDPrefix + strconv.Itoa(ifIndex))
 		inOctets := parseUintOrZero(inStr)
 		outOctets := parseUintOrZero(outStr)
 		// Synthesize packet counters from octets / 500B — coarse but
@@ -92,7 +104,11 @@ func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 		outPkts := uint32(outOctets / 500)
 
 		body := encodeIfCountersBody(uint32(ifIndex), s.cycler.ifSpeedBps[slot], inOctets, outOctets, inPkts, outPkts)
-		out = append(out, CounterRecord{Format: sflowCtrFmtGeneric, Body: body})
+		out = append(out, CounterRecord{
+			Format:   sflowCtrFmtGeneric,
+			SourceID: uint32(ifIndex),
+			Body:     body,
+		})
 	}
 	return out
 }
@@ -163,30 +179,6 @@ func encodeIfCountersBody(ifIndex uint32, speedBps, inOctets, outOctets uint64, 
 	return body
 }
 
-// itoa is a tiny helper to avoid pulling strconv into this counter path for
-// hot-loop use — the caller only passes small positive ifIndex values.
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	var buf [20]byte
-	n := len(buf)
-	neg := i < 0
-	if neg {
-		i = -i
-	}
-	for i > 0 {
-		n--
-		buf[n] = byte('0' + i%10)
-		i /= 10
-	}
-	if neg {
-		n--
-		buf[n] = '-'
-	}
-	return string(buf[n:])
-}
-
 // parseUintOrZero is tolerant of empty / malformed inputs — it returns 0
 // rather than erroring so Snapshot never blocks the tick goroutine on a
 // single malformed OID.
@@ -203,26 +195,30 @@ func parseUintOrZero(s string) uint64 {
 
 // CPUCounterSource emits a single sFlow processor_information counter record
 // per snapshot. The values are not driven from any real CPU meter — they are
-// synthesized from the device's metricsCycler so the shape looks plausible to
-// sFlow collectors (non-flat line, slowly drifting).
-type CPUCounterSource struct {
-	device *DeviceSimulator
+// synthesized constants so the shape looks plausible to sFlow collectors.
+// The standard processor_information counter already carries total_memory
+// and free_memory fields, so no separate memory counter record is needed.
+type CPUCounterSource struct{}
+
+// NewCPUCounterSource returns a per-device CPU counter source. The receiver
+// carries no device state today because values are synthetic constants; the
+// signature keeps room for MetricsCycler-driven sine-wave wiring in a
+// follow-up without changing call sites.
+func NewCPUCounterSource(_ *DeviceSimulator) *CPUCounterSource {
+	return &CPUCounterSource{}
 }
 
-// NewCPUCounterSource returns a per-device CPU counter source.
-func NewCPUCounterSource(d *DeviceSimulator) *CPUCounterSource {
-	return &CPUCounterSource{device: d}
-}
-
-// Snapshot returns a single processor_information CounterRecord. Layout
-// (simplified — the standard sFlow processor_information counter only carries
-// CPU percentage fields plus memory; real counters are surfaced via SNMP):
+// Snapshot returns a single processor_information CounterRecord. The record
+// carries device-wide counters, so SourceID is 0 (ds_class=0, ds_index=0) —
+// collectors group these under a single counters_sample per device.
 //
-//	u32 cpu_5s    (0..100)
-//	u32 cpu_1m    (0..100)
-//	u32 cpu_5m    (0..100)
-//	u64 total_memory
-//	u64 free_memory
+// Layout (sflow_version_5.txt §5.4 "processor information"):
+//
+//	u32 cpu_5s           (load 0..100)
+//	u32 cpu_1m           (load 0..100)
+//	u32 cpu_5m           (load 0..100)
+//	u64 total_memory     (bytes)
+//	u64 free_memory      (bytes)
 func (s *CPUCounterSource) Snapshot(_ time.Time) []CounterRecord {
 	body := make([]byte, 4+4+4+8+8)
 	pos := 0
@@ -236,34 +232,9 @@ func (s *CPUCounterSource) Snapshot(_ time.Time) []CounterRecord {
 	binary.BigEndian.PutUint64(body[pos:], 16*1024*1024*1024) // 16 GiB total
 	pos += 8
 	binary.BigEndian.PutUint64(body[pos:], 8*1024*1024*1024) // 8 GiB free
-	return []CounterRecord{{Format: sflowCtrFmtProcessor, Body: body}}
-}
-
-// MemoryCounterSource emits a single memory counter record per snapshot. See
-// sflowCtrFmtMemory for the format caveat — this is a simulator-local format
-// ID because sFlow v5's standard counter registry doesn't include a
-// freestanding memory type.
-type MemoryCounterSource struct {
-	device *DeviceSimulator
-}
-
-// NewMemoryCounterSource returns a per-device memory counter source.
-func NewMemoryCounterSource(d *DeviceSimulator) *MemoryCounterSource {
-	return &MemoryCounterSource{device: d}
-}
-
-// Snapshot returns one memory CounterRecord with total / used / free / cached
-// bytes. Values are synthetic constants; real memory telemetry should use
-// hrStorage via SNMP.
-func (s *MemoryCounterSource) Snapshot(_ time.Time) []CounterRecord {
-	body := make([]byte, 8*4)
-	pos := 0
-	binary.BigEndian.PutUint64(body[pos:], 16*1024*1024*1024) // total
-	pos += 8
-	binary.BigEndian.PutUint64(body[pos:], 8*1024*1024*1024) // used
-	pos += 8
-	binary.BigEndian.PutUint64(body[pos:], 8*1024*1024*1024) // free
-	pos += 8
-	binary.BigEndian.PutUint64(body[pos:], 2*1024*1024*1024) // cached
-	return []CounterRecord{{Format: sflowCtrFmtMemory, Body: body}}
+	return []CounterRecord{{
+		Format:   sflowCtrFmtProcessor,
+		SourceID: 0,
+		Body:     body,
+	}}
 }

--- a/go/simulator/counter_source.go
+++ b/go/simulator/counter_source.go
@@ -1,0 +1,269 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"time"
+)
+
+// CounterRecord is a single protocol-agnostic counter payload ready to be
+// serialised into an sFlow counters_sample flow_record. Format is the sFlow v5
+// counter-record format tag (enterprise 0), Body is the XDR-encoded counter
+// body without the 8-byte record header.
+//
+// Protocol-specific encoding of this record into the target wire format is
+// owned by the encoder (see sflow.go EncodeCounterDatagram).
+type CounterRecord struct {
+	Format uint32
+	Body   []byte
+}
+
+// CounterSource produces CounterRecord snapshots at the given time. Sources
+// are registered per-device in the device lifecycle and drained on each sFlow
+// flow-export tick when Phase 2 counter samples are enabled.
+//
+// Implementations must be safe for concurrent use — the sFlow ticker goroutine
+// calls Snapshot while SNMP queries may be touching the same underlying
+// counter state from multiple worker goroutines.
+type CounterSource interface {
+	Snapshot(t time.Time) []CounterRecord
+}
+
+// InterfaceCounterSource adapts an IfCounterCycler to the CounterSource
+// interface. It reuses the cycler's monotonic HC-octet math so the sFlow
+// if_counters record values match byte-for-byte against what SNMP returns for
+// the same device at time t. This is the spec's "byte-identical SNMP/sFlow
+// counters" requirement (flow-export-sflow Scenario
+// "InterfaceCounterSource reuses IfCounterCycler state").
+type InterfaceCounterSource struct {
+	cycler *IfCounterCycler
+}
+
+// NewInterfaceCounterSource returns an adapter that reads its counter state
+// from c. Returns nil if c is nil — callers should skip registration in that
+// case.
+func NewInterfaceCounterSource(c *IfCounterCycler) *InterfaceCounterSource {
+	if c == nil {
+		return nil
+	}
+	return &InterfaceCounterSource{cycler: c}
+}
+
+// Snapshot returns one if_counters CounterRecord per known interface, with
+// ifHCInOctets / ifHCOutOctets sourced from the cycler's sine-wave math. The
+// remaining fields (ifInUcastPkts etc.) are synthesized from the octet
+// counters using a coarse 500-byte average packet size — adequate for
+// collector smoke tests, not for graphing accuracy.
+func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
+	if s == nil || s.cycler == nil {
+		return nil
+	}
+	idxs := make([]int, 0, len(s.cycler.knownIfIndexes))
+	for i := range s.cycler.knownIfIndexes {
+		idxs = append(idxs, i)
+	}
+	out := make([]CounterRecord, 0, len(idxs))
+	for _, ifIndex := range idxs {
+		slot := ifIndex - 1
+		if slot < 0 || slot >= len(s.cycler.ifSpeedBps) {
+			continue
+		}
+		inStr := s.cycler.GetHCOctets(hcInOIDPrefix + itoa(ifIndex))
+		outStr := s.cycler.GetHCOctets(hcOutOIDPrefix + itoa(ifIndex))
+		inOctets := parseUintOrZero(inStr)
+		outOctets := parseUintOrZero(outStr)
+		// Synthesize packet counters from octets / 500B — coarse but
+		// monotonic since octets are monotonic.
+		inPkts := uint32(inOctets / 500)
+		outPkts := uint32(outOctets / 500)
+
+		body := encodeIfCountersBody(uint32(ifIndex), s.cycler.ifSpeedBps[slot], inOctets, outOctets, inPkts, outPkts)
+		out = append(out, CounterRecord{Format: sflowCtrFmtGeneric, Body: body})
+	}
+	return out
+}
+
+// encodeIfCountersBody encodes the sFlow generic-interface-counters body
+// (sflow_version_5.txt §5.4 "generic interface counters"). The structure is
+// 88 bytes fixed:
+//
+//	u32 ifIndex
+//	u32 ifType       (6 = ethernetCsmacd)
+//	u64 ifSpeed      (bps)
+//	u32 ifDirection  (1 = full-duplex)
+//	u32 ifStatus     (bit 0 = admin up, bit 1 = oper up; 3 = both up)
+//	u64 ifInOctets
+//	u32 ifInUcastPkts
+//	u32 ifInMulticastPkts
+//	u32 ifInBroadcastPkts
+//	u32 ifInDiscards
+//	u32 ifInErrors
+//	u32 ifInUnknownProtos
+//	u64 ifOutOctets
+//	u32 ifOutUcastPkts
+//	u32 ifOutMulticastPkts
+//	u32 ifOutBroadcastPkts
+//	u32 ifOutDiscards
+//	u32 ifOutErrors
+//	u32 ifPromiscuousMode
+func encodeIfCountersBody(ifIndex uint32, speedBps, inOctets, outOctets uint64, inPkts, outPkts uint32) []byte {
+	body := make([]byte, 88)
+	pos := 0
+	binary.BigEndian.PutUint32(body[pos:], ifIndex)
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 6) // ethernetCsmacd
+	pos += 4
+	binary.BigEndian.PutUint64(body[pos:], speedBps)
+	pos += 8
+	binary.BigEndian.PutUint32(body[pos:], 1) // full-duplex
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 3) // admin+oper up
+	pos += 4
+	binary.BigEndian.PutUint64(body[pos:], inOctets)
+	pos += 8
+	binary.BigEndian.PutUint32(body[pos:], inPkts)
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // multicast
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // broadcast
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // in discards
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // in errors
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // in unknown protos
+	pos += 4
+	binary.BigEndian.PutUint64(body[pos:], outOctets)
+	pos += 8
+	binary.BigEndian.PutUint32(body[pos:], outPkts)
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // out multicast
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // out broadcast
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // out discards
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // out errors
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 0) // promiscuous
+	return body
+}
+
+// itoa is a tiny helper to avoid pulling strconv into this counter path for
+// hot-loop use — the caller only passes small positive ifIndex values.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	n := len(buf)
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	for i > 0 {
+		n--
+		buf[n] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		n--
+		buf[n] = '-'
+	}
+	return string(buf[n:])
+}
+
+// parseUintOrZero is tolerant of empty / malformed inputs — it returns 0
+// rather than erroring so Snapshot never blocks the tick goroutine on a
+// single malformed OID.
+func parseUintOrZero(s string) uint64 {
+	var n uint64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + uint64(c-'0')
+	}
+	return n
+}
+
+// CPUCounterSource emits a single sFlow processor_information counter record
+// per snapshot. The values are not driven from any real CPU meter — they are
+// synthesized from the device's metricsCycler so the shape looks plausible to
+// sFlow collectors (non-flat line, slowly drifting).
+type CPUCounterSource struct {
+	device *DeviceSimulator
+}
+
+// NewCPUCounterSource returns a per-device CPU counter source.
+func NewCPUCounterSource(d *DeviceSimulator) *CPUCounterSource {
+	return &CPUCounterSource{device: d}
+}
+
+// Snapshot returns a single processor_information CounterRecord. Layout
+// (simplified — the standard sFlow processor_information counter only carries
+// CPU percentage fields plus memory; real counters are surfaced via SNMP):
+//
+//	u32 cpu_5s    (0..100)
+//	u32 cpu_1m    (0..100)
+//	u32 cpu_5m    (0..100)
+//	u64 total_memory
+//	u64 free_memory
+func (s *CPUCounterSource) Snapshot(_ time.Time) []CounterRecord {
+	body := make([]byte, 4+4+4+8+8)
+	pos := 0
+	// Synthetic 20% / 25% / 30% loads — stable across runs so tests assert.
+	binary.BigEndian.PutUint32(body[pos:], 20)
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 25)
+	pos += 4
+	binary.BigEndian.PutUint32(body[pos:], 30)
+	pos += 4
+	binary.BigEndian.PutUint64(body[pos:], 16*1024*1024*1024) // 16 GiB total
+	pos += 8
+	binary.BigEndian.PutUint64(body[pos:], 8*1024*1024*1024) // 8 GiB free
+	return []CounterRecord{{Format: sflowCtrFmtProcessor, Body: body}}
+}
+
+// MemoryCounterSource emits a single memory counter record per snapshot. See
+// sflowCtrFmtMemory for the format caveat — this is a simulator-local format
+// ID because sFlow v5's standard counter registry doesn't include a
+// freestanding memory type.
+type MemoryCounterSource struct {
+	device *DeviceSimulator
+}
+
+// NewMemoryCounterSource returns a per-device memory counter source.
+func NewMemoryCounterSource(d *DeviceSimulator) *MemoryCounterSource {
+	return &MemoryCounterSource{device: d}
+}
+
+// Snapshot returns one memory CounterRecord with total / used / free / cached
+// bytes. Values are synthetic constants; real memory telemetry should use
+// hrStorage via SNMP.
+func (s *MemoryCounterSource) Snapshot(_ time.Time) []CounterRecord {
+	body := make([]byte, 8*4)
+	pos := 0
+	binary.BigEndian.PutUint64(body[pos:], 16*1024*1024*1024) // total
+	pos += 8
+	binary.BigEndian.PutUint64(body[pos:], 8*1024*1024*1024) // used
+	pos += 8
+	binary.BigEndian.PutUint64(body[pos:], 8*1024*1024*1024) // free
+	pos += 8
+	binary.BigEndian.PutUint64(body[pos:], 2*1024*1024*1024) // cached
+	return []CounterRecord{{Format: sflowCtrFmtMemory, Body: body}}
+}

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -269,6 +269,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 				device.flowExporter = NewFlowExporter(device, flowProfile,
 					sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
 				sm.openFlowConnForDevice(device)
+				sm.registerSFlowCounterSources(device)
 			}
 
 			// Cache the dynamic values using atomic for lock-free access
@@ -500,6 +501,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 		device.flowExporter = NewFlowExporter(device, flowProfile,
 			sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
 		sm.openFlowConnForDevice(device)
+		sm.registerSFlowCounterSources(device)
 	}
 
 	// Cache the dynamic values using atomic for lock-free access

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -261,8 +261,11 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 		for len(allRecords) > 0 {
 			batch := allRecords
 			// Pick the largest batch that fits in a 1500-byte buf. Each record
-			// occupies at most sflowMaxCountersSampleSize bytes once wrapped.
-			maxBatch := (len(buf) - sflowDatagramHeaderSize - 16 /* sample hdr */) / sflowMaxCountersSampleSize
+			// occupies at most sflowMaxCountersSampleSize bytes once wrapped,
+			// and each counters_sample wrapper contributes
+			// sflowCountersSampleHeaderSize bytes of overhead on top of the
+			// datagram header.
+			maxBatch := (len(buf) - sflowDatagramHeaderSize - sflowCountersSampleHeaderSize) / sflowMaxCountersSampleSize
 			if maxBatch < 1 {
 				break
 			}
@@ -309,8 +312,10 @@ func (sm *SimulatorManager) registerSFlowCounterSources(device *DeviceSimulator)
 			sources = append(sources, s)
 		}
 	}
+	// CPUCounterSource's processor_information record already carries
+	// total_memory and free_memory — a separate memory counter source would
+	// emit a non-standard sFlow format ID that strict collectors drop.
 	sources = append(sources, NewCPUCounterSource(device))
-	sources = append(sources, NewMemoryCounterSource(device))
 	device.flowExporter.counterSources = sources
 }
 

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -27,18 +27,22 @@ import (
 	"time"
 )
 
-// FlowEncoder is the protocol-agnostic interface satisfied by all flow
-// encoders in this package (NetFlow v5, v9, IPFIX). uptimeMs is the device
-// uptime in milliseconds at export time; IPFIX encoders may use it to compute
-// absolute timestamps.
+// FlowEncoder is the protocol-agnostic interface satisfied by the NetFlow v5,
+// NetFlow v9, IPFIX, and sFlow encoders. uptimeMs is the device uptime in
+// milliseconds at export time; IPFIX encoders may use it to compute absolute
+// timestamps.
 type FlowEncoder interface {
 	EncodePacket(domainID uint32, seqNo uint32, uptimeMs uint32,
 		records []FlowRecord, includeTemplate bool, buf []byte) (int, error)
 	// PacketSizes returns the three per-packet size constants that Tick() needs
-	// to compute batch capacity correctly for each protocol:
+	// to compute batch capacity correctly for fixed-size record protocols:
 	//   baseOverhead — message/packet header + data-set/flowset header (bytes)
 	//   templateSize — template set/flowset byte length
 	//   recordSize   — bytes per flow record on the wire
+	//
+	// For encoders that produce variable-length records (e.g. sFlow), recordSize
+	// is advisory — Tick() consults MaxRecordSize() to pick a safe worst-case
+	// paginator bound instead of dividing buffer space by recordSize.
 	PacketSizes() (baseOverhead int, templateSize int, recordSize int)
 	// SeqIncrement returns how much to advance the flow-sequence counter after
 	// a packet carrying packetRecordCount data records. NetFlow v9 and IPFIX
@@ -47,6 +51,11 @@ type FlowEncoder interface {
 	// because Cisco v5 defines flow_sequence as the cumulative count of
 	// records, not packets.
 	SeqIncrement(packetRecordCount int) int
+	// MaxRecordSize returns the worst-case on-wire byte size of a single record
+	// for variable-length protocols. Fixed-size encoders (NetFlow v5 / v9,
+	// IPFIX) return 0 and keep the existing PacketSizes()-driven pagination.
+	// A non-zero return opts into variable-length pagination in Tick().
+	MaxRecordSize() int
 }
 
 // FlowTickStats holds per-tick export counters returned by Tick.
@@ -82,6 +91,11 @@ type FlowExporter struct {
 	// clear it without racing. Callers must use Load/Store/Swap — never touch
 	// the field by address.
 	conn atomic.Pointer[net.UDPConn]
+	// counterSources is consulted on each sFlow tick to emit COUNTERS_SAMPLE
+	// records alongside FLOW_SAMPLEs. Written once at device init and read-only
+	// thereafter, so no locking is required for the read path in Tick.
+	// Under NetFlow/IPFIX exporters the slice is non-nil but ignored.
+	counterSources []CounterSource
 }
 
 // NewFlowExporter creates a FlowExporter for device, using profile to drive
@@ -165,15 +179,25 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 	// Capacity depends on the active encoder's protocol (NF9: 45B/record,
 	// IPFIX: 53B/record), so we ask the encoder for its sizes rather than
 	// hard-coding NF9 constants here.
+	//
+	// Variable-length encoders (sFlow) return a non-zero MaxRecordSize and we
+	// bound batches by that worst-case; fixed-size encoders return 0 and keep
+	// the original (len(buf) - overhead) / recSize division unchanged so
+	// existing NetFlow/IPFIX datagram framing is preserved byte-for-byte.
 	baseOverhead, templSize, recSize := encoder.PacketSizes()
+	maxRecSize := encoder.MaxRecordSize()
 	for {
 		overhead := baseOverhead
 		if sendTemplate {
 			overhead += templSize
 		}
 		var batch []FlowRecord
-		if len(buf) >= overhead+recSize {
-			cap := (len(buf) - overhead) / recSize
+		perRec := recSize
+		if maxRecSize > 0 {
+			perRec = maxRecSize
+		}
+		if len(buf) >= overhead+perRec {
+			cap := (len(buf) - overhead) / perRec
 			if cap >= len(expired) {
 				batch = expired
 				expired = nil
@@ -187,7 +211,20 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 			break
 		}
 
-		n, err := encoder.EncodePacket(fe.domainID, fe.seqNo, uptimeMs, batch, sendTemplate, buf)
+		var n int
+		var err error
+		if sfe, ok := encoder.(SFlowEncoder); ok {
+			// sFlow routes through EncodeFlowDatagram so sampling_rate can be
+			// derived from the device's FlowProfile — the FlowEncoder interface
+			// doesn't carry the profile, and a shared encoder can't hold state.
+			rate := uint32(fe.profile.ConcurrentFlows * SyntheticSamplingRateMultiplier)
+			if rate == 0 {
+				rate = 1
+			}
+			n, err = sfe.EncodeFlowDatagram(fe.domainID, fe.seqNo, uptimeMs, batch, rate, buf)
+		} else {
+			n, err = encoder.EncodePacket(fe.domainID, fe.seqNo, uptimeMs, batch, sendTemplate, buf)
+		}
 		if err != nil || n == 0 {
 			break
 		}
@@ -209,6 +246,43 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 			break
 		}
 	}
+
+	// Phase 2: after the flow-sample loop, sFlow emits one COUNTERS_SAMPLE
+	// datagram per tick aggregating all registered CounterSources. Each source's
+	// Snapshot is called once; records are concatenated into a single datagram
+	// bounded by sflowMaxCountersSampleSize * recordCount. Datagrams that would
+	// exceed the buffer are split — EncodeCounterDatagram is called repeatedly
+	// with remaining records until the batch is drained.
+	if sfe, ok := encoder.(SFlowEncoder); ok && len(fe.counterSources) > 0 {
+		var allRecords []CounterRecord
+		for _, src := range fe.counterSources {
+			allRecords = append(allRecords, src.Snapshot(now)...)
+		}
+		for len(allRecords) > 0 {
+			batch := allRecords
+			// Pick the largest batch that fits in a 1500-byte buf. Each record
+			// occupies at most sflowMaxCountersSampleSize bytes once wrapped.
+			maxBatch := (len(buf) - sflowDatagramHeaderSize - 16 /* sample hdr */) / sflowMaxCountersSampleSize
+			if maxBatch < 1 {
+				break
+			}
+			if len(batch) > maxBatch {
+				batch = batch[:maxBatch]
+				allRecords = allRecords[maxBatch:]
+			} else {
+				allRecords = nil
+			}
+			n, err := sfe.EncodeCounterDatagram(fe.domainID, fe.seqNo, uptimeMs, batch, buf)
+			if err != nil || n == 0 {
+				break
+			}
+			writeConn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
+			stats.PacketsSent++
+			stats.BytesSent += uint64(n)
+			fe.seqNo++
+		}
+	}
+
 	return stats
 }
 
@@ -218,6 +292,26 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 // container host IP. Must be called before InitFlowExport.
 func (sm *SimulatorManager) SetFlowSourcePerDevice(enabled bool) {
 	sm.flowSourcePerDevice = enabled
+}
+
+// registerSFlowCounterSources wires per-device CounterSource instances onto
+// the FlowExporter, but only when the active protocol is sFlow. Under
+// NetFlow/IPFIX/NF5 the sources are never consulted, so skipping registration
+// avoids per-device allocations for the 30,000+ device workloads this
+// simulator is built for.
+func (sm *SimulatorManager) registerSFlowCounterSources(device *DeviceSimulator) {
+	if sm.flowProtocol != "sflow" || device.flowExporter == nil {
+		return
+	}
+	var sources []CounterSource
+	if device.metricsCycler != nil && device.metricsCycler.ifCounters != nil {
+		if s := NewInterfaceCounterSource(device.metricsCycler.ifCounters); s != nil {
+			sources = append(sources, s)
+		}
+	}
+	sources = append(sources, NewCPUCounterSource(device))
+	sources = append(sources, NewMemoryCounterSource(device))
+	device.flowExporter.counterSources = sources
 }
 
 // openFlowConnForDevice opens a per-device UDP socket bound to the device's
@@ -240,7 +334,11 @@ func (sm *SimulatorManager) openFlowConnForDevice(device *DeviceSimulator) {
 	addr := &net.UDPAddr{IP: device.IP, Port: 0}
 	conn, err := device.netNamespace.ListenUDPInNamespace(addr)
 	if err != nil {
-		log.Printf("flow export: device %s per-device bind failed, falling back to shared socket: %v", device.IP, err)
+		if sm.flowProtocol == "sflow" {
+			log.Printf("flow export: device %s per-device bind failed, falling back to shared socket: %v (sFlow agent_address may not match UDP source IP observed by collector)", device.IP, err)
+		} else {
+			log.Printf("flow export: device %s per-device bind failed, falling back to shared socket: %v", device.IP, err)
+		}
 		return
 	}
 	conn.SetWriteBuffer(65536)
@@ -289,9 +387,12 @@ func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activ
 	case "netflow5", "nf5":
 		enc = &NetFlow5Encoder{}
 		canonicalProtocol = "netflow5"
+	case "sflow", "sflow5":
+		enc = SFlowEncoder{}
+		canonicalProtocol = "sflow"
 	default:
 		conn.Close()
-		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9, ipfix, netflow5)", protocol)
+		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9, ipfix, netflow5, sflow)", protocol)
 	}
 
 	sm.flowConn = conn

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -683,6 +683,56 @@ func TestFlowExporter_Tick_CloseRace(t *testing.T) {
 	}
 }
 
+// TestInitFlowExport_UnknownProtocol verifies that the default-case error
+// message lists all supported protocols including sflow. This is the
+// assertion point for the spec scenario "Unknown protocol is rejected with
+// updated error message".
+func TestInitFlowExport_UnknownProtocol(t *testing.T) {
+	sm := NewSimulatorManagerWithOptions(false)
+	err := sm.InitFlowExport("127.0.0.1:65530", "nonexistent", time.Second, time.Second, time.Minute, time.Second)
+	if err == nil {
+		t.Fatal("expected error for unknown protocol, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"netflow9", "ipfix", "sflow"} {
+		if !contains(msg, want) {
+			t.Errorf("error message %q missing substring %q", msg, want)
+		}
+	}
+}
+
+// TestInitFlowExport_SFlowCanonicalized verifies both sflow and sflow5 select
+// the sFlow encoder and canonicalize to "sflow" in GetFlowStatus.
+func TestInitFlowExport_SFlowCanonicalized(t *testing.T) {
+	for _, alias := range []string{"sflow", "sflow5", "SFLOW", "SFlow5"} {
+		sm := NewSimulatorManagerWithOptions(false)
+		err := sm.InitFlowExport("127.0.0.1:65531", alias, time.Second, time.Second, time.Minute, time.Hour)
+		if err != nil {
+			t.Errorf("alias %q: InitFlowExport returned error: %v", alias, err)
+			continue
+		}
+		status := sm.GetFlowStatus()
+		if status.Protocol != "sflow" {
+			t.Errorf("alias %q: Protocol = %q, want \"sflow\" (canonical)", alias, status.Protocol)
+		}
+		_ = sm.Shutdown()
+	}
+}
+
+// contains is a tiny stand-in for strings.Contains to avoid growing this test
+// file's import list for a single use.
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // TestFlowExporter_Close_Idempotent verifies that Close is safe on nil and
 // repeat invocations — required because both DeviceSimulator.Stop and
 // DeviceSimulator.stopListenersOnly call Close during shutdown paths.

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -16,6 +16,8 @@
 package main
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"net"
 	"sync"
 	"testing"
@@ -731,6 +733,213 @@ func contains(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+// ── Byte-identity regression tests (PR #47 review fix #2) ────────────────────
+//
+// These tests guard against regressions in the NetFlow9 / IPFIX / NetFlow5
+// wire output after the `MaxRecordSize()` + `SeqIncrement()` FlowEncoder
+// interface extensions. The fixed-size encoders must continue to emit the
+// exact same byte layout they did before the extensions landed.
+//
+// The tests encode a canned FlowRecord slice with pinned inputs (domainID,
+// seqNo, uptimeMs), then zero out the two wall-clock timestamp fields that
+// legitimately vary between runs (unix_secs for NF9/NF5, export_time for
+// IPFIX, plus unix_nsecs for NF5) and hash the rest. Any change to the
+// structural wire layout — field order, sizes, padding, template content —
+// flips the hash.
+//
+// If a legitimate change bumps the layout, update the pinned hash below;
+// the point is that the change is visible and reviewed, not silent.
+
+// canonicalFlowRecords returns the canned FlowRecord slice used by every
+// byte-identity test. Keep this stable — pinned hashes depend on it.
+func canonicalFlowRecords() []FlowRecord {
+	return []FlowRecord{
+		{
+			SrcIP:    net.ParseIP("10.0.0.1").To4(),
+			DstIP:    net.ParseIP("10.0.0.2").To4(),
+			NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+			SrcPort:  54321,
+			DstPort:  443,
+			Protocol: 6,
+			TCPFlags: 0x18,
+			ToS:      0,
+			Bytes:    9876,
+			Packets:  7,
+			StartMs:  1000,
+			EndMs:    2500,
+			InIface:  3,
+			OutIface: 4,
+			SrcMask:  24,
+			DstMask:  24,
+		},
+		{
+			SrcIP:    net.ParseIP("10.0.0.3").To4(),
+			DstIP:    net.ParseIP("10.0.0.4").To4(),
+			NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+			SrcPort:  55555,
+			DstPort:  53,
+			Protocol: 17,
+			TCPFlags: 0,
+			ToS:      0,
+			Bytes:    128,
+			Packets:  1,
+			StartMs:  2000,
+			EndMs:    2100,
+			InIface:  5,
+			OutIface: 6,
+			SrcMask:  24,
+			DstMask:  24,
+		},
+	}
+}
+
+// zeroBytes sets buf[start:start+count] to zero. Used to mask wall-clock
+// fields before hashing.
+func zeroBytes(buf []byte, start, count int) {
+	for i := start; i < start+count && i < len(buf); i++ {
+		buf[i] = 0
+	}
+}
+
+// TestByteIdentity_NetFlow9 pins the structural (non-wall-clock) bytes of a
+// NetFlow v9 packet against an MD5 hash. NetFlow v9 header layout:
+//
+//	u16 version (=9)       // 0..2
+//	u16 count              // 2..4
+//	u32 uptimeMs           // 4..8   (caller-supplied, stable)
+//	u32 unix_secs          // 8..12  (wall clock — masked)
+//	u32 seqNo              // 12..16 (caller-supplied, stable)
+//	u32 domainID           // 16..20 (caller-supplied, stable)
+func TestByteIdentity_NetFlow9(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(0x0A000001, 42, 5000, canonicalFlowRecords(), true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket: %v", err)
+	}
+	out := append([]byte(nil), buf[:n]...)
+	// Mask unix_secs at offset 8 (4 bytes).
+	zeroBytes(out, 8, 4)
+
+	const wantHash = "db530ac552b2a47f7a27d4ef673e1598"
+	got := md5.Sum(out)
+	gotHex := hex.EncodeToString(got[:])
+	if gotHex != wantHash {
+		t.Errorf("NetFlow9 byte-identity hash mismatch:\n  got:  %s\n  want: %s\n  "+
+			"(structural bytes changed; if intentional, update wantHash — length was %d)",
+			gotHex, wantHash, n)
+	}
+}
+
+// TestByteIdentity_IPFIX pins IPFIX structural bytes. IPFIX header layout:
+//
+//	u16 version (=10)       // 0..2
+//	u16 length              // 2..4
+//	u32 export_time         // 4..8  (wall clock — masked)
+//	u32 seqNo               // 8..12 (caller-supplied, stable)
+//	u32 domainID            // 12..16
+//
+// Within data records, lastSwitched / firstSwitched are absolute epoch ms
+// computed from uptimeMs and wall-clock time. Because the test freezes
+// uptimeMs to a known value and those fields resolve relative to the *test's*
+// wall-clock, they also drift. We mask them too.
+func TestByteIdentity_IPFIX(t *testing.T) {
+	enc := IPFIXEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(0x0A000001, 42, 5000, canonicalFlowRecords(), true, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket: %v", err)
+	}
+	out := append([]byte(nil), buf[:n]...)
+
+	// Mask export_time at offset 4 (4 bytes).
+	zeroBytes(out, 4, 4)
+
+	// IPFIX records contain absolute epoch-ms timestamps (flowStartMilliseconds
+	// and flowEndMilliseconds). These are 8-byte fields positioned at the end
+	// of each 53-byte data record. With templates + header, the data record
+	// section starts at:
+	//   header(16) + templateSet(80) + dataSetHeader(4) = 100.
+	// Each record is 53 bytes; the last 16 bytes are the two 8-byte timestamps.
+	const ipfixRecStart = 100
+	const ipfixRecLen = 53
+	const tsTailBytes = 16
+	for i := 0; i < len(canonicalFlowRecords()); i++ {
+		recStart := ipfixRecStart + i*ipfixRecLen
+		zeroBytes(out, recStart+ipfixRecLen-tsTailBytes, tsTailBytes)
+	}
+
+	const wantHash = "3307363c55a2bd3d40ddca19cd4e9598"
+	got := md5.Sum(out)
+	gotHex := hex.EncodeToString(got[:])
+	if gotHex != wantHash {
+		t.Errorf("IPFIX byte-identity hash mismatch:\n  got:  %s\n  want: %s\n  "+
+			"(structural bytes changed; if intentional, update wantHash — length was %d)",
+			gotHex, wantHash, n)
+	}
+}
+
+// TestByteIdentity_NetFlow5 pins NetFlow v5 structural bytes. NF5 header:
+//
+//	u16 version (=5)         // 0..2
+//	u16 count                // 2..4
+//	u32 uptimeMs             // 4..8   (caller-supplied, stable)
+//	u32 unix_secs            // 8..12  (wall clock — masked)
+//	u32 unix_nsecs           // 12..16 (wall clock — masked)
+//	u32 seqNo                // 16..20 (caller-supplied, stable)
+//	u8  engine_type          // 20
+//	u8  engine_id            // 21
+//	u16 sampling_interval    // 22..24
+func TestByteIdentity_NetFlow5(t *testing.T) {
+	enc := &NetFlow5Encoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(0x0A000001, 42, 5000, canonicalFlowRecords(), false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket: %v", err)
+	}
+	out := append([]byte(nil), buf[:n]...)
+	// Mask unix_secs + unix_nsecs at offsets 8 and 12 (8 bytes total).
+	zeroBytes(out, 8, 8)
+
+	const wantHash = "32619195905a513bd84a1677d438587b"
+	got := md5.Sum(out)
+	gotHex := hex.EncodeToString(got[:])
+	if gotHex != wantHash {
+		t.Errorf("NetFlow5 byte-identity hash mismatch:\n  got:  %s\n  want: %s\n  "+
+			"(structural bytes changed; if intentional, update wantHash — length was %d)",
+			gotHex, wantHash, n)
+	}
+}
+
+// TestByteIdentity_NetFlow9_Deterministic is a secondary cross-check: two
+// encodes of identical inputs SHALL produce byte-identical output once the
+// wall-clock field is masked. Catches any accidental non-deterministic
+// behaviour in the encoder that the pinned-hash tests might mask by updating.
+func TestByteIdentity_NetFlow9_Deterministic(t *testing.T) {
+	enc := NetFlow9Encoder{}
+	buf1 := make([]byte, 1500)
+	buf2 := make([]byte, 1500)
+	recs := canonicalFlowRecords()
+	n1, err := enc.EncodePacket(0x0A000001, 42, 5000, recs, true, buf1)
+	if err != nil {
+		t.Fatalf("encode 1: %v", err)
+	}
+	n2, err := enc.EncodePacket(0x0A000001, 42, 5000, recs, true, buf2)
+	if err != nil {
+		t.Fatalf("encode 2: %v", err)
+	}
+	if n1 != n2 {
+		t.Fatalf("encode lengths differ: %d vs %d", n1, n2)
+	}
+	zeroBytes(buf1, 8, 4)
+	zeroBytes(buf2, 8, 4)
+	for i := 0; i < n1; i++ {
+		if buf1[i] != buf2[i] {
+			t.Fatalf("NetFlow9 non-deterministic at byte %d: %02x vs %02x", i, buf1[i], buf2[i])
+		}
+	}
 }
 
 // TestFlowExporter_Close_Idempotent verifies that Close is safe on nil and

--- a/go/simulator/if_counters_test.go
+++ b/go/simulator/if_counters_test.go
@@ -238,6 +238,94 @@ func TestIfCounterCycler_NoHCOIDs(t *testing.T) {
 	}
 }
 
+// TestInterfaceCounterSource_MatchesSNMPSurface is the regression gate for the
+// sFlow Phase 2 CounterSource abstraction (openspec capability flow-export-sflow,
+// "InterfaceCounterSource reuses IfCounterCycler state" scenario).
+//
+// The adapter exposes the same octet counters that ifHCInOctets / ifHCOutOctets
+// return over SNMP, so a collector reading both surfaces for the same device
+// at the same time sees identical values. Because GetHCOctets is time-driven,
+// we compare the adapter body's octets against a snapshot taken within the
+// same goroutine tick.
+func TestInterfaceCounterSource_MatchesSNMPSurface(t *testing.T) {
+	const gbps = 1_000_000_000
+	res := buildTestResources(t, []uint64{gbps, gbps, gbps})
+
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 4242)
+	if c.ifCounters == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	adapter := NewInterfaceCounterSource(c.ifCounters)
+	if adapter == nil {
+		t.Fatal("NewInterfaceCounterSource returned nil")
+	}
+	recs := adapter.Snapshot(time.Now())
+	if len(recs) != 3 {
+		t.Fatalf("Snapshot returned %d records, want 3", len(recs))
+	}
+	// Build a map of ifIndex -> decoded (in, out) octets for each adapter record.
+	decoded := make(map[uint32][2]uint64)
+	for _, r := range recs {
+		if len(r.Body) != 88 {
+			t.Fatalf("if_counters body length = %d, want 88", len(r.Body))
+		}
+		ifIdx := uint32ByBigEndian(r.Body[0:])
+		in := uint64ByBigEndian(r.Body[24:])
+		out := uint64ByBigEndian(r.Body[56:])
+		decoded[ifIdx] = [2]uint64{in, out}
+	}
+	// Read the SNMP-surface values as closely as possible to the adapter call
+	// and assert the absolute difference is within a small tolerance (the
+	// floating-point integral drifts with the time delta between the two
+	// Snapshot / GetHCOctets calls).
+	for ifIdx := uint32(1); ifIdx <= 3; ifIdx++ {
+		pair, ok := decoded[ifIdx]
+		if !ok {
+			t.Errorf("adapter missing ifIndex %d", ifIdx)
+			continue
+		}
+		inStr := c.ifCounters.GetHCOctets(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", ifIdx))
+		outStr := c.ifCounters.GetHCOctets(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", ifIdx))
+		snmpIn, _ := strconv.ParseUint(inStr, 10, 64)
+		snmpOut, _ := strconv.ParseUint(outStr, 10, 64)
+
+		// At 1 Gbps ≈ 125 MB/s, one millisecond of drift moves the counter by
+		// up to 125 KB. Allow 2 MB slack for slow CI machines.
+		const slack = uint64(2 << 20)
+		adapterIn, adapterOut := pair[0], pair[1]
+		if absDiff(adapterIn, snmpIn) > slack {
+			t.Errorf("ifIndex %d in-octets adapter=%d vs SNMP=%d differ by more than slack %d",
+				ifIdx, adapterIn, snmpIn, slack)
+		}
+		if absDiff(adapterOut, snmpOut) > slack {
+			t.Errorf("ifIndex %d out-octets adapter=%d vs SNMP=%d differ by more than slack %d",
+				ifIdx, adapterOut, snmpOut, slack)
+		}
+	}
+}
+
+// absDiff returns |a - b|.
+func absDiff(a, b uint64) uint64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+// uint32ByBigEndian and uint64ByBigEndian avoid pulling encoding/binary into
+// this test file just to parse 4- and 8-byte big-endian integers. Identical to
+// binary.BigEndian.Uint32 / Uint64 at the byte level.
+func uint32ByBigEndian(b []byte) uint32 {
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}
+
+func uint64ByBigEndian(b []byte) uint64 {
+	return uint64(b[0])<<56 | uint64(b[1])<<48 | uint64(b[2])<<40 | uint64(b[3])<<32 |
+		uint64(b[4])<<24 | uint64(b[5])<<16 | uint64(b[6])<<8 | uint64(b[7])
+}
+
 func TestIfCounterCycler_BaseIsPositive(t *testing.T) {
 	// At t≈0, counter must equal approximately base (large positive number).
 	res := buildTestResources(t, []uint64{1_000_000_000})

--- a/go/simulator/ipfix.go
+++ b/go/simulator/ipfix.go
@@ -144,6 +144,11 @@ func (IPFIXEncoder) SeqIncrement(_ int) int {
 	return 1
 }
 
+// MaxRecordSize returns 0 because IPFIX records are fixed-size under this
+// simulator's single 18-field template; Tick paginates by PacketSizes()'s
+// recordSize in that case.
+func (IPFIXEncoder) MaxRecordSize() int { return 0 }
+
 // EncodePacket serialises a complete IPFIX UDP payload into buf and returns
 // the number of bytes written.
 //

--- a/go/simulator/netflow5.go
+++ b/go/simulator/netflow5.go
@@ -76,6 +76,10 @@ func (*NetFlow5Encoder) PacketSizes() (int, int, int) {
 	return netFlow5HeaderLen, 0, netFlow5RecordLen
 }
 
+// MaxRecordSize returns 0 because NetFlow v5 records are fixed-size at 48
+// bytes on the wire; Tick paginates by PacketSizes()'s recordSize in that case.
+func (*NetFlow5Encoder) MaxRecordSize() int { return 0 }
+
 // EncodePacket serialises a complete NetFlow v5 UDP payload into buf and
 // returns the number of bytes written.
 //

--- a/go/simulator/netflow9.go
+++ b/go/simulator/netflow9.go
@@ -132,6 +132,10 @@ func (NetFlow9Encoder) SeqIncrement(_ int) int {
 	return 1
 }
 
+// MaxRecordSize returns 0 because NetFlow v9 records are fixed-size; Tick
+// paginates by PacketSizes()'s recordSize in that case.
+func (NetFlow9Encoder) MaxRecordSize() int { return 0 }
+
 // EncodePacket serialises a complete NetFlow v9 UDP payload into buf and
 // returns the number of bytes written.
 //

--- a/go/simulator/sflow.go
+++ b/go/simulator/sflow.go
@@ -1,0 +1,504 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// sFlow v5 wire constants (sflow_version_5.txt).
+const (
+	sflowVersion     = 5
+	sflowAddrTypeIP4 = 1
+
+	// Sample-type format tags (enterprise 0 = standard).
+	sflowSampleTypeFlow     = 1 // flow_sample
+	sflowSampleTypeCounters = 2 // counters_sample
+
+	// Flow-record format tags (enterprise 0).
+	sflowFlowFmtSampledHeader = 1 // sampled_header
+
+	// Counter-record format tags (enterprise 0).
+	sflowCtrFmtGeneric   = 1 // if_counters (generic interface)
+	sflowCtrFmtProcessor = 1001
+	// memoryInformation is not a standard sFlow v5 counter type. Use a
+	// simulator-local format ID under enterprise 0 reserved here so the XDR
+	// oracle round-trips it cleanly; real collectors that care about memory
+	// should observe hrStorage via SNMP. Phase 2 emits it purely so the
+	// spec's "memory_information" counter surface has a concrete on-wire
+	// representation.
+	sflowCtrFmtMemory = 4000 // simulator-local; not a standard sFlow IE
+
+	// header_protocol enum values we emit (sflow_version_5.txt §5.3).
+	sflowHdrProtoIPv4 = 11
+
+	// Datagram header on the wire, when agent_address_type is IPv4.
+	//   version(4) + address_type(4) + agent_address(4) + sub_agent_id(4)
+	//   + sequence_number(4) + uptime(4) + num_samples(4) = 28 bytes.
+	sflowDatagramHeaderSize = 28
+
+	// Conservative worst-case size for a single flow_sample carrying one
+	// sampled_header record with a synthesized IPv4+UDP/TCP packet header.
+	//   flow_sample body (8 u32) + one flow_record hdr (8B) + header body
+	//   (protocol+frame_length+stripped+length = 16B) + sampled bytes (up
+	//   to 40B for IPv4+TCP + XDR 4B padding).
+	// 32 + 8 + 16 + 44 = 100 bytes. We round up to 128 for safety.
+	sflowMaxFlowSampleSize = 128
+
+	// Conservative worst-case size for a counters_sample carrying a single
+	// if_counters record. if_counters body is 88 bytes; header + record
+	// header + body + padding gives ~128 bytes. Multiple interfaces are
+	// split across datagrams by Tick's MaxRecordSize pagination.
+	sflowMaxCountersSampleSize = 256
+
+	// SyntheticSamplingRateMultiplier is the fixed multiplier applied to
+	// FlowProfile.ConcurrentFlows when synthesizing a sampling rate for
+	// emitted FLOW_SAMPLE records. The value is documented as synthetic
+	// in README.md and CLAUDE.md — collectors that extrapolate volume from
+	// sampling_rate will produce numbers shaped like real device output
+	// but not reflective of any real traffic.
+	SyntheticSamplingRateMultiplier = 10
+)
+
+// SFlowEncoder encodes FlowRecords into sFlow v5 UDP datagrams.
+//
+// It implements the FlowEncoder interface. Unlike NetFlow/IPFIX, sFlow records
+// are variable-length and self-describing, so MaxRecordSize returns a non-zero
+// worst-case bound and PacketSizes' recordSize is advisory only — FlowExporter
+// consults MaxRecordSize to paginate.
+//
+// The encoder is stateless; agent identity, uptime, and sequence numbers are
+// passed in by Tick through FlowEncoder.EncodePacket arguments. A single
+// encoder instance is shared across all devices.
+//
+// Phase 1 emits FLOW_SAMPLE records only. Phase 2 additionally emits
+// COUNTERS_SAMPLE records for interface, CPU, and memory counters via
+// EncodeDatagram (see flow_exporter.go sFlow code path).
+type SFlowEncoder struct{}
+
+// PacketSizes returns a conservative upper bound on the datagram header and
+// per-record overhead. recordSize is advisory — MaxRecordSize drives Tick's
+// pagination for variable-length protocols.
+func (SFlowEncoder) PacketSizes() (int, int, int) {
+	return sflowDatagramHeaderSize, 0, sflowMaxFlowSampleSize
+}
+
+// MaxRecordSize returns the worst-case byte size of a single flow_sample on
+// the wire. FlowExporter.Tick uses this to bound the number of flow records
+// per datagram so no datagram exceeds the UDP buffer (1500 B).
+func (SFlowEncoder) MaxRecordSize() int { return sflowMaxFlowSampleSize }
+
+// SeqIncrement returns 1 because sFlow v5's datagram sequence_number is the
+// monotonic count of datagrams sent by this agent (sflow_version_5.txt §5.1),
+// advancing once per datagram regardless of sample count.
+func (SFlowEncoder) SeqIncrement(_ int) int { return 1 }
+
+// EncodePacket serialises an sFlow v5 UDP datagram into buf and returns the
+// number of bytes written. It emits flow samples only; counter samples are
+// handled by the Phase 2 code path through a dedicated EncodeCounterSamples
+// entry point (see flow_exporter.go).
+//
+// Parameters:
+//
+//	domainID        — device IPv4 as uint32 (agent_address on the wire).
+//	seqNo           — per-(agent,sub-agent) datagram sequence number.
+//	uptimeMs        — device uptime in milliseconds at export time.
+//	records         — flow records to wrap as sampled_header FLOW_SAMPLEs.
+//	includeTemplate — ignored under sFlow (records are self-describing).
+//	buf             — caller-supplied output buffer; must be >= 1500 bytes.
+//
+// Returns (0, nil) when records is empty. Returns an error if buf is too small
+// to hold the datagram header plus a single flow sample.
+func (SFlowEncoder) EncodePacket(
+	domainID uint32,
+	seqNo uint32,
+	uptimeMs uint32,
+	records []FlowRecord,
+	_ bool,
+	buf []byte,
+) (int, error) {
+	if len(records) == 0 {
+		return 0, nil
+	}
+	if len(buf) < sflowDatagramHeaderSize+sflowMaxFlowSampleSize {
+		return 0, fmt.Errorf("sflow: buffer too small (%d bytes), need at least %d", len(buf), sflowDatagramHeaderSize+sflowMaxFlowSampleSize)
+	}
+
+	// Cap records to what fits in the buffer using the worst-case per-record
+	// bound. The caller (FlowExporter.Tick) already paginates with MaxRecordSize,
+	// so this is defence in depth against a misconfigured buf.
+	maxRecs := (len(buf) - sflowDatagramHeaderSize) / sflowMaxFlowSampleSize
+	if maxRecs < 1 {
+		return 0, fmt.Errorf("sflow: buffer %d too small for a single flow sample", len(buf))
+	}
+	if len(records) > maxRecs {
+		records = records[:maxRecs]
+	}
+
+	pos := encodeDatagramHeader(buf, domainID, seqNo, uptimeMs, uint32(len(records)))
+
+	// Sampling rate is synthetic (see SyntheticSamplingRateMultiplier comment).
+	// FlowExporter knows the device profile; pass it through via the per-device
+	// exporter's own encoder call site (see EncodeFlowSample below). Here we
+	// derive it from profile indirection — but because EncodePacket's signature
+	// is fixed by FlowEncoder, we emit a conservative default rate of 1 when no
+	// profile is available. The device-driven code path in flow_exporter.go
+	// sFlow mode uses EncodeFlowDatagram with a profile-aware rate.
+	for _, r := range records {
+		pos = encodeFlowSample(buf, pos, r, 0, 1)
+	}
+	return pos, nil
+}
+
+// EncodeFlowDatagram is the sFlow-specific, profile-aware equivalent of
+// EncodePacket. It is called by FlowExporter.Tick when the active protocol is
+// sFlow, so the synthesized sampling_rate can reflect the device's FlowProfile
+// (rate = SyntheticSamplingRateMultiplier × profile.ConcurrentFlows).
+//
+// The FlowEncoder.EncodePacket entry point still works for out-of-tree callers
+// and tests that don't care about rate, but in-tree ticks go through here so
+// the sampling_rate matches the spec's synthetic-rate contract.
+func (SFlowEncoder) EncodeFlowDatagram(
+	domainID uint32,
+	seqNo uint32,
+	uptimeMs uint32,
+	records []FlowRecord,
+	samplingRate uint32,
+	buf []byte,
+) (int, error) {
+	if len(records) == 0 {
+		return 0, nil
+	}
+	if len(buf) < sflowDatagramHeaderSize+sflowMaxFlowSampleSize {
+		return 0, fmt.Errorf("sflow: buffer too small (%d bytes)", len(buf))
+	}
+	maxRecs := (len(buf) - sflowDatagramHeaderSize) / sflowMaxFlowSampleSize
+	if maxRecs < 1 {
+		return 0, fmt.Errorf("sflow: buffer %d too small for a single flow sample", len(buf))
+	}
+	if len(records) > maxRecs {
+		records = records[:maxRecs]
+	}
+
+	pos := encodeDatagramHeader(buf, domainID, seqNo, uptimeMs, uint32(len(records)))
+	samplePool := uint32(0)
+	for _, r := range records {
+		pos = encodeFlowSample(buf, pos, r, samplePool, samplingRate)
+		samplePool += r.Packets
+	}
+	return pos, nil
+}
+
+// encodeDatagramHeader writes the sFlow v5 datagram header into buf starting
+// at offset 0 and returns the post-header position.
+//
+// Layout (28 bytes, sflow_version_5.txt §5.1):
+//
+//	uint32 version            = 5
+//	uint32 agent_address_type = 1 (IPv4)
+//	4-byte agent_address      = device IPv4 (big-endian)
+//	uint32 sub_agent_id       = 0 (simulator always emits single-agent)
+//	uint32 sequence_number
+//	uint32 uptime             (milliseconds since agent start)
+//	uint32 num_samples
+func encodeDatagramHeader(buf []byte, agentIPv4 uint32, seqNo, uptimeMs, numSamples uint32) int {
+	binary.BigEndian.PutUint32(buf[0:], sflowVersion)
+	binary.BigEndian.PutUint32(buf[4:], sflowAddrTypeIP4)
+	binary.BigEndian.PutUint32(buf[8:], agentIPv4)
+	binary.BigEndian.PutUint32(buf[12:], 0) // sub_agent_id
+	binary.BigEndian.PutUint32(buf[16:], seqNo)
+	binary.BigEndian.PutUint32(buf[20:], uptimeMs)
+	binary.BigEndian.PutUint32(buf[24:], numSamples)
+	return sflowDatagramHeaderSize
+}
+
+// encodeFlowSample writes one flow_sample record (sample_type=1) containing a
+// single sampled_header flow_record. Returns the new position.
+//
+// We emit the compact flow_sample format (not flow_sample_expanded) because
+// the simulator's single-agent / low-ifIndex topology fits the 24-bit ds_index
+// and 31-bit input/output encoding comfortably. Collectors that don't support
+// flow_sample (OpenNMS Telemetryd does) can be addressed in a follow-up by
+// switching to flow_sample_expanded (format 3).
+//
+// Layout of sample_data for flow_sample (sflow_version_5.txt §5.3):
+//
+//	u32 sample_length       (bytes of body that follow; filled in last)
+//	u32 sequence_number     (per-instance; we use domain seqNo for simplicity)
+//	u32 source_id           (ds_class<<24 | ds_index; we emit 0 for interface 0)
+//	u32 sampling_rate
+//	u32 sample_pool
+//	u32 drops
+//	u32 input               (ifIndex of ingress)
+//	u32 output              (ifIndex of egress)
+//	u32 num_flow_records    (= 1 — one sampled_header)
+//	...flow_records...
+func encodeFlowSample(buf []byte, pos int, r FlowRecord, samplePool, samplingRate uint32) int {
+	// sample_type + sample_length header: uint32 sample_type, uint32 length.
+	// The length is filled in after encoding the body so we can walk variable
+	// records without a second pass for counter-sample cases.
+	binary.BigEndian.PutUint32(buf[pos:], sflowSampleTypeFlow)
+	sampleLenOffset := pos + 4
+	// length placeholder
+	binary.BigEndian.PutUint32(buf[sampleLenOffset:], 0)
+	bodyStart := pos + 8
+	p := bodyStart
+
+	// flow_sample body — 8 u32 fields then the flow_records array.
+	binary.BigEndian.PutUint32(buf[p:], 0) // sequence_number (local; 0 is valid)
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], uint32(r.InIface)) // source_id = ds_class(0)<<24 | ds_index
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], samplingRate)
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], samplePool)
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], 0) // drops
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], uint32(r.InIface))
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], uint32(r.OutIface))
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], 1) // num_flow_records
+	p += 4
+
+	p = encodeSampledHeader(buf, p, r)
+
+	// Fill in sample_length (body bytes, not including the sample_type/length
+	// header itself).
+	binary.BigEndian.PutUint32(buf[sampleLenOffset:], uint32(p-bodyStart))
+	return p
+}
+
+// encodeSampledHeader writes one sampled_header flow_record (format=1) with a
+// synthesized IPv4+UDP (or IPv4+TCP) packet header derived from r's 5-tuple.
+// Returns the new position.
+//
+// Layout (sflow_version_5.txt §5.3 "sampled_header"):
+//
+//	u32 flow_record_format = 1 (sampled_header)
+//	u32 flow_record_length (bytes of body; filled last)
+//	u32 header_protocol    = 11 (IPv4) — we skip L2 framing
+//	u32 frame_length       (original "on-wire" packet length; we use r.Bytes
+//	                        clamped to uint32, or a synthesized per-packet size)
+//	u32 stripped           = 0
+//	opaque header<>        — XDR opaque: u32 length then header bytes then
+//	                        zero-padding to 4-byte boundary.
+func encodeSampledHeader(buf []byte, pos int, r FlowRecord) int {
+	// flow_record header: format + length placeholder.
+	binary.BigEndian.PutUint32(buf[pos:], sflowFlowFmtSampledHeader)
+	lenOffset := pos + 4
+	binary.BigEndian.PutUint32(buf[lenOffset:], 0)
+	bodyStart := pos + 8
+	p := bodyStart
+
+	binary.BigEndian.PutUint32(buf[p:], sflowHdrProtoIPv4)
+	p += 4
+
+	// frame_length: clamp the flow's total octets to uint32 and reuse as the
+	// "original packet length". This is synthetic — real sampled_header frames
+	// carry the length of the single captured packet, not a flow-wide total.
+	frameLen := r.Bytes
+	if frameLen > 0xFFFFFFFF {
+		frameLen = 0xFFFFFFFF
+	}
+	if frameLen == 0 {
+		frameLen = 20 + 8 // minimal IPv4+UDP synthesized header below
+	}
+	binary.BigEndian.PutUint32(buf[p:], uint32(frameLen))
+	p += 4
+
+	binary.BigEndian.PutUint32(buf[p:], 0) // stripped bytes
+	p += 4
+
+	// opaque header<> — 4-byte length prefix, bytes, then zero pad to 4B.
+	headerStart := p + 4 // skip the opaque length field; fill in after.
+	hdrLen := encodeIPv4Header(buf, headerStart, r)
+	binary.BigEndian.PutUint32(buf[p:], uint32(hdrLen))
+	p = headerStart + hdrLen
+	// Pad header bytes to 4-byte boundary.
+	if rem := hdrLen % 4; rem != 0 {
+		padBytes := 4 - rem
+		for i := 0; i < padBytes; i++ {
+			buf[p] = 0
+			p++
+		}
+	}
+
+	// Fill in flow_record_length (bytes of body that follow the length field).
+	binary.BigEndian.PutUint32(buf[lenOffset:], uint32(p-bodyStart))
+	return p
+}
+
+// encodeIPv4Header writes a minimal synthetic IPv4 header followed by a bare
+// UDP or TCP transport header into buf at pos and returns the number of bytes
+// written.
+//
+// For protocols other than TCP/UDP (e.g. ICMP) only the IPv4 header is written.
+// This matches the spec's sampled_header expectation of a parseable IPv4 packet
+// while keeping the synthetic payload minimal.
+func encodeIPv4Header(buf []byte, pos int, r FlowRecord) int {
+	start := pos
+
+	src := r.SrcIP.To4()
+	if src == nil {
+		src = []byte{0, 0, 0, 0}
+	}
+	dst := r.DstIP.To4()
+	if dst == nil {
+		dst = []byte{0, 0, 0, 0}
+	}
+
+	// IPv4 header (20 bytes, no options).
+	buf[pos] = 0x45 // version 4, ihl 5
+	pos++
+	buf[pos] = r.ToS
+	pos++
+
+	// total_length placeholder (2B) — filled after transport header.
+	totalLenOffset := pos
+	pos += 2
+
+	// identification (2B), flags+frag_offset (2B), ttl (1B), protocol (1B).
+	binary.BigEndian.PutUint16(buf[pos:], 0)
+	pos += 2
+	binary.BigEndian.PutUint16(buf[pos:], 0x4000) // DF set
+	pos += 2
+	buf[pos] = 64 // ttl
+	pos++
+	buf[pos] = r.Protocol
+	pos++
+
+	// header_checksum placeholder — 0, not computed (synthetic header).
+	binary.BigEndian.PutUint16(buf[pos:], 0)
+	pos += 2
+
+	copy(buf[pos:], src)
+	pos += 4
+	copy(buf[pos:], dst)
+	pos += 4
+
+	// Transport header.
+	switch r.Protocol {
+	case 17: // UDP (8 bytes)
+		binary.BigEndian.PutUint16(buf[pos:], r.SrcPort)
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], r.DstPort)
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], 8) // UDP length (header-only)
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], 0) // checksum (0 = unused for IPv4 UDP)
+		pos += 2
+	case 6: // TCP (20 bytes, no options)
+		binary.BigEndian.PutUint16(buf[pos:], r.SrcPort)
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], r.DstPort)
+		pos += 2
+		binary.BigEndian.PutUint32(buf[pos:], 0) // seq
+		pos += 4
+		binary.BigEndian.PutUint32(buf[pos:], 0) // ack
+		pos += 4
+		buf[pos] = 0x50 // data offset 5<<4, reserved 0
+		pos++
+		buf[pos] = r.TCPFlags
+		pos++
+		binary.BigEndian.PutUint16(buf[pos:], 0xFFFF) // window
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], 0) // checksum (synthetic header)
+		pos += 2
+		binary.BigEndian.PutUint16(buf[pos:], 0) // urgent
+		pos += 2
+	}
+
+	total := pos - start
+	binary.BigEndian.PutUint16(buf[totalLenOffset:], uint16(total))
+	return total
+}
+
+// EncodeCounterDatagram writes an sFlow v5 datagram containing one or more
+// counters_sample records sourced from the provided CounterRecord slices.
+//
+// The caller is expected to have already bounded the number of records so the
+// datagram fits in a single UDP buffer. Returns (0, nil) on empty input.
+func (SFlowEncoder) EncodeCounterDatagram(
+	domainID uint32,
+	seqNo uint32,
+	uptimeMs uint32,
+	records []CounterRecord,
+	buf []byte,
+) (int, error) {
+	if len(records) == 0 {
+		return 0, nil
+	}
+	if len(buf) < sflowDatagramHeaderSize+sflowMaxCountersSampleSize {
+		return 0, fmt.Errorf("sflow: buffer too small for counter sample (%d bytes)", len(buf))
+	}
+
+	pos := encodeDatagramHeader(buf, domainID, seqNo, uptimeMs, 1)
+
+	// Single counters_sample carrying all records. Format (sample_type=2):
+	//   u32 sample_length (fill in last)
+	//   u32 sequence_number
+	//   u32 source_id
+	//   u32 num_counter_records
+	//   ...counter_records...
+	binary.BigEndian.PutUint32(buf[pos:], sflowSampleTypeCounters)
+	sampleLenOffset := pos + 4
+	binary.BigEndian.PutUint32(buf[sampleLenOffset:], 0)
+	bodyStart := pos + 8
+	p := bodyStart
+
+	binary.BigEndian.PutUint32(buf[p:], seqNo) // sequence_number
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], 0) // source_id (ds_class=0, ds_index=0)
+	p += 4
+	binary.BigEndian.PutUint32(buf[p:], uint32(len(records))) // num_counter_records
+	p += 4
+
+	for _, rec := range records {
+		if len(buf)-p < 8+len(rec.Body)+4 {
+			break // best-effort: skip rest rather than overflow
+		}
+		binary.BigEndian.PutUint32(buf[p:], rec.Format)
+		p += 4
+		recLenOffset := p
+		binary.BigEndian.PutUint32(buf[p:], uint32(len(rec.Body)))
+		p += 4
+		copy(buf[p:], rec.Body)
+		p += len(rec.Body)
+		// Pad to 4-byte boundary.
+		if rem := len(rec.Body) % 4; rem != 0 {
+			padBytes := 4 - rem
+			for i := 0; i < padBytes; i++ {
+				buf[p] = 0
+				p++
+			}
+		}
+		_ = recLenOffset
+	}
+
+	binary.BigEndian.PutUint32(buf[sampleLenOffset:], uint32(p-bodyStart))
+	return p, nil
+}
+
+// _ compile-time guard that SFlowEncoder satisfies FlowEncoder.
+var _ FlowEncoder = SFlowEncoder{}
+
+// sflowNowMs is a package-level time source for datagram headers. It exists
+// mainly so tests can hold uptime stable across encode calls if needed.
+func sflowNowMs() int64 { return time.Now().UnixMilli() }

--- a/go/simulator/sflow.go
+++ b/go/simulator/sflow.go
@@ -18,6 +18,7 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 	"time"
 )
 
@@ -36,13 +37,6 @@ const (
 	// Counter-record format tags (enterprise 0).
 	sflowCtrFmtGeneric   = 1 // if_counters (generic interface)
 	sflowCtrFmtProcessor = 1001
-	// memoryInformation is not a standard sFlow v5 counter type. Use a
-	// simulator-local format ID under enterprise 0 reserved here so the XDR
-	// oracle round-trips it cleanly; real collectors that care about memory
-	// should observe hrStorage via SNMP. Phase 2 emits it purely so the
-	// spec's "memory_information" counter surface has a concrete on-wire
-	// representation.
-	sflowCtrFmtMemory = 4000 // simulator-local; not a standard sFlow IE
 
 	// header_protocol enum values we emit (sflow_version_5.txt §5.3).
 	sflowHdrProtoIPv4 = 11
@@ -51,6 +45,13 @@ const (
 	//   version(4) + address_type(4) + agent_address(4) + sub_agent_id(4)
 	//   + sequence_number(4) + uptime(4) + num_samples(4) = 28 bytes.
 	sflowDatagramHeaderSize = 28
+
+	// sflowCountersSampleHeaderSize is the on-wire byte overhead of a single
+	// counters_sample wrapper: sample_type(4) + sample_length(4) +
+	// sequence_number(4) + source_id(4) + num_counter_records(4) = 20 bytes.
+	// flow_exporter.go uses this to compute pagination capacity so the
+	// overhead arithmetic isn't an unlabelled magic number at the call site.
+	sflowCountersSampleHeaderSize = 20
 
 	// Conservative worst-case size for a single flow_sample carrying one
 	// sampled_header record with a synthesized IPv4+UDP/TCP packet header.
@@ -433,8 +434,18 @@ func encodeIPv4Header(buf []byte, pos int, r FlowRecord) int {
 // EncodeCounterDatagram writes an sFlow v5 datagram containing one or more
 // counters_sample records sourced from the provided CounterRecord slices.
 //
+// Records are grouped into counters_sample wrappers by SourceID. This matters
+// for collectors such as OpenNMS Telemetryd that key if_counters records by
+// ds_index: per-interface records (SourceID = ifIndex) appear under their own
+// counters_sample and device-wide records (SourceID = 0, e.g.
+// processor_information) appear under a separate counters_sample with
+// source_id=0. Records sharing a SourceID remain in input order within their
+// group.
+//
 // The caller is expected to have already bounded the number of records so the
-// datagram fits in a single UDP buffer. Returns (0, nil) on empty input.
+// datagram fits in a single UDP buffer. Records that would overflow the
+// buffer are dropped with a log.Printf warning so silent loss is visible.
+// Returns (0, nil) on empty input.
 func (SFlowEncoder) EncodeCounterDatagram(
 	domainID uint32,
 	seqNo uint32,
@@ -449,51 +460,111 @@ func (SFlowEncoder) EncodeCounterDatagram(
 		return 0, fmt.Errorf("sflow: buffer too small for counter sample (%d bytes)", len(buf))
 	}
 
-	pos := encodeDatagramHeader(buf, domainID, seqNo, uptimeMs, 1)
-
-	// Single counters_sample carrying all records. Format (sample_type=2):
-	//   u32 sample_length (fill in last)
-	//   u32 sequence_number
-	//   u32 source_id
-	//   u32 num_counter_records
-	//   ...counter_records...
-	binary.BigEndian.PutUint32(buf[pos:], sflowSampleTypeCounters)
-	sampleLenOffset := pos + 4
-	binary.BigEndian.PutUint32(buf[sampleLenOffset:], 0)
-	bodyStart := pos + 8
-	p := bodyStart
-
-	binary.BigEndian.PutUint32(buf[p:], seqNo) // sequence_number
-	p += 4
-	binary.BigEndian.PutUint32(buf[p:], 0) // source_id (ds_class=0, ds_index=0)
-	p += 4
-	binary.BigEndian.PutUint32(buf[p:], uint32(len(records))) // num_counter_records
-	p += 4
-
+	// Group by SourceID while preserving input order: both the order of first
+	// appearance of each SourceID and the order of records within a group.
+	groupOrder := make([]uint32, 0, 4)
+	groups := make(map[uint32][]CounterRecord, 4)
 	for _, rec := range records {
-		if len(buf)-p < 8+len(rec.Body)+4 {
-			break // best-effort: skip rest rather than overflow
+		if _, seen := groups[rec.SourceID]; !seen {
+			groupOrder = append(groupOrder, rec.SourceID)
 		}
-		binary.BigEndian.PutUint32(buf[p:], rec.Format)
-		p += 4
-		recLenOffset := p
-		binary.BigEndian.PutUint32(buf[p:], uint32(len(rec.Body)))
-		p += 4
-		copy(buf[p:], rec.Body)
-		p += len(rec.Body)
-		// Pad to 4-byte boundary.
-		if rem := len(rec.Body) % 4; rem != 0 {
-			padBytes := 4 - rem
-			for i := 0; i < padBytes; i++ {
-				buf[p] = 0
-				p++
-			}
-		}
-		_ = recLenOffset
+		groups[rec.SourceID] = append(groups[rec.SourceID], rec)
 	}
 
-	binary.BigEndian.PutUint32(buf[sampleLenOffset:], uint32(p-bodyStart))
-	return p, nil
+	// Reserve datagram-header space; num_samples is filled once the number of
+	// samples actually emitted is known (a group may be skipped if the buffer
+	// can't hold even its fixed-size header).
+	pos := sflowDatagramHeaderSize
+	dropped := 0
+	samplesEmitted := uint32(0)
+
+	for _, sourceID := range groupOrder {
+		recs := groups[sourceID]
+		// Conservative check: counters_sample wrapper itself needs 20 bytes.
+		if len(buf)-pos < sflowCountersSampleHeaderSize {
+			dropped += len(recs)
+			continue
+		}
+
+		// counters_sample header: sample_type(4) + sample_length(4).
+		// Then body: sequence_number(4) + source_id(4) + num_counter_records(4)
+		// followed by the counter_records themselves.
+		binary.BigEndian.PutUint32(buf[pos:], sflowSampleTypeCounters)
+		sampleLenOffset := pos + 4
+		binary.BigEndian.PutUint32(buf[sampleLenOffset:], 0)
+		bodyStart := pos + 8
+		p := bodyStart
+
+		binary.BigEndian.PutUint32(buf[p:], seqNo) // sequence_number
+		p += 4
+		binary.BigEndian.PutUint32(buf[p:], sourceID) // source_id (ds_class=0, ds_index=sourceID)
+		p += 4
+		// num_counter_records — placeholder; backfilled after emitting records
+		// so partial overflow shrinks the count instead of lying to the decoder.
+		numRecsOffset := p
+		binary.BigEndian.PutUint32(buf[p:], 0)
+		p += 4
+
+		emitted := uint32(0)
+		for _, rec := range recs {
+			padded := len(rec.Body)
+			if rem := padded % 4; rem != 0 {
+				padded += 4 - rem
+			}
+			// 8B record header (format + length) + padded body.
+			if len(buf)-p < 8+padded {
+				dropped++
+				continue
+			}
+			binary.BigEndian.PutUint32(buf[p:], rec.Format)
+			p += 4
+			binary.BigEndian.PutUint32(buf[p:], uint32(len(rec.Body)))
+			p += 4
+			copy(buf[p:], rec.Body)
+			p += len(rec.Body)
+			// Pad to 4-byte boundary.
+			if rem := len(rec.Body) % 4; rem != 0 {
+				padBytes := 4 - rem
+				for i := 0; i < padBytes; i++ {
+					buf[p] = 0
+					p++
+				}
+			}
+			emitted++
+		}
+
+		// Skip empty samples — if every record in this group overflowed we
+		// shouldn't emit a header with num_counter_records=0.
+		if emitted == 0 {
+			// Rewind the sample wrapper we started writing.
+			continue
+		}
+
+		// Backfill sample_length (body bytes after the sample_type/length
+		// header itself) and num_counter_records.
+		binary.BigEndian.PutUint32(buf[sampleLenOffset:], uint32(p-bodyStart))
+		binary.BigEndian.PutUint32(buf[numRecsOffset:], emitted)
+
+		pos = p
+		samplesEmitted++
+	}
+
+	if samplesEmitted == 0 {
+		// Nothing fit; surface the drop without writing a half-formed datagram.
+		if dropped > 0 {
+			log.Printf("sflow: dropping %d counter records that don't fit in datagram", dropped)
+		}
+		return 0, nil
+	}
+
+	// Backfill the datagram header — encodeDatagramHeader writes 7 u32 fields
+	// including num_samples at offset 24.
+	encodeDatagramHeader(buf, domainID, seqNo, uptimeMs, samplesEmitted)
+
+	if dropped > 0 {
+		log.Printf("sflow: dropping %d counter records that don't fit in datagram", dropped)
+	}
+	return pos, nil
 }
 
 // _ compile-time guard that SFlowEncoder satisfies FlowEncoder.

--- a/go/simulator/sflow_test.go
+++ b/go/simulator/sflow_test.go
@@ -704,3 +704,125 @@ func TestSFlowCounterDatagramMTU(t *testing.T) {
 		t.Fatal("expected at least one counter record in sample")
 	}
 }
+
+// TestSFlowCounterDatagramGroupsBySourceID verifies the PR #47 review fix for
+// counter-sample source_id grouping: collectors such as OpenNMS Telemetryd key
+// if_counters records by ds_index (ifIndex) and misattribute metrics when all
+// records are packed into a single counters_sample with source_id=0. The
+// encoder SHALL emit one counters_sample per distinct SourceID, so N per-
+// interface records plus one device-wide record (SourceID=0) yield N+1
+// samples in the datagram.
+func TestSFlowCounterDatagramGroupsBySourceID(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+
+	// Three interfaces (ifIndex 1, 2, 3) plus one device-wide processor
+	// record. Expected: 4 counters_samples with source_id = 1, 2, 3, 0.
+	recs := []CounterRecord{
+		{
+			Format:   sflowCtrFmtGeneric,
+			SourceID: 1,
+			Body:     encodeIfCountersBody(1, 1_000_000_000, 100, 200, 1, 2),
+		},
+		{
+			Format:   sflowCtrFmtGeneric,
+			SourceID: 2,
+			Body:     encodeIfCountersBody(2, 1_000_000_000, 300, 400, 3, 4),
+		},
+		{
+			Format:   sflowCtrFmtGeneric,
+			SourceID: 3,
+			Body:     encodeIfCountersBody(3, 1_000_000_000, 500, 600, 5, 6),
+		},
+		{
+			Format:   sflowCtrFmtProcessor,
+			SourceID: 0,
+			Body:     make([]byte, 28), // processor_information fixed body
+		},
+	}
+
+	n, err := enc.EncodeCounterDatagram(0x0A000001, 7, 1000, recs, buf)
+	if err != nil {
+		t.Fatalf("EncodeCounterDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+
+	if got := int(dg.Header.NumSamples); got != 4 {
+		t.Fatalf("num_samples = %d, want 4 (one per source_id, including device-wide)", got)
+	}
+	if len(dg.Samples) != 4 {
+		t.Fatalf("decoded samples = %d, want 4", len(dg.Samples))
+	}
+
+	wantSourceIDs := []uint32{1, 2, 3, 0}
+	for i, s := range dg.Samples {
+		if s.Type != sflowSampleTypeCounters {
+			t.Errorf("sample[%d] type = %d, want %d (counters_sample)", i, s.Type, sflowSampleTypeCounters)
+			continue
+		}
+		if s.CounterSmpl == nil {
+			t.Errorf("sample[%d] counter sample not decoded", i)
+			continue
+		}
+		if s.CounterSmpl.SourceID != wantSourceIDs[i] {
+			t.Errorf("sample[%d] source_id = %d, want %d", i, s.CounterSmpl.SourceID, wantSourceIDs[i])
+		}
+		if s.CounterSmpl.NumRecords != 1 {
+			t.Errorf("sample[%d] num_counter_records = %d, want 1", i, s.CounterSmpl.NumRecords)
+		}
+	}
+}
+
+// TestSFlowInterfaceCounterSource_OneSamplePerIfIndex exercises the end-to-end
+// path: InterfaceCounterSource produces one record per interface, and when
+// those records are passed through EncodeCounterDatagram the output has one
+// counters_sample per interface with source_id = ifIndex. This is the
+// spec scenario "counters_sample source_id keyed by ds_index".
+func TestSFlowInterfaceCounterSource_OneSamplePerIfIndex(t *testing.T) {
+	const gbps = 1_000_000_000
+	res := buildTestResources(t, []uint64{gbps, gbps, gbps})
+
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 9999)
+	if c.ifCounters == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	adapter := NewInterfaceCounterSource(c.ifCounters)
+	recs := adapter.Snapshot(time.Now())
+	if len(recs) != 3 {
+		t.Fatalf("Snapshot returned %d records, want 3", len(recs))
+	}
+
+	// Each adapter-produced record must carry SourceID = ifIndex (1, 2, 3).
+	gotIDs := map[uint32]bool{}
+	for _, r := range recs {
+		gotIDs[r.SourceID] = true
+	}
+	for want := uint32(1); want <= 3; want++ {
+		if !gotIDs[want] {
+			t.Errorf("adapter missing CounterRecord with SourceID=%d", want)
+		}
+	}
+
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodeCounterDatagram(0x0A000001, 1, 1000, recs, buf)
+	if err != nil {
+		t.Fatalf("EncodeCounterDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	if got := int(dg.Header.NumSamples); got != 3 {
+		t.Errorf("num_samples = %d, want 3 (one per ifIndex)", got)
+	}
+	// Every sample should be counters_sample with source_id matching an ifIndex.
+	for i, s := range dg.Samples {
+		if s.Type != sflowSampleTypeCounters {
+			t.Errorf("sample[%d] type = %d, want %d", i, s.Type, sflowSampleTypeCounters)
+			continue
+		}
+		if s.CounterSmpl.SourceID < 1 || s.CounterSmpl.SourceID > 3 {
+			t.Errorf("sample[%d] source_id = %d, want in [1,3]", i, s.CounterSmpl.SourceID)
+		}
+	}
+}

--- a/go/simulator/sflow_test.go
+++ b/go/simulator/sflow_test.go
@@ -1,0 +1,706 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// ── Inline sFlow v5 XDR decoder (test oracle) ────────────────────────────────
+//
+// Minimal parser for the subset of sFlow v5 emitted by SFlowEncoder. Validates
+// that datagrams round-trip through an independent decoder, proving we produce
+// wire-compliant XDR without introducing an external dependency.
+
+type sflowDatagramHdr struct {
+	Version     uint32
+	AddrType    uint32
+	AgentIPv4   [4]byte
+	SubAgentID  uint32
+	SequenceNo  uint32
+	Uptime      uint32
+	NumSamples  uint32
+}
+
+type sflowSampledHeader struct {
+	HeaderProtocol uint32
+	FrameLength    uint32
+	Stripped       uint32
+	Header         []byte
+}
+
+type sflowFlowRecord struct {
+	Format        uint32
+	Length        uint32
+	SampledHeader *sflowSampledHeader // populated when Format == 1
+}
+
+type sflowFlowSample struct {
+	SequenceNumber uint32
+	SourceID       uint32
+	SamplingRate   uint32
+	SamplePool     uint32
+	Drops          uint32
+	Input          uint32
+	Output         uint32
+	NumFlowRecords uint32
+	Records        []sflowFlowRecord
+}
+
+type sflowCounterRecord struct {
+	Format uint32
+	Length uint32
+	Body   []byte
+}
+
+type sflowCountersSample struct {
+	SequenceNumber uint32
+	SourceID       uint32
+	NumRecords     uint32
+	Records        []sflowCounterRecord
+}
+
+type sflowSample struct {
+	Type         uint32
+	Length       uint32
+	FlowSample   *sflowFlowSample   // populated when Type == 1
+	CounterSmpl  *sflowCountersSample // populated when Type == 2
+}
+
+type sflowDatagram struct {
+	Header  sflowDatagramHdr
+	Samples []sflowSample
+}
+
+func decodeSFlow(t *testing.T, data []byte) *sflowDatagram {
+	t.Helper()
+	if len(data) < sflowDatagramHeaderSize {
+		t.Fatalf("sflow: datagram too short: %d bytes", len(data))
+	}
+	dg := &sflowDatagram{}
+	dg.Header.Version = binary.BigEndian.Uint32(data[0:])
+	dg.Header.AddrType = binary.BigEndian.Uint32(data[4:])
+	copy(dg.Header.AgentIPv4[:], data[8:12])
+	dg.Header.SubAgentID = binary.BigEndian.Uint32(data[12:])
+	dg.Header.SequenceNo = binary.BigEndian.Uint32(data[16:])
+	dg.Header.Uptime = binary.BigEndian.Uint32(data[20:])
+	dg.Header.NumSamples = binary.BigEndian.Uint32(data[24:])
+
+	pos := sflowDatagramHeaderSize
+	for i := uint32(0); i < dg.Header.NumSamples && pos+8 <= len(data); i++ {
+		var s sflowSample
+		s.Type = binary.BigEndian.Uint32(data[pos:])
+		s.Length = binary.BigEndian.Uint32(data[pos+4:])
+		if pos+8+int(s.Length) > len(data) {
+			t.Fatalf("sflow: sample length %d overruns datagram at offset %d", s.Length, pos)
+		}
+		bodyStart := pos + 8
+		bodyEnd := bodyStart + int(s.Length)
+
+		switch s.Type {
+		case sflowSampleTypeFlow:
+			fs := decodeFlowSample(t, data[bodyStart:bodyEnd])
+			s.FlowSample = fs
+		case sflowSampleTypeCounters:
+			cs := decodeCountersSample(t, data[bodyStart:bodyEnd])
+			s.CounterSmpl = cs
+		default:
+			// Unknown sample type — skip body.
+		}
+		dg.Samples = append(dg.Samples, s)
+		pos = bodyEnd
+	}
+	return dg
+}
+
+func decodeFlowSample(t *testing.T, b []byte) *sflowFlowSample {
+	t.Helper()
+	if len(b) < 32 {
+		t.Fatalf("sflow: flow_sample body too short: %d", len(b))
+	}
+	fs := &sflowFlowSample{}
+	fs.SequenceNumber = binary.BigEndian.Uint32(b[0:])
+	fs.SourceID = binary.BigEndian.Uint32(b[4:])
+	fs.SamplingRate = binary.BigEndian.Uint32(b[8:])
+	fs.SamplePool = binary.BigEndian.Uint32(b[12:])
+	fs.Drops = binary.BigEndian.Uint32(b[16:])
+	fs.Input = binary.BigEndian.Uint32(b[20:])
+	fs.Output = binary.BigEndian.Uint32(b[24:])
+	fs.NumFlowRecords = binary.BigEndian.Uint32(b[28:])
+
+	pos := 32
+	for i := uint32(0); i < fs.NumFlowRecords && pos+8 <= len(b); i++ {
+		var fr sflowFlowRecord
+		fr.Format = binary.BigEndian.Uint32(b[pos:])
+		fr.Length = binary.BigEndian.Uint32(b[pos+4:])
+		recBodyStart := pos + 8
+		recBodyEnd := recBodyStart + int(fr.Length)
+		if recBodyEnd > len(b) {
+			t.Fatalf("sflow: flow_record length %d overruns flow_sample at offset %d", fr.Length, pos)
+		}
+		if fr.Format == sflowFlowFmtSampledHeader {
+			fr.SampledHeader = decodeSampledHeader(t, b[recBodyStart:recBodyEnd])
+		}
+		fs.Records = append(fs.Records, fr)
+		pos = recBodyEnd
+	}
+	return fs
+}
+
+func decodeSampledHeader(t *testing.T, b []byte) *sflowSampledHeader {
+	t.Helper()
+	if len(b) < 12+4 {
+		t.Fatalf("sflow: sampled_header body too short: %d", len(b))
+	}
+	sh := &sflowSampledHeader{}
+	sh.HeaderProtocol = binary.BigEndian.Uint32(b[0:])
+	sh.FrameLength = binary.BigEndian.Uint32(b[4:])
+	sh.Stripped = binary.BigEndian.Uint32(b[8:])
+	hdrLen := binary.BigEndian.Uint32(b[12:])
+	if 16+int(hdrLen) > len(b) {
+		t.Fatalf("sflow: sampled_header header length %d overruns body of len %d", hdrLen, len(b))
+	}
+	sh.Header = append([]byte{}, b[16:16+int(hdrLen)]...)
+	return sh
+}
+
+func decodeCountersSample(t *testing.T, b []byte) *sflowCountersSample {
+	t.Helper()
+	if len(b) < 12 {
+		t.Fatalf("sflow: counters_sample body too short: %d", len(b))
+	}
+	cs := &sflowCountersSample{}
+	cs.SequenceNumber = binary.BigEndian.Uint32(b[0:])
+	cs.SourceID = binary.BigEndian.Uint32(b[4:])
+	cs.NumRecords = binary.BigEndian.Uint32(b[8:])
+	pos := 12
+	for i := uint32(0); i < cs.NumRecords && pos+8 <= len(b); i++ {
+		var rec sflowCounterRecord
+		rec.Format = binary.BigEndian.Uint32(b[pos:])
+		rec.Length = binary.BigEndian.Uint32(b[pos+4:])
+		bodyStart := pos + 8
+		bodyEnd := bodyStart + int(rec.Length)
+		if bodyEnd > len(b) {
+			t.Fatalf("sflow: counter_record length %d overruns counters_sample at offset %d", rec.Length, pos)
+		}
+		rec.Body = append([]byte{}, b[bodyStart:bodyEnd]...)
+		cs.Records = append(cs.Records, rec)
+		// Skip 4-byte XDR padding for non-aligned bodies.
+		pad := (4 - (int(rec.Length) % 4)) % 4
+		pos = bodyEnd + pad
+	}
+	return cs
+}
+
+// parseIPv4 returns (srcIP, dstIP, protocol, srcPort, dstPort) extracted from
+// the first 20 bytes + transport header of a synthesized IPv4 packet emitted
+// by encodeIPv4Header.
+func parseIPv4(t *testing.T, hdr []byte) (net.IP, net.IP, uint8, uint16, uint16) {
+	t.Helper()
+	if len(hdr) < 20 {
+		t.Fatalf("parseIPv4: header too short: %d", len(hdr))
+	}
+	if hdr[0] != 0x45 {
+		t.Errorf("parseIPv4: version/ihl = %#x, want 0x45", hdr[0])
+	}
+	proto := hdr[9]
+	src := net.IP(append([]byte{}, hdr[12:16]...))
+	dst := net.IP(append([]byte{}, hdr[16:20]...))
+	var sp, dp uint16
+	switch proto {
+	case 6, 17:
+		if len(hdr) < 24 {
+			t.Fatalf("parseIPv4: transport truncated: %d", len(hdr))
+		}
+		sp = binary.BigEndian.Uint16(hdr[20:])
+		dp = binary.BigEndian.Uint16(hdr[22:])
+	}
+	return src, dst, proto, sp, dp
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestSFlowFlowEncoderInterface(t *testing.T) {
+	// Compile-time assertion: SFlowEncoder implements FlowEncoder.
+	var _ FlowEncoder = SFlowEncoder{}
+
+	enc := SFlowEncoder{}
+	if got := enc.MaxRecordSize(); got == 0 {
+		t.Errorf("SFlowEncoder.MaxRecordSize() = 0, want non-zero for variable-length opt-in")
+	}
+}
+
+func TestSFlowDatagramHeader(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	r := makeRecord("10.0.1.1", "10.0.2.2", 50000, 443, 6)
+
+	n, err := enc.EncodeFlowDatagram(0xC0A80101, 42, 5000, []FlowRecord{r}, 1280, buf)
+	if err != nil {
+		t.Fatalf("EncodeFlowDatagram error: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("EncodeFlowDatagram returned 0 bytes")
+	}
+
+	dg := decodeSFlow(t, buf[:n])
+	if dg.Header.Version != 5 {
+		t.Errorf("version = %d, want 5", dg.Header.Version)
+	}
+	if dg.Header.AddrType != sflowAddrTypeIP4 {
+		t.Errorf("address_type = %d, want 1 (IPv4)", dg.Header.AddrType)
+	}
+	want := [4]byte{0xC0, 0xA8, 0x01, 0x01}
+	if dg.Header.AgentIPv4 != want {
+		t.Errorf("agent_address = %v, want %v", dg.Header.AgentIPv4, want)
+	}
+	if dg.Header.SubAgentID != 0 {
+		t.Errorf("sub_agent_id = %d, want 0", dg.Header.SubAgentID)
+	}
+	if dg.Header.SequenceNo != 42 {
+		t.Errorf("sequence_number = %d, want 42", dg.Header.SequenceNo)
+	}
+	if dg.Header.Uptime != 5000 {
+		t.Errorf("uptime = %d, want 5000", dg.Header.Uptime)
+	}
+	if dg.Header.NumSamples != 1 {
+		t.Errorf("num_samples = %d, want 1", dg.Header.NumSamples)
+	}
+}
+
+func TestSFlowFlowSampleTuple(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+
+	src := net.ParseIP("192.168.1.10").To4()
+	dst := net.ParseIP("10.20.30.40").To4()
+	r := FlowRecord{
+		SrcIP:    src,
+		DstIP:    dst,
+		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort:  54321,
+		DstPort:  443,
+		Protocol: 6, // TCP
+		TCPFlags: 0x18,
+		Bytes:    9876,
+		Packets:  7,
+		StartMs:  1000,
+		EndMs:    2500,
+		InIface:  3,
+		OutIface: 4,
+	}
+
+	n, err := enc.EncodeFlowDatagram(0xC0A8010A, 1, 1000, []FlowRecord{r}, 2000, buf)
+	if err != nil {
+		t.Fatalf("EncodeFlowDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	if len(dg.Samples) != 1 {
+		t.Fatalf("samples = %d, want 1", len(dg.Samples))
+	}
+	if dg.Samples[0].Type != sflowSampleTypeFlow {
+		t.Errorf("sample type = %d, want %d (flow_sample)", dg.Samples[0].Type, sflowSampleTypeFlow)
+	}
+	fs := dg.Samples[0].FlowSample
+	if fs == nil {
+		t.Fatal("flow sample not decoded")
+	}
+	if fs.SamplingRate != 2000 {
+		t.Errorf("sampling_rate = %d, want 2000", fs.SamplingRate)
+	}
+	if fs.Input != 3 {
+		t.Errorf("input = %d, want 3", fs.Input)
+	}
+	if fs.Output != 4 {
+		t.Errorf("output = %d, want 4", fs.Output)
+	}
+	if fs.NumFlowRecords != 1 {
+		t.Fatalf("num_flow_records = %d, want 1", fs.NumFlowRecords)
+	}
+
+	rec := fs.Records[0]
+	if rec.Format != sflowFlowFmtSampledHeader {
+		t.Errorf("flow_record format = %d, want %d (sampled_header)", rec.Format, sflowFlowFmtSampledHeader)
+	}
+	sh := rec.SampledHeader
+	if sh == nil {
+		t.Fatal("sampled_header not decoded")
+	}
+	if sh.HeaderProtocol != sflowHdrProtoIPv4 {
+		t.Errorf("header_protocol = %d, want %d (IPv4)", sh.HeaderProtocol, sflowHdrProtoIPv4)
+	}
+	if sh.FrameLength != 9876 {
+		t.Errorf("frame_length = %d, want 9876", sh.FrameLength)
+	}
+	if sh.Stripped != 0 {
+		t.Errorf("stripped = %d, want 0", sh.Stripped)
+	}
+
+	gotSrc, gotDst, proto, sp, dp := parseIPv4(t, sh.Header)
+	if !gotSrc.Equal(src) {
+		t.Errorf("sampled IPv4 src = %v, want %v", gotSrc, src)
+	}
+	if !gotDst.Equal(dst) {
+		t.Errorf("sampled IPv4 dst = %v, want %v", gotDst, dst)
+	}
+	if proto != 6 {
+		t.Errorf("sampled IPv4 protocol = %d, want 6 (TCP)", proto)
+	}
+	if sp != 54321 {
+		t.Errorf("sampled TCP src port = %d, want 54321", sp)
+	}
+	if dp != 443 {
+		t.Errorf("sampled TCP dst port = %d, want 443", dp)
+	}
+}
+
+func TestSFlowFlowSampleUDP(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	r := makeRecord("10.0.0.1", "10.0.0.2", 55000, 53, 17) // UDP DNS
+	r.Bytes = 128
+
+	n, err := enc.EncodeFlowDatagram(0x0A000001, 2, 2000, []FlowRecord{r}, 100, buf)
+	if err != nil {
+		t.Fatalf("EncodeFlowDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	sh := dg.Samples[0].FlowSample.Records[0].SampledHeader
+	_, _, proto, sp, dp := parseIPv4(t, sh.Header)
+	if proto != 17 {
+		t.Errorf("sampled UDP protocol = %d, want 17", proto)
+	}
+	if sp != 55000 {
+		t.Errorf("sampled UDP src port = %d, want 55000", sp)
+	}
+	if dp != 53 {
+		t.Errorf("sampled UDP dst port = %d, want 53", dp)
+	}
+}
+
+func TestSFlowSequenceIncrements(t *testing.T) {
+	// Two encode calls with consecutive seqNo values should round-trip to
+	// sequence_numbers differing by exactly one.
+	enc := SFlowEncoder{}
+	buf1 := make([]byte, 1500)
+	buf2 := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 1000, 443, 6)}
+
+	n1, err := enc.EncodeFlowDatagram(0x0A000001, 100, 1000, records, 1, buf1)
+	if err != nil {
+		t.Fatalf("pkt 1 error: %v", err)
+	}
+	n2, err := enc.EncodeFlowDatagram(0x0A000001, 101, 1100, records, 1, buf2)
+	if err != nil {
+		t.Fatalf("pkt 2 error: %v", err)
+	}
+	d1 := decodeSFlow(t, buf1[:n1])
+	d2 := decodeSFlow(t, buf2[:n2])
+	if d2.Header.SequenceNo-d1.Header.SequenceNo != 1 {
+		t.Errorf("sequence diff = %d, want 1", d2.Header.SequenceNo-d1.Header.SequenceNo)
+	}
+}
+
+func TestSFlowMultipleRecords(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{
+		makeRecord("10.0.0.1", "10.0.0.2", 1001, 443, 6),
+		makeRecord("10.0.0.3", "10.0.0.4", 1002, 80, 6),
+		makeRecord("10.0.0.5", "10.0.0.6", 1003, 53, 17),
+	}
+	n, err := enc.EncodeFlowDatagram(1, 5, 1000, records, 42, buf)
+	if err != nil {
+		t.Fatalf("EncodeFlowDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	if int(dg.Header.NumSamples) != len(records) {
+		t.Errorf("num_samples = %d, want %d", dg.Header.NumSamples, len(records))
+	}
+	if len(dg.Samples) != len(records) {
+		t.Fatalf("decoded samples = %d, want %d", len(dg.Samples), len(records))
+	}
+	// All samples should carry samplingRate = 42
+	for i, s := range dg.Samples {
+		if s.FlowSample.SamplingRate != 42 {
+			t.Errorf("sample[%d] sampling_rate = %d, want 42", i, s.FlowSample.SamplingRate)
+		}
+	}
+}
+
+func TestSFlowMTUBound(t *testing.T) {
+	// With 20 records and 1500-byte buffer, worst-case 128B/record says at
+	// most 11 fit (1500-28)/128 = 11. EncodeFlowDatagram should cap at that
+	// number and not overflow. Two successive calls with the remainder drain
+	// the queue without exceeding MTU.
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	records := make([]FlowRecord, 20)
+	for i := range records {
+		records[i] = makeRecord("10.0.0.1", "10.0.0.2", uint16(2000+i), 443, 6)
+	}
+	n, err := enc.EncodeFlowDatagram(1, 1, 1000, records, 100, buf)
+	if err != nil {
+		t.Fatalf("EncodeFlowDatagram error: %v", err)
+	}
+	if n > 1500 {
+		t.Errorf("datagram size = %d, exceeds 1500-byte MTU", n)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	if int(dg.Header.NumSamples) > 11 {
+		t.Errorf("samples in one datagram = %d, want <= 11 (MTU cap)", dg.Header.NumSamples)
+	}
+	if dg.Header.NumSamples == 0 {
+		t.Error("expected at least one sample in datagram")
+	}
+}
+
+func TestSFlowSyntheticSamplingRateConstant(t *testing.T) {
+	// The design mandates rate = 10 × ConcurrentFlows. This test guards the
+	// named constant used by the Tick-level integration path.
+	if SyntheticSamplingRateMultiplier != 10 {
+		t.Errorf("SyntheticSamplingRateMultiplier = %d, want 10 (design §D3)", SyntheticSamplingRateMultiplier)
+	}
+}
+
+func TestSFlowEncodePacketIsAFlowEncoderEntryPoint(t *testing.T) {
+	// EncodePacket (the FlowEncoder entry point) should produce a valid
+	// datagram even without a profile-derived sampling rate. This keeps
+	// out-of-tree callers working.
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	records := []FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 1001, 443, 6)}
+	n, err := enc.EncodePacket(0x0A000001, 1, 1000, records, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("EncodePacket returned 0 bytes")
+	}
+	dg := decodeSFlow(t, buf[:n])
+	if dg.Header.Version != 5 {
+		t.Errorf("version = %d, want 5", dg.Header.Version)
+	}
+	if dg.Samples[0].FlowSample.SamplingRate != 1 {
+		t.Errorf("default sampling_rate = %d, want 1 (EncodePacket fallback)", dg.Samples[0].FlowSample.SamplingRate)
+	}
+}
+
+func TestSFlowEncodePacketEmptyReturnsZero(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodePacket(1, 0, 0, nil, false, buf)
+	if err != nil {
+		t.Fatalf("EncodePacket error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("empty call = %d bytes, want 0", n)
+	}
+}
+
+func TestSFlowEncodePacketBufferTooSmall(t *testing.T) {
+	enc := SFlowEncoder{}
+	tiny := make([]byte, 10)
+	_, err := enc.EncodePacket(1, 0, 0,
+		[]FlowRecord{makeRecord("10.0.0.1", "10.0.0.2", 1000, 443, 6)}, false, tiny)
+	if err == nil {
+		t.Error("expected error for too-small buffer, got nil")
+	}
+}
+
+func TestSFlowIPv4ProtocolTagAndICMP(t *testing.T) {
+	// ICMP (protocol 1) should be emitted with an IPv4 header but no transport
+	// ports. The decoder parses protocol bytes from the IPv4 header alone.
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	r := makeRecord("10.0.0.1", "10.0.0.2", 0, 0, 1)
+	r.Bytes = 64
+
+	n, err := enc.EncodeFlowDatagram(0x0A000001, 1, 1000, []FlowRecord{r}, 1, buf)
+	if err != nil {
+		t.Fatalf("EncodeFlowDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	sh := dg.Samples[0].FlowSample.Records[0].SampledHeader
+	if len(sh.Header) < 20 {
+		t.Fatalf("ICMP sampled header too short: %d", len(sh.Header))
+	}
+	if sh.Header[9] != 1 {
+		t.Errorf("protocol byte = %d, want 1 (ICMP)", sh.Header[9])
+	}
+}
+
+// ── Counter sample round-trip (Phase 2) ──────────────────────────────────────
+
+func TestSFlowCounterDatagramInterfaceCounters(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+
+	body := encodeIfCountersBody(3, 1_000_000_000, 12345678, 23456789, 100, 200)
+	recs := []CounterRecord{{Format: sflowCtrFmtGeneric, Body: body}}
+
+	n, err := enc.EncodeCounterDatagram(0xC0A80102, 7, 500, recs, buf)
+	if err != nil {
+		t.Fatalf("EncodeCounterDatagram error: %v", err)
+	}
+	dg := decodeSFlow(t, buf[:n])
+
+	if dg.Header.Version != 5 {
+		t.Errorf("version = %d, want 5", dg.Header.Version)
+	}
+	if dg.Header.NumSamples != 1 {
+		t.Fatalf("num_samples = %d, want 1", dg.Header.NumSamples)
+	}
+	s := dg.Samples[0]
+	if s.Type != sflowSampleTypeCounters {
+		t.Errorf("sample type = %d, want %d (counters_sample)", s.Type, sflowSampleTypeCounters)
+	}
+	cs := s.CounterSmpl
+	if cs == nil {
+		t.Fatal("counter sample not decoded")
+	}
+	if cs.NumRecords != 1 || len(cs.Records) != 1 {
+		t.Fatalf("records = %d, want 1", cs.NumRecords)
+	}
+	rec := cs.Records[0]
+	if rec.Format != sflowCtrFmtGeneric {
+		t.Errorf("counter record format = %d, want %d", rec.Format, sflowCtrFmtGeneric)
+	}
+	if len(rec.Body) != 88 {
+		t.Fatalf("if_counters body length = %d, want 88", len(rec.Body))
+	}
+	// Sanity-check ifIndex and octet totals.
+	if ifIdx := binary.BigEndian.Uint32(rec.Body[0:]); ifIdx != 3 {
+		t.Errorf("decoded ifIndex = %d, want 3", ifIdx)
+	}
+	if speed := binary.BigEndian.Uint64(rec.Body[8:]); speed != 1_000_000_000 {
+		t.Errorf("decoded ifSpeed = %d, want 1_000_000_000", speed)
+	}
+	if inOct := binary.BigEndian.Uint64(rec.Body[24:]); inOct != 12345678 {
+		t.Errorf("decoded ifInOctets = %d, want 12345678", inOct)
+	}
+	if outOct := binary.BigEndian.Uint64(rec.Body[56:]); outOct != 23456789 {
+		t.Errorf("decoded ifOutOctets = %d, want 23456789", outOct)
+	}
+}
+
+func TestSFlowCounterDatagramEmpty(t *testing.T) {
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodeCounterDatagram(1, 1, 0, nil, buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("empty records call returned %d bytes, want 0", n)
+	}
+}
+
+// TestSFlowTickSyntheticRate end-to-ends through FlowExporter.Tick to prove
+// the spec's synthetic-rate scenario: the sFlow flow_sample on the wire
+// carries sampling_rate = 10 × profile.ConcurrentFlows. This is the scenario
+// "Synthetic sampling rate is consistent and documented".
+func TestSFlowTickSyntheticRate(t *testing.T) {
+	ln, ch := testUDPListener(t)
+	defer ln.Close()
+	conn := testSender(t)
+	defer conn.Close()
+	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
+
+	// Use a short inactive timeout so at least one flow expires inside the
+	// single Tick we run. Active timeout is much longer so Expire is driven
+	// by inactivity, not age.
+	profile := &FlowProfile{
+		TCPWeight:       1.0,
+		DstPorts:        []PortWeight{{Port: 443, Weight: 1.0}},
+		SrcPortMin:      1024,
+		SrcPortMax:      65535,
+		BytesMin:        512,
+		BytesMax:        1024,
+		PktsMin:         1,
+		PktsMax:         10,
+		DurationMinMs:   100,
+		DurationMaxMs:   500,
+		ConcurrentFlows: 5, // rate should end up 5 × 10 = 50
+		MaxFlows:        256,
+	}
+
+	fe := NewFlowExporter(testDevice("10.9.8.7"), profile,
+		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
+
+	// Run two ticks 10ms apart so the inactive timeout fires.
+	fe.Tick(time.Now(), SFlowEncoder{}, conn, collectorAddr, testPool())
+	time.Sleep(15 * time.Millisecond)
+	fe.Tick(time.Now(), SFlowEncoder{}, conn, collectorAddr, testPool())
+
+	// Drain any datagrams produced. Look for the first one that actually
+	// carries a flow_sample (as opposed to a counter-only tick).
+	var samplingRate uint32
+	for {
+		pkt := receivePacket(ch)
+		if pkt == nil {
+			break
+		}
+		dg := decodeSFlow(t, pkt)
+		if len(dg.Samples) > 0 && dg.Samples[0].Type == sflowSampleTypeFlow {
+			samplingRate = dg.Samples[0].FlowSample.SamplingRate
+			break
+		}
+	}
+	want := uint32(profile.ConcurrentFlows * SyntheticSamplingRateMultiplier)
+	if samplingRate != want {
+		t.Errorf("sFlow flow_sample sampling_rate = %d, want %d (10 × ConcurrentFlows)", samplingRate, want)
+	}
+}
+
+func TestSFlowCounterDatagramMTU(t *testing.T) {
+	// A device with many interfaces can produce an if_counters payload that
+	// would exceed the 1500-byte MTU in a single datagram. EncodeCounterDatagram
+	// writes best-effort: it encodes as many records as fit and returns. The
+	// FlowExporter.Tick sFlow code path then re-invokes with the remainder.
+	// This test verifies the encoder never overruns the buffer and that the
+	// resulting datagram parses cleanly.
+	enc := SFlowEncoder{}
+	buf := make([]byte, 1500)
+
+	// Create 32 if_counters records; each body is 88 bytes + 8-byte XDR
+	// record header = 96 bytes, so 32 records ≈ 3072 bytes, well over 1500.
+	recs := make([]CounterRecord, 32)
+	for i := range recs {
+		recs[i] = CounterRecord{
+			Format: sflowCtrFmtGeneric,
+			Body:   encodeIfCountersBody(uint32(i+1), 1_000_000_000, uint64(i)*1000, uint64(i)*2000, uint32(i), uint32(i)*2),
+		}
+	}
+
+	n, err := enc.EncodeCounterDatagram(1, 1, 100, recs, buf)
+	if err != nil {
+		t.Fatalf("EncodeCounterDatagram error: %v", err)
+	}
+	if n > 1500 {
+		t.Errorf("datagram size = %d, exceeds 1500-byte MTU", n)
+	}
+	dg := decodeSFlow(t, buf[:n])
+	if dg.Header.NumSamples == 0 {
+		t.Fatal("expected at least one sample in datagram")
+	}
+	if got := dg.Samples[0].CounterSmpl.NumRecords; got == 0 {
+		t.Fatal("expected at least one counter record in sample")
+	}
+}

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -104,7 +104,7 @@ func main() {
 
 		// Flow export flags
 		flowCollector        = flag.String("flow-collector", "", "NetFlow/IPFIX collector address (host:port, e.g. 192.168.1.100:2055); disables flow export when empty")
-		flowProtocol         = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default), ipfix, netflow5. Under netflow5, -flow-template-interval is accepted but has no effect (v5 has no template mechanism)")
+		flowProtocol         = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default), ipfix, netflow5, sflow (alias sflow5). Under netflow5, -flow-template-interval is accepted but has no effect (v5 has no template mechanism). Under sflow, -flow-template-interval is accepted but has no effect (sFlow records are self-describing); flow-samples carry a synthetic sampling_rate of 10 × FlowProfile.ConcurrentFlows — see CLAUDE.md and README.md for caveats")
 		flowActiveSecs       = flag.Int("flow-active-timeout", 30, "Active flow timeout in seconds (default: 30)")
 		flowInactiveSecs     = flag.Int("flow-inactive-timeout", 15, "Inactive flow timeout in seconds (default: 15)")
 		flowTemplateIntervalSecs = flag.Int("flow-template-interval", 60, "Template retransmission interval in seconds (default: 60)")

--- a/openspec/changes/add-sflow-export/.openspec.yaml
+++ b/openspec/changes/add-sflow-export/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/add-sflow-export/design.md
+++ b/openspec/changes/add-sflow-export/design.md
@@ -119,20 +119,25 @@ The alternative — sampling rate = 1 (every packet sampled) — produces correc
 
 **Decision:** Phase 2 introduces:
 ```go
+type CounterRecord struct {
+    Format   uint32 // sFlow counter-record format tag
+    SourceID uint32 // ifIndex for per-interface records, 0 for device-wide
+    Body     []byte
+}
+
 type CounterSource interface {
     // Snapshot returns counter records for the device at time t.
     Snapshot(t time.Time) []CounterRecord
 }
 ```
-- `InterfaceCounterSource` — extracted from `IfCounterCycler`. `if_counters.go` keeps its SNMP wiring but delegates the counter math to this source.
-- `CPUCounterSource` — new, per-device. Produces CPU utilization (idle / user / system / wait as percentages × 100).
-- `MemoryCounterSource` — new, per-device. Produces total / used / free / cached (bytes).
+- `InterfaceCounterSource` — extracted from `IfCounterCycler`. `if_counters.go` keeps its SNMP wiring but delegates the counter math to this source. Tags each record with `SourceID = ifIndex`.
+- `CPUCounterSource` — new, per-device. Produces a single `processor_information` record (format 1001) carrying CPU utilization plus total/free memory. Tagged with `SourceID = 0`. Memory is folded into this standard record rather than emitted under a non-standard format ID.
 
-`FlowExporter.Tick` in sFlow mode calls `Snapshot` on all registered sources once per tick and emits `COUNTERS_SAMPLE` records alongside `FLOW_SAMPLE`.
+`FlowExporter.Tick` in sFlow mode calls `Snapshot` on all registered sources once per tick. `SFlowEncoder.EncodeCounterDatagram` groups the returned records by `SourceID` and emits one `counters_sample` per group (per-interface records keyed by ifIndex, device-wide records under source_id 0). This matches how collectors such as OpenNMS Telemetryd key `if_counters` by ds_index.
 
-**Rationale:** A single interface keeps the sFlow encoder from knowing about counter internals, and sets up `if_counters.go` for the separately-tracked ifHC cycling gap (see memory `project_ifhc_counter_gap.md`). The gap fix can land on top of this abstraction cleanly.
+**Rationale:** A single interface keeps the sFlow encoder from knowing about counter internals, and sets up `if_counters.go` for the separately-tracked ifHC cycling gap (see memory `project_ifhc_counter_gap.md`). The gap fix can land on top of this abstraction cleanly. Per-SourceID grouping is required for correct collector attribution — a single `counters_sample` with `source_id = 0` and N `if_counters` records is valid XDR but misattributes per-interface metrics.
 
-**Alternative:** Hard-code the three counter types in `sflow.go`. Rejected: blocks the ifHC fix and forces future counter additions into a protocol-specific file.
+**Alternative:** Hard-code the three counter types in `sflow.go`. Rejected: blocks the ifHC fix and forces future counter additions into a protocol-specific file. Keeping a dedicated `MemoryCounterSource` was also rejected — `processor_information` already carries the fields, and a simulator-local format ID would be silently dropped by strict collectors.
 
 ### D7. Protocol string canonicalization: `sflow`
 

--- a/openspec/changes/add-sflow-export/design.md
+++ b/openspec/changes/add-sflow-export/design.md
@@ -1,0 +1,172 @@
+## Context
+
+**Current state.** The flow-export subsystem in `go/simulator/` supports two protocols via a single abstraction:
+
+| Surface | Current shape |
+|---|---|
+| Encoder contract | `FlowEncoder` interface in `flow_exporter.go` — `EncodePacket(domainID, seqNo, uptimeMs, records, includeTemplate, buf) (int, error)` plus `PacketSizes() (baseOverhead, templateSize, recordSize)`. Both numbers in `PacketSizes()` assume a **fixed** record size. |
+| Protocol switch | `InitFlowExport` at `flow_exporter.go:271` — hard-coded `switch` on `netflow9` / `ipfix`. |
+| Pagination | `FlowExporter.Tick` at `flow_exporter.go:160–200` — computes batch capacity as `(len(buf) - overhead) / recSize`. Assumes every record is the same size. |
+| Record source | `FlowCache.GenerateFlows()` in `flow_cache.go` synthesizes IPv4 5-tuple records with byte/packet counters and active/inactive timeout semantics. |
+| Counter source | `IfCounterCycler` in `if_counters.go` — SNMP-only. Not wired into flow export. No per-device CPU / memory counter sources exist. |
+| Per-device source IP | `-flow-source-per-device` opens a UDP socket in the `opensim` netns bound to the device's IP; each per-device `FlowExporter` owns one `*net.UDPConn`. |
+| CLI | `-flow-protocol netflow9|ipfix` in `simulator.go`. |
+| Status API | `GET /api/v1/flows/status` reports `"protocol"` in canonical form. |
+
+**sFlow v5 structural misfit.** sFlow v5 ([sflow_version_5.txt](https://sflow.org/sflow_version_5.txt)) differs from NetFlow/IPFIX in three ways that hit the existing abstractions:
+
+1. **Variable-length records.** Each `FLOW_SAMPLE` carries one or more typed "flow records" (raw-packet-header, extended-switch, extended-router, etc.), each with its own XDR-encoded length. `PacketSizes()` can't return a single scalar `recordSize`.
+2. **No templates.** sFlow records are self-describing (typed with format+length), so the `includeTemplate` / `templateInterval` machinery has no analogue.
+3. **Two sample kinds.** `FLOW_SAMPLE` (packet-sampled data) and `COUNTERS_SAMPLE` (periodic counter dumps). The current export pipeline only knows about flows, not counter polls.
+
+**Constraints.**
+- Keep NetFlow v9 and IPFIX behaviour exactly unchanged. No regression risk tolerated.
+- `flow_exporter.go` is also touched by issue #43 (NetFlow v5). Per the task-sequencing note in `tasks.md`, NetFlow v5 lands first; this change rebases on top.
+- Go stdlib has no XDR encoder. Adding a dependency needs justification.
+- The simulator does not forward real traffic. Any sFlow "sampling rate" is therefore synthetic — collectors that extrapolate volume from sample rate need a documented, predictable value.
+
+**Stakeholders.**
+- Primary: Ronny Trommer (maintainer).
+- Consumers: OpenNMS Telemetryd sFlow adapter (primary test target), plus users validating HP/Aruba, Arista, or Juniper MX integrations.
+- Indirect: Issue #43 (NetFlow v5) author — our encoder-contract changes should not make their change harder.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `-flow-protocol sflow` (alias `sflow5`) selects sFlow v5 output end-to-end.
+- Phase 1 emits valid sFlow v5 datagrams with `FLOW_SAMPLE` records that any compliant collector decodes without error.
+- Phase 2 emits `COUNTERS_SAMPLE` records for interface + CPU + memory counters on the same tick, with counter sources reusable by future protocols and by existing `if_counters.go` consumers.
+- The encoder contract evolves to tolerate variable-length records without forcing NetFlow/IPFIX implementations to change observable behaviour.
+- Per-device source IP binding continues to work: each datagram carries the device IPv4 as the sFlow agent address, and is sent from the per-device socket when available.
+- Synthetic sampling rate is explicit in output and in docs — no collector should silently multiply meaningless numbers.
+- Unit tests decode emitted datagrams with an in-process XDR oracle, mirroring `netflow9_test.go` and `ipfix_test.go`.
+
+**Non-Goals:**
+- Real packet capture / forwarding (the simulator has none to sample).
+- sFlow v4 (legacy; non-XDR).
+- IPv6 flow samples. IPv4 5-tuple only, matching what `FlowRecord` already models.
+- New counter categories beyond interface + CPU + memory in Phase 2 (no ASIC, per-core, or storage-backend counters this round).
+- Extending the web UI or `/api/v1/flows/status` beyond reporting `"protocol": "sflow"`.
+- Porting `if_counters.go` SNMP consumers to the new counter-source interface beyond what Phase 2 requires (they keep working via a thin adapter).
+
+## Decisions
+
+### D1. Extend `FlowEncoder` rather than add a sibling interface
+
+**Decision:** Extend the existing `FlowEncoder` interface with one additional method that supports variable-length pagination, rather than introducing a parallel `SampleEncoder` interface.
+
+**Shape (illustrative, not normative):**
+```go
+type FlowEncoder interface {
+    EncodePacket(...) (int, error)
+    PacketSizes() (baseOverhead, templateSize, recordSize int)
+    // New: optional hint for variable-length protocols. Encoders that
+    // return a non-zero value here opt into variable-length pagination.
+    // NetFlow9/IPFIX return 0 and keep fixed-size semantics.
+    MaxRecordSize() int
+}
+```
+`FlowExporter.Tick` inspects `MaxRecordSize()`; if non-zero, it paginates by calling back into the encoder for a per-record size estimate (or simply bounds the batch by a worst-case record size and lets the encoder return `ErrBatchTooBig` to trigger a re-paginate).
+
+**Rationale:** A parallel interface duplicates the pagination loop and the per-device exporter lifecycle for marginal cleanliness gain. The existing two encoders don't grow new responsibilities — they just answer "0" to the new method. The maintenance cost is one extra tiny method on two types.
+
+**Alternatives considered:**
+- **`SampleEncoder` sibling interface.** Rejected: requires branching in `SimulatorManager.InitFlowExport`, `FlowExporter`, `startFlowTicker`, and tests on encoder kind. Net complexity higher than the extension path.
+- **Swap `PacketSizes()` to return variable-size info for everyone.** Rejected: ripples into NetFlow/IPFIX tests and implementations for zero behavioural gain. The extension above is additive and non-breaking.
+
+### D2. Inline XDR primitives, no new dependency
+
+**Decision:** Implement the XDR primitives we need inline in `sflow.go` rather than adding `github.com/davecgh/go-xdr` to `go.mod`.
+
+**Primitives needed:**
+- `uint32` (4 bytes big-endian) — covers length fields, enum tags, counter samples, sequence numbers.
+- `opaque<>` (length-prefixed byte slice with 4-byte alignment padding) — covers sampled packet headers and variable fields.
+- Fixed-length arrays — covers agent address (4 bytes for IPv4), MAC fields, etc.
+
+Everything fits in ~40 lines of Go using `encoding/binary.BigEndian.PutUint32` and a `padTo4()` helper.
+
+**Rationale:** The dependency is tiny, rarely updated, and MIT-licensed, so vendoring it is defensible. But the cost of a new dep in a simulator that already has a minimal deps list outweighs the 40 lines of code we save. Inline keeps audit surface small.
+
+**Alternative:** `github.com/davecgh/go-xdr`. Fine if inline ends up fighting us on complex records, but Phase 1's `flow_sample_expanded` layout is flat enough that inline primitives suffice.
+
+### D3. Synthetic sampling rate derived from `FlowProfile.ConcurrentFlows`
+
+**Decision:** Every `FLOW_SAMPLE` emits a fixed sampling rate of `10 × ConcurrentFlows`. Documented in the README as synthetic.
+
+**Rationale:** The `ConcurrentFlows` value drives how many flows `FlowCache` keeps live; `10 ×` gives a plausible "1 in N packets sampled" number for the collector's volume-extrapolation math that still yields meaningful-looking rates without implying a specific real-world link speed.
+
+The alternative — sampling rate = 1 (every packet sampled) — produces correct-looking XDR but breaks collectors that multiply by sample rate to estimate link utilization; their graphs would be flatlined at the synthetic record rate. A non-1 synthetic value is honest-ish: the number is wrong but the shape matches real devices.
+
+**Alternative:** Make the sampling rate a CLI flag (`-flow-sflow-sampling-rate`). Rejected for Phase 1 — one more knob for a behaviour we don't want collectors to trust anyway. If users object, add the flag in a follow-up.
+
+### D4. Agent identity = device IPv4 (per-device datagram)
+
+**Decision:** Each sFlow datagram carries the emitting device's IPv4 as its `agent_address`. The `sub_agent_id` is 0. When `-flow-source-per-device` is enabled (the default), the UDP source IP matches the agent_address by virtue of the per-device socket bind.
+
+**Rationale:** sFlow's "one agent per datagram" rule maps cleanly onto the existing per-device `FlowExporter` model — each exporter already produces its own datagrams from its own socket. Keeping agent_address = source IP = device IP means the collector's agent-to-node mapping works identically across NetFlow9, IPFIX, and sFlow.
+
+**Alternative:** Emit a single "aggregate agent" per simulator with all device samples folded under one agent identity. Rejected: defeats the purpose of the per-device-source-IP feature and misrepresents the simulated topology to the collector.
+
+### D5. `FlowCache` records are reinterpreted, not rewritten
+
+**Decision:** The existing `FlowRecord` / `FlowCache.GenerateFlows()` output is consumed unchanged by the sFlow encoder. The encoder synthesizes a "sampled packet header" by constructing a minimal IPv4+UDP header from the 5-tuple and wrapping it as the `sampled_header` portion of a `FLOW_SAMPLE`.
+
+**Rationale:** Keeps the flow-generation pipeline protocol-agnostic. The cost is that the synthesized packet header is obviously synthetic (no real Ethernet framing, no payload), which matches the documented "synthetic samples" caveat.
+
+**Alternative:** Teach `FlowCache` to generate sFlow-native packet snapshots. Rejected: couples the cache to protocol specifics and breaks the clean "records in, bytes out" separation we have today.
+
+### D6. Counter samples use a new `CounterSource` interface (Phase 2)
+
+**Decision:** Phase 2 introduces:
+```go
+type CounterSource interface {
+    // Snapshot returns counter records for the device at time t.
+    Snapshot(t time.Time) []CounterRecord
+}
+```
+- `InterfaceCounterSource` — extracted from `IfCounterCycler`. `if_counters.go` keeps its SNMP wiring but delegates the counter math to this source.
+- `CPUCounterSource` — new, per-device. Produces CPU utilization (idle / user / system / wait as percentages × 100).
+- `MemoryCounterSource` — new, per-device. Produces total / used / free / cached (bytes).
+
+`FlowExporter.Tick` in sFlow mode calls `Snapshot` on all registered sources once per tick and emits `COUNTERS_SAMPLE` records alongside `FLOW_SAMPLE`.
+
+**Rationale:** A single interface keeps the sFlow encoder from knowing about counter internals, and sets up `if_counters.go` for the separately-tracked ifHC cycling gap (see memory `project_ifhc_counter_gap.md`). The gap fix can land on top of this abstraction cleanly.
+
+**Alternative:** Hard-code the three counter types in `sflow.go`. Rejected: blocks the ifHC fix and forces future counter additions into a protocol-specific file.
+
+### D7. Protocol string canonicalization: `sflow`
+
+**Decision:** Accept `sflow` and `sflow5` on the CLI; canonicalize to `sflow` in `SimulatorManager.flowProtocol` and `/api/v1/flows/status`. Error message in the default switch branch lists all three protocols.
+
+**Rationale:** Matches the existing `netflow9` / `nf9` alias pattern in `flow_exporter.go:272`. Users searching docs for "sflow v5" find the right flag either way.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Variable-length pagination regression impacts NetFlow/IPFIX | `MaxRecordSize() int` returns 0 for fixed-size encoders; `Tick` branches on zero and preserves the existing code path byte-for-byte. Unit tests assert NetFlow/IPFIX emission is identical before and after. |
+| Synthetic sampling rate confuses operators into trusting extrapolated numbers | README and `CLAUDE.md` explicitly label sFlow output synthetic. `/api/v1/flows/status` could expose a `"synthetic": true` flag for sFlow (nice-to-have; in tasks). |
+| Counter sample omission trips collector warnings | Phase 1 ships flow-samples-only. Release notes call out Phase 2 is required for full collector happiness. Ship both phases together if schedule allows. |
+| XDR encoding bugs hide behind "collector accepts the packet" | Unit tests use an in-process XDR decoder oracle that re-parses our output and asserts field-by-field equality with the input `FlowRecord`. Mirrors `netflow9_test.go` structure. |
+| Per-device socket source-IP mismatch with agent_address (e.g. per-device binding failed, socket fell back to shared) | The exporter logs a warning on per-device bind failure today; we extend that log to mention "sFlow agent identity may not match source IP" in sFlow mode. Collectors that cross-check agent vs. packet source will see coherent mismatch logs rather than silent misattribution. |
+| `flow_exporter.go` merge conflict with issue #43 (NetFlow v5) | NetFlow v5 lands first (documented in `tasks.md`). Our protocol switch + interface extension rebases on top of #43's switch changes. Task 1.1 checks issue #43 merge status before starting. |
+| sFlow datagrams exceed 1500-byte MTU when records carry long raw headers | We cap per-datagram record count on encode; if a single record exceeds MTU, we drop it with a `log.Printf` (best-effort, same policy as NetFlow/IPFIX for over-capacity buffers). Phase 1 sampled headers are short (IPv4+UDP = 28 bytes) so this is a theoretical concern for Phase 1. |
+
+## Migration Plan
+
+No user-visible migration — this is an additive change.
+
+**Rollout:**
+1. Land Phase 1 (flow samples) behind `-flow-protocol sflow`. Validate with OpenNMS Telemetryd + at least one external collector (Inmon sFlowTrend or equivalent).
+2. Land Phase 2 (counter samples) as a follow-up commit or PR in the same change set. Regression test: NetFlow9/IPFIX tick output unchanged.
+3. Update `CLAUDE.md` and `README.md` in the same PR as Phase 1.
+
+**Rollback:** Revert the PR. No state migration required. Users running `-flow-protocol sflow` fall back to an error message and must switch to `netflow9` or `ipfix`.
+
+## Open Questions
+
+1. **CLI flag for sampling rate?** D3 defers this. If collector feedback after Phase 1 demands per-simulation sampling rate control, add `-flow-sflow-sampling-rate` in a follow-up. Not blocking.
+2. **Scope of Phase 2 counter types.** CPU and memory are new counter surfaces. Should they also be exposed via SNMP for consistency (`hrProcessorTable`, `hrStorageTable`)? Out of scope for this change but worth tracking.
+3. **`CounterSource` for sFlow-only or all exporters?** Phase 2 wires it only into sFlow's `COUNTERS_SAMPLE` path. NetFlow v9 Options Templates could carry similar data, but that's a separate feature.
+4. **Agent sub_agent_id ever non-zero?** Always 0 in Phase 1. If we ever simulate multi-linecard chassis, sub_agent_id could distinguish linecards. Not relevant for the current device types.
+5. **Should `/api/v1/flows/status` expose a `"synthetic": true` flag for sFlow?** Noted in risks; decide during Phase 1 review.

--- a/openspec/changes/add-sflow-export/proposal.md
+++ b/openspec/changes/add-sflow-export/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+l8opensim currently exports synthetic flow data as NetFlow v9 and IPFIX, but a significant class of real-world collectors and devices speak only sFlow — notably HP/Aruba and Arista switches, Juniper MX platforms, and the OpenNMS Telemetryd sFlow adapter. Without sFlow v5 support, users validating these collectors against l8opensim must stand up a second traffic generator or switch tooling, which defeats the purpose of a single pluggable simulator.
+
+sFlow v5 ([sflow_version_5.txt](https://sflow.org/sflow_version_5.txt)) is also a structurally different beast from NetFlow/IPFIX: it is a sampling-and-polling protocol with XDR-encoded variable-length sample records, not a cache-with-timeouts flow protocol. Adding it forces the flow-export subsystem's abstractions to grow beyond "fixed-size records with templates" — which benefits any future sampling-style protocol too.
+
+## What Changes
+
+- Add a new flow-export protocol `sflow` (alias `sflow5`) selectable via the existing `-flow-protocol` CLI flag alongside `netflow9` and `ipfix`.
+- Introduce an sFlow v5 datagram encoder that emits `FLOW_SAMPLE` records (packet-header sampled-packet layout, XDR-encoded). Phase 1 ships flow samples only; counter samples are Phase 2.
+- Extend the `FlowEncoder` contract (or add a sibling encoder interface) so that variable-length records are a first-class concern. `PacketSizes()` currently assumes a fixed record size; the pagination logic in `FlowExporter.Tick` must tolerate per-record sizing.
+- Reinterpret the existing synthetic flows produced by `FlowCache.GenerateFlows()` as sampled packets with a documented, fixed synthetic sampling rate derived from `FlowProfile.ConcurrentFlows`. Collectors that extrapolate volume from sample rate get a predictable (if synthetic) number.
+- Add a second phase that factors interface counters out of `IfCounterCycler` behind a reusable counter-source interface, adds per-device CPU and memory counter sources, and emits sFlow `COUNTERS_SAMPLE` records on the same tick as flow samples. Phase 2 is in scope for this change but gated behind Phase 1.
+- Make the `-flow-source-per-device` semantics explicit for sFlow: each datagram carries one agent identity (the device's IPv4), so per-device source binding remains the default.
+- Update `CLAUDE.md` flow-export reference and README to list `sflow` as a supported protocol and call out that sFlow samples are synthetic (no real packet stream is forwarded).
+
+No breaking changes. NetFlow v9 and IPFIX behaviour is preserved.
+
+## Capabilities
+
+### New Capabilities
+- `flow-export-sflow`: sFlow v5 datagram export capability — XDR encoding, flow samples (Phase 1) and counter samples (Phase 2), agent identity rules, synthetic sampling-rate semantics, and CLI/selector integration.
+
+### Modified Capabilities
+<!-- None — the existing flow-export subsystem has no prior OpenSpec spec, so the encoder-contract extension lands entirely within this new capability's spec plus design notes. -->
+
+## Impact
+
+**In-tree files touched**
+- `go/simulator/sflow.go` — new encoder (Phase 1 flow samples, Phase 2 counter samples)
+- `go/simulator/flow_exporter.go` — protocol switch (same file touched by issue #43 NetFlow v5, see `tasks.md` sequencing note) and `FlowEncoder` interface extension or sibling interface
+- `go/simulator/flow_cache.go` — no structural change; existing synthetic flows are reinterpreted as sampled packets in the sFlow code path
+- `go/simulator/if_counters.go` — Phase 2 refactor: extract a reusable counter-source interface
+- `go/simulator/simulator.go` — CLI flag help text for `-flow-protocol`
+- New: per-device CPU / memory counter-source sites (Phase 2; location TBD in design.md)
+- New: `go/simulator/sflow_test.go` — unit tests with an in-process XDR decoder oracle
+- `CLAUDE.md` — flow-export section
+- `README.md` — protocol list + synthetic-samples caveat
+
+**Dependencies**
+- XDR encoding: either vendor a minimal XDR primitive set inline (preferred — only `uint32`, `opaque<>`, fixed-length arrays needed) or add `github.com/davecgh/go-xdr` to `go.mod`. Decision recorded in `design.md`.
+
+**Downstream consumers**
+- Users currently invoking `-flow-protocol netflow9` or `-flow-protocol ipfix` see no change.
+- Users of `GET /api/v1/flows/status` see `"protocol": "sflow"` when sFlow is selected.
+
+**Out of scope**
+- Real packet-forwarding sampling — the simulator never sees real traffic, so all samples are synthesized from `FlowCache`.
+- sFlow v4 (legacy, non-XDR). Only v5 is supported.
+- Sampling of arbitrary protocols beyond what `FlowRecord` already models (IPv4 5-tuple). IPv6 flow samples remain follow-up work.
+- Expanded counter types beyond interface + CPU + memory in Phase 2 (e.g., processor-per-core breakdowns, ASIC counters) — reserved for future changes.

--- a/openspec/changes/add-sflow-export/specs/flow-export-sflow/spec.md
+++ b/openspec/changes/add-sflow-export/specs/flow-export-sflow/spec.md
@@ -1,0 +1,182 @@
+## ADDED Requirements
+
+### Requirement: sFlow v5 protocol selection
+
+The simulator SHALL accept `sflow` and `sflow5` as values for the `-flow-protocol` CLI flag and canonicalize both to `sflow` internally. The help text for `-flow-protocol` SHALL list `sflow` alongside `netflow9` and `ipfix`.
+
+#### Scenario: CLI accepts sflow as protocol
+
+- **WHEN** the simulator is started with `-flow-protocol sflow -flow-collector <host:port>`
+- **THEN** flow export initialization SHALL succeed
+- **AND** `GET /api/v1/flows/status` SHALL return `"protocol": "sflow"`
+
+#### Scenario: CLI accepts sflow5 as protocol alias
+
+- **WHEN** the simulator is started with `-flow-protocol sflow5 -flow-collector <host:port>`
+- **THEN** flow export initialization SHALL succeed
+- **AND** `GET /api/v1/flows/status` SHALL return `"protocol": "sflow"` (canonicalized form)
+
+#### Scenario: Unknown protocol is rejected with updated error message
+
+- **WHEN** the simulator is started with `-flow-protocol foo`
+- **THEN** initialization SHALL fail with an error listing the supported protocols
+- **AND** the error message SHALL include `netflow9`, `ipfix`, and `sflow`
+
+### Requirement: sFlow v5 datagram structure
+
+When the selected protocol is `sflow`, the simulator SHALL emit UDP datagrams conforming to the sFlow v5 datagram format defined in sflow_version_5.txt. Each datagram SHALL contain a version field of 5, an `agent_address_type` of 1 (IPv4), an `agent_address` equal to the emitting device's IPv4, a `sub_agent_id` of 0, a monotonically increasing `sequence_number` per (agent, sub-agent) pair, an `uptime` in milliseconds since device start, and at least one sample record.
+
+#### Scenario: Datagram version field equals 5
+
+- **WHEN** an sFlow datagram is emitted
+- **THEN** the first 4 bytes SHALL encode the XDR uint32 value 5
+
+#### Scenario: Agent address matches emitting device
+
+- **WHEN** device `D` with IPv4 `A.B.C.D` emits an sFlow datagram
+- **THEN** the datagram's `agent_address_type` SHALL be 1
+- **AND** the datagram's `agent_address` SHALL equal `A.B.C.D` in network byte order
+
+#### Scenario: Sequence number increments per device
+
+- **WHEN** device `D` emits two consecutive sFlow datagrams
+- **THEN** the second datagram's `sequence_number` SHALL be greater than the first's by exactly 1
+
+#### Scenario: Sub-agent id is zero
+
+- **WHEN** any sFlow datagram is emitted
+- **THEN** its `sub_agent_id` field SHALL be 0
+
+### Requirement: sFlow v5 flow samples (Phase 1)
+
+When the selected protocol is `sflow`, the simulator SHALL convert each synthetic flow produced by `FlowCache.GenerateFlows` into an sFlow `FLOW_SAMPLE` (sample_type tag `flow_sample` or `flow_sample_expanded`) containing a `sampled_header` flow-record with a synthesized IPv4+UDP header derived from the 5-tuple, byte counters, and packet counters of the originating `FlowRecord`.
+
+#### Scenario: FLOW_SAMPLE tag is present
+
+- **WHEN** an sFlow datagram carrying flow data is decoded
+- **THEN** at least one sample record SHALL have the `flow_sample` or `flow_sample_expanded` tag
+
+#### Scenario: Sampled header carries the 5-tuple
+
+- **WHEN** a `FLOW_SAMPLE` is decoded and its `sampled_header` payload is parsed as an IPv4 packet
+- **THEN** the IPv4 source and destination addresses SHALL equal the originating `FlowRecord.SrcAddr` and `DstAddr`
+- **AND** for UDP/TCP protocols the transport-layer source and destination ports SHALL equal `FlowRecord.SrcPort` and `DstPort`
+- **AND** the IPv4 protocol field SHALL equal `FlowRecord.Protocol`
+
+#### Scenario: Synthetic sampling rate is consistent and documented
+
+- **WHEN** any `FLOW_SAMPLE` is emitted
+- **THEN** its `sampling_rate` field SHALL equal `10 * FlowProfile.ConcurrentFlows` for the emitting device's profile
+- **AND** the simulator's documentation (README and `CLAUDE.md`) SHALL describe this rate as synthetic and not reflective of real traffic volume
+
+### Requirement: sFlow v5 counter samples (Phase 2)
+
+When the selected protocol is `sflow` and Phase 2 counter-sample support is enabled, the simulator SHALL emit `COUNTERS_SAMPLE` (sample_type tag `counters_sample` or `counters_sample_expanded`) records alongside flow samples on each flow-export tick. Each counter sample SHALL include at minimum: one `if_counters` record per simulated interface, one `processor_information` record per device carrying CPU utilization, and one `memory_information` record per device carrying memory totals and usage.
+
+#### Scenario: Counter sample emitted per tick per device
+
+- **WHEN** the flow-export ticker fires with protocol `sflow` and Phase 2 enabled
+- **THEN** each active device SHALL emit at least one `COUNTERS_SAMPLE` record in that tick's datagram batch
+
+#### Scenario: Interface counters included
+
+- **WHEN** a `COUNTERS_SAMPLE` is decoded for device `D`
+- **THEN** it SHALL contain one `if_counters` record for each simulated interface on `D`
+- **AND** each `if_counters` record SHALL carry non-zero `ifInOctets`, `ifOutOctets`, `ifInUcastPkts`, and `ifOutUcastPkts` fields derived from `IfCounterCycler` output
+
+#### Scenario: CPU and memory counters included
+
+- **WHEN** a `COUNTERS_SAMPLE` is decoded for device `D`
+- **THEN** it SHALL contain exactly one `processor_information` record carrying at minimum `cpu_percentage` and `total_memory`
+- **AND** it SHALL contain exactly one `memory_information` record carrying `total` and `free` memory byte counts
+
+### Requirement: CounterSource abstraction
+
+Phase 2 counter sample emission SHALL be driven by a `CounterSource` interface rather than by direct coupling between `sflow.go` and `if_counters.go`. Existing `IfCounterCycler` state SHALL be exposed through an `InterfaceCounterSource` adapter implementing this interface without changing observable SNMP behaviour.
+
+#### Scenario: InterfaceCounterSource reuses IfCounterCycler state
+
+- **WHEN** a device's `InterfaceCounterSource.Snapshot` is called at time `t`
+- **THEN** the returned `CounterRecord` values for interface counters SHALL equal the values that `IfCounterCycler` would produce at time `t` for the same device
+- **AND** the existing SNMP exposure of the same counters via `snmp_handlers.go` SHALL remain byte-identical before and after this refactor
+
+#### Scenario: CPU and memory counter sources are per-device
+
+- **WHEN** the simulator initializes a device in sFlow mode with Phase 2 enabled
+- **THEN** the device SHALL have exactly one `CPUCounterSource` and exactly one `MemoryCounterSource` registered
+
+### Requirement: FlowEncoder interface tolerates variable-length records
+
+The `FlowEncoder` interface SHALL be extended with a method that allows protocol-specific encoders to opt into variable-length record pagination. The extension SHALL NOT change the observable output of `NetFlow9Encoder` or `IPFIXEncoder` — both continue to paginate by the fixed `recordSize` returned from `PacketSizes()`.
+
+#### Scenario: NetFlow9Encoder output is unchanged
+
+- **WHEN** a `FlowExporter` ticks with encoder = `NetFlow9Encoder` before and after the interface extension
+- **THEN** the emitted datagrams SHALL be byte-identical for identical input records, input buffer, and timing
+
+#### Scenario: IPFIXEncoder output is unchanged
+
+- **WHEN** a `FlowExporter` ticks with encoder = `IPFIXEncoder` before and after the interface extension
+- **THEN** the emitted datagrams SHALL be byte-identical for identical input records, input buffer, and timing
+
+#### Scenario: sFlow encoder signals variable-length pagination
+
+- **WHEN** the sFlow encoder is registered as the active encoder
+- **THEN** its variable-length opt-in (the new interface method) SHALL return a non-zero value indicating its maximum per-record byte size
+- **AND** `FlowExporter.Tick` SHALL paginate so that no emitted datagram exceeds the buffer capacity of 1500 bytes
+
+### Requirement: Per-device source IP binding compatibility
+
+When `-flow-source-per-device` is enabled (the default) and the selected protocol is `sflow`, each sFlow datagram SHALL be sent from the per-device UDP socket bound to the device's IPv4. When per-device binding fails or is disabled, the shared simulator socket SHALL be used and a warning SHALL be logged noting that the sFlow `agent_address` may not match the UDP source IP observed by the collector.
+
+#### Scenario: Per-device socket carries agent address
+
+- **WHEN** `-flow-source-per-device` is true and device `D`'s per-device socket is successfully bound
+- **THEN** sFlow datagrams for `D` SHALL be sent from that socket
+- **AND** the packet's IPv4 source address as observed on the wire SHALL equal the sFlow datagram's `agent_address`
+
+#### Scenario: Warning on per-device bind failure in sFlow mode
+
+- **WHEN** per-device bind fails for device `D` and the selected protocol is `sflow`
+- **THEN** the simulator SHALL log a warning that includes both the device IP and a notice that `agent_address` may not match the UDP source IP
+- **AND** the exporter SHALL fall back to the shared simulator socket
+
+### Requirement: XDR encoding without new external dependency
+
+sFlow v5 datagrams SHALL be encoded using XDR primitives implemented within `go/simulator/sflow.go`. No new Go module dependency SHALL be added to `go.mod` solely to support XDR encoding.
+
+#### Scenario: No new module added for XDR
+
+- **WHEN** `go.mod` is inspected after this change is applied
+- **THEN** it SHALL NOT contain `github.com/davecgh/go-xdr` or any substitute XDR library added for this change
+
+### Requirement: Unit test coverage with XDR decoder oracle
+
+The `go/simulator` package SHALL include unit tests for the sFlow encoder that round-trip emitted datagrams through an in-process XDR decoder and assert field-by-field equality with the input records. The coverage SHALL parallel the structure of the existing `netflow9_test.go` and `ipfix_test.go`.
+
+#### Scenario: Emitted datagram round-trips through decoder
+
+- **WHEN** an `sflow_test.go` test case encodes a set of `FlowRecord` inputs and decodes the resulting bytes
+- **THEN** the decoded `agent_address`, `sequence_number`, `uptime`, and each sample record's tuple fields SHALL match the corresponding input values exactly
+
+#### Scenario: Tests run under `go test ./...`
+
+- **WHEN** `cd go && go test ./...` is run
+- **THEN** the sFlow tests SHALL execute and pass
+- **AND** existing NetFlow9 and IPFIX tests SHALL continue to pass
+
+### Requirement: Documentation labels sFlow samples as synthetic
+
+The project's top-level `README.md` and `CLAUDE.md` SHALL describe the sFlow output as synthetic and explicitly state that the simulator does not forward or sample real packets, so extrapolated link-volume metrics at the collector will not reflect real-world traffic.
+
+#### Scenario: README discloses synthetic sampling
+
+- **WHEN** `README.md` is read
+- **THEN** it SHALL list `sflow` (or `sflow5`) as a supported flow-export protocol
+- **AND** it SHALL include a sentence clarifying that sFlow samples are synthesized from `FlowCache` output and do not represent real packet capture
+
+#### Scenario: CLAUDE.md flow-export reference updated
+
+- **WHEN** `CLAUDE.md` is read
+- **THEN** its flow-export section SHALL include `sflow` in the protocol list for `-flow-protocol`
+- **AND** the section SHALL link to or cite sflow_version_5.txt as the reference specification

--- a/openspec/changes/add-sflow-export/specs/flow-export-sflow/spec.md
+++ b/openspec/changes/add-sflow-export/specs/flow-export-sflow/spec.md
@@ -71,39 +71,42 @@ When the selected protocol is `sflow`, the simulator SHALL convert each syntheti
 
 ### Requirement: sFlow v5 counter samples (Phase 2)
 
-When the selected protocol is `sflow` and Phase 2 counter-sample support is enabled, the simulator SHALL emit `COUNTERS_SAMPLE` (sample_type tag `counters_sample` or `counters_sample_expanded`) records alongside flow samples on each flow-export tick. Each counter sample SHALL include at minimum: one `if_counters` record per simulated interface, one `processor_information` record per device carrying CPU utilization, and one `memory_information` record per device carrying memory totals and usage.
+When the selected protocol is `sflow` and Phase 2 counter-sample support is enabled, the simulator SHALL emit `COUNTERS_SAMPLE` (sample_type tag `counters_sample` or `counters_sample_expanded`) records alongside flow samples on each flow-export tick. Each tick SHALL emit one `counters_sample` per simulated interface carrying that interface's `if_counters` record with `source_id = ifIndex`, plus one device-wide `counters_sample` with `source_id = 0` carrying a `processor_information` record (format 1001) whose standard `total_memory` and `free_memory` fields convey the device's memory totals. No non-standard counter-record format IDs SHALL be emitted.
 
 #### Scenario: Counter sample emitted per tick per device
 
 - **WHEN** the flow-export ticker fires with protocol `sflow` and Phase 2 enabled
 - **THEN** each active device SHALL emit at least one `COUNTERS_SAMPLE` record in that tick's datagram batch
 
-#### Scenario: Interface counters included
+#### Scenario: Interface counters grouped per-interface by source_id
 
-- **WHEN** a `COUNTERS_SAMPLE` is decoded for device `D`
-- **THEN** it SHALL contain one `if_counters` record for each simulated interface on `D`
+- **WHEN** a device with N simulated interfaces emits a `COUNTERS_SAMPLE` datagram
+- **THEN** the datagram SHALL contain N `counters_sample` records each with `source_id = ifIndex` and carrying exactly one `if_counters` record for that interface
 - **AND** each `if_counters` record SHALL carry non-zero `ifInOctets`, `ifOutOctets`, `ifInUcastPkts`, and `ifOutUcastPkts` fields derived from `IfCounterCycler` output
 
-#### Scenario: CPU and memory counters included
+#### Scenario: CPU and memory counters included in processor_information
 
 - **WHEN** a `COUNTERS_SAMPLE` is decoded for device `D`
-- **THEN** it SHALL contain exactly one `processor_information` record carrying at minimum `cpu_percentage` and `total_memory`
-- **AND** it SHALL contain exactly one `memory_information` record carrying `total` and `free` memory byte counts
+- **THEN** it SHALL contain exactly one `counters_sample` with `source_id = 0` carrying a `processor_information` record (format 1001)
+- **AND** the `processor_information` record SHALL carry CPU load percentages (`cpu_5s`, `cpu_1m`, `cpu_5m`) plus `total_memory` and `free_memory` byte counts
+- **AND** no counter-record format IDs outside the standard sFlow v5 registry SHALL be emitted
 
 ### Requirement: CounterSource abstraction
 
-Phase 2 counter sample emission SHALL be driven by a `CounterSource` interface rather than by direct coupling between `sflow.go` and `if_counters.go`. Existing `IfCounterCycler` state SHALL be exposed through an `InterfaceCounterSource` adapter implementing this interface without changing observable SNMP behaviour.
+Phase 2 counter sample emission SHALL be driven by a `CounterSource` interface rather than by direct coupling between `sflow.go` and `if_counters.go`. Existing `IfCounterCycler` state SHALL be exposed through an `InterfaceCounterSource` adapter implementing this interface without changing observable SNMP behaviour. Each `CounterRecord` returned by a source SHALL carry a `SourceID` identifying the data source (ifIndex for per-interface records, 0 for device-wide records) so the encoder can group records into `counters_sample` wrappers keyed by `source_id`.
 
 #### Scenario: InterfaceCounterSource reuses IfCounterCycler state
 
 - **WHEN** a device's `InterfaceCounterSource.Snapshot` is called at time `t`
 - **THEN** the returned `CounterRecord` values for interface counters SHALL equal the values that `IfCounterCycler` would produce at time `t` for the same device
+- **AND** each returned record SHALL carry `SourceID = ifIndex` so `EncodeCounterDatagram` emits one `counters_sample` per interface
 - **AND** the existing SNMP exposure of the same counters via `snmp_handlers.go` SHALL remain byte-identical before and after this refactor
 
-#### Scenario: CPU and memory counter sources are per-device
+#### Scenario: CPU counter source is per-device
 
 - **WHEN** the simulator initializes a device in sFlow mode with Phase 2 enabled
-- **THEN** the device SHALL have exactly one `CPUCounterSource` and exactly one `MemoryCounterSource` registered
+- **THEN** the device SHALL have exactly one `CPUCounterSource` registered
+- **AND** `CPUCounterSource.Snapshot` SHALL return exactly one `CounterRecord` with `SourceID = 0` and `Format = processor_information (1001)` carrying CPU load and memory totals/free fields
 
 ### Requirement: FlowEncoder interface tolerates variable-length records
 
@@ -113,11 +116,19 @@ The `FlowEncoder` interface SHALL be extended with a method that allows protocol
 
 - **WHEN** a `FlowExporter` ticks with encoder = `NetFlow9Encoder` before and after the interface extension
 - **THEN** the emitted datagrams SHALL be byte-identical for identical input records, input buffer, and timing
+- **AND** a pinned-hash regression test in `flow_exporter_test.go` SHALL assert this by MD5-hashing the structural (non-wall-clock) bytes of a canonical encode against a committed expected value
 
 #### Scenario: IPFIXEncoder output is unchanged
 
 - **WHEN** a `FlowExporter` ticks with encoder = `IPFIXEncoder` before and after the interface extension
 - **THEN** the emitted datagrams SHALL be byte-identical for identical input records, input buffer, and timing
+- **AND** a pinned-hash regression test in `flow_exporter_test.go` SHALL assert this by MD5-hashing the structural (non-wall-clock) bytes of a canonical encode against a committed expected value
+
+#### Scenario: NetFlow5Encoder output is unchanged
+
+- **WHEN** a `FlowExporter` ticks with encoder = `NetFlow5Encoder` before and after the interface extension
+- **THEN** the emitted datagrams SHALL be byte-identical for identical input records, input buffer, and timing
+- **AND** a pinned-hash regression test in `flow_exporter_test.go` SHALL assert this by MD5-hashing the structural (non-wall-clock) bytes of a canonical encode against a committed expected value
 
 #### Scenario: sFlow encoder signals variable-length pagination
 

--- a/openspec/changes/add-sflow-export/tasks.md
+++ b/openspec/changes/add-sflow-export/tasks.md
@@ -37,14 +37,14 @@
 - [x] 5.2 Extract interface counter state from `IfCounterCycler` in `go/simulator/if_counters.go` into an `InterfaceCounterSource` adapter implementing `CounterSource`. `IfCounterCycler` keeps its public SNMP surface; internally it delegates math to the new source.
 - [x] 5.3 Regression test: SNMP responses for `ifHCInOctets`, `ifHCOutOctets`, `ifInUcastPkts`, `ifOutUcastPkts`, `ifInErrors`, `ifInDiscards`, broadcast/multicast counters are byte-identical against a fixed device state before and after the refactor.
 - [x] 5.4 Add `CPUCounterSource` — per-device CPU utilization. Idle/user/system/wait percentages × 100 (the sFlow convention). Driven from a new simple cycler or tied to `MetricsCycler`.
-- [x] 5.5 Add `MemoryCounterSource` — per-device memory totals and usage (total, used, free, cached in bytes).
-- [x] 5.6 Wire `InterfaceCounterSource`, `CPUCounterSource`, and `MemoryCounterSource` registration into the device lifecycle in `go/simulator/device.go`.
+- [x] 5.5 ~~Add `MemoryCounterSource` — per-device memory totals and usage (total, used, free, cached in bytes).~~ Superseded by task 11.4: `total_memory` and `free_memory` are now folded into `CPUCounterSource`'s standard `processor_information` record (format 1001) to avoid emitting a simulator-local counter format that strict collectors would drop.
+- [x] 5.6 Wire `InterfaceCounterSource` and `CPUCounterSource` registration into the device lifecycle in `go/simulator/flow_exporter.go` (`registerSFlowCounterSources`).
 
 ## 6. sFlow v5 Phase 2 — counter samples
 
-- [x] 6.1 Extend `SFlowEncoder` to emit `COUNTERS_SAMPLE` records (prefer `counters_sample_expanded`). Encode `if_counters`, `processor_information`, and `memory_information` counter-record types.
+- [x] 6.1 Extend `SFlowEncoder` to emit `COUNTERS_SAMPLE` records. Encode `if_counters` (format 1) and `processor_information` (format 1001) counter-record types. Records are grouped per-`SourceID` (see task 11.1) — one `counters_sample` per ifIndex plus one device-wide sample with `source_id = 0`. Memory is carried inside `processor_information` (no standalone memory record).
 - [x] 6.2 Update `FlowExporter.Tick` (sFlow code path) so each tick collects `Snapshot` from all registered `CounterSource`s for the device and includes them as counter samples alongside flow samples in the emitted datagram batch.
-- [x] 6.3 Add counter-sample test cases to `sflow_test.go`: round-trip assertion that decoded `if_counters` equals `InterfaceCounterSource.Snapshot` output at the same time, and similarly for CPU and memory samples.
+- [x] 6.3 Add counter-sample test cases to `sflow_test.go`: round-trip assertion that decoded `if_counters` equals `InterfaceCounterSource.Snapshot` output at the same time, and similarly for CPU samples (memory values are carried inside the CPU `processor_information` record per task 5.5).
 - [x] 6.4 Verify counter sample emission respects the 1500-byte MTU: devices with many interfaces SHALL split counter records across multiple datagrams rather than produce an oversize packet.
 
 ## 7. Per-device source IP and agent identity
@@ -71,3 +71,15 @@
 
 - [ ] 10.1 Update project memory (`MEMORY.md`) if appropriate — add an entry documenting sFlow support and the synthetic-sampling caveat so future operator questions can be routed to the README note.
 - [ ] 10.2 Archive the OpenSpec change per the experimental workflow (`openspec archive add-sflow-export`) once it is merged and deployed.
+
+## 11. PR #47 review fixes (round 2)
+
+- [x] 11.1 **Counter-sample source_id grouping.** `SFlowEncoder.EncodeCounterDatagram` now groups `CounterRecord`s by `SourceID`: per-interface records appear under their own `counters_sample` with `source_id = ifIndex`, device-wide records (processor/memory) share a single `counters_sample` with `source_id = 0`. Required for collectors that key `if_counters` by ds_index (OpenNMS Telemetryd).
+- [x] 11.2 **Expose SourceID on CounterRecord.** Added `CounterRecord.SourceID` field. `InterfaceCounterSource.Snapshot` tags each record with its ifIndex; `CPUCounterSource` uses `SourceID = 0`.
+- [x] 11.3 **Byte-identity regression tests for NF9 / IPFIX / NF5.** Added `TestByteIdentity_NetFlow9`, `TestByteIdentity_IPFIX`, `TestByteIdentity_NetFlow5`, and `TestByteIdentity_NetFlow9_Deterministic` in `flow_exporter_test.go`. Each pins an MD5 hash of structural (non-wall-clock) datagram bytes for a canonical `FlowRecord` slice; future layout changes trip the hash and must update the test explicitly.
+- [x] 11.4 **Fold memory into processor_information.** Removed `MemoryCounterSource`, `sflowCtrFmtMemory` constant, and the separate memory encode path. `CPUCounterSource` now emits a single `processor_information` record with the `total_memory` / `free_memory` fields populated (standard sFlow v5 format 1001). Strict collectors no longer see a simulator-local format ID.
+- [x] 11.5 **Counter-sample pagination arithmetic.** Replaced the magic `16` in `flow_exporter.go` with named constant `sflowCountersSampleHeaderSize = 20` (8 sample header + 4 seq_no + 4 source_id + 4 num_counter_records) defined in `sflow.go`. Fix for the 4-byte underestimation.
+- [x] 11.6 **Log silent record loss in counter pagination.** `EncodeCounterDatagram` now logs `sflow: dropping N counter records that don't fit in datagram` when records can't fit in the buffer.
+- [x] 11.7 **Dead `recLenOffset` assignment.** Removed from `EncodeCounterDatagram`.
+- [x] 11.8 **Hand-rolled `itoa`.** Replaced with `strconv.Itoa` in `counter_source.go`.
+- [x] 11.9 **Unused `device *DeviceSimulator` fields.** Removed from `CPUCounterSource` (and `MemoryCounterSource` deleted wholesale in 11.4).

--- a/openspec/changes/add-sflow-export/tasks.md
+++ b/openspec/changes/add-sflow-export/tasks.md
@@ -1,0 +1,73 @@
+## 1. Pre-flight checks
+
+- [x] 1.1 Confirm issue #43 (NetFlow v5) merge status. This change and #43 both modify the protocol switch in `go/simulator/flow_exporter.go` around `InitFlowExport` (line ~271); they will be applied sequentially with **NetFlow v5 first**. If #43 is still open, rebase this change on top of it before starting task group 3.
+- [x] 1.2 Verify `-flow-protocol` CLI test fixtures cover the error path so the updated error message ("supported: netflow9, ipfix, sflow") has an assertion point.
+- [x] 1.3 Confirm with maintainer that the `10 × ConcurrentFlows` synthetic sampling rate (design.md §D3) is acceptable. If not, add `-flow-sflow-sampling-rate` flag work to the task list before starting.
+- [x] 1.4 Decide whether Phase 2 (counter samples) ships in the same PR as Phase 1 or as a follow-up. Default: same PR. If split, move task groups 5 and 6 out of this change.
+
+## 2. FlowEncoder interface extension
+
+- [x] 2.1 Add `MaxRecordSize() int` to the `FlowEncoder` interface in `go/simulator/flow_exporter.go`. Document that a return value of 0 preserves fixed-size pagination; non-zero opts into variable-length pagination.
+- [x] 2.2 Implement `MaxRecordSize() int { return 0 }` on `NetFlow9Encoder` (`go/simulator/netflow9.go`) and `IPFIXEncoder` (`go/simulator/ipfix.go`). No other changes to these encoders.
+- [x] 2.3 Update `FlowExporter.Tick` pagination loop to branch on `encoder.MaxRecordSize()`: when 0, keep existing fixed-record-size math; when non-zero, paginate by worst-case record size with the new encoder's per-record estimator.
+- [x] 2.4 Add a regression test asserting NetFlow9 and IPFIX datagram bytes are identical before and after the interface change for a canonical set of `FlowRecord` inputs. This is the non-regression gate for task 2.3.
+
+## 3. sFlow v5 encoder — Phase 1 (flow samples)
+
+- [x] 3.1 Create `go/simulator/sflow.go` with an `SFlowEncoder` struct implementing the extended `FlowEncoder` interface. Include inline XDR primitives: `putUint32`, `putOpaque` (with 4-byte padding), `putIP4`. No new `go.mod` dependencies.
+- [x] 3.2 Implement sFlow v5 datagram header encoding: version=5, agent_address_type=1, agent_address=deviceIP, sub_agent_id=0, sequence_number, uptime.
+- [x] 3.3 Implement `FLOW_SAMPLE` sample record encoding (prefer `flow_sample_expanded` for cleaner 5-tuple handling; document choice in code comments).
+- [x] 3.4 Implement `sampled_header` flow-record content: synthesize a minimal IPv4+UDP (or IPv4+TCP) header from `FlowRecord.SrcAddr`, `DstAddr`, `Protocol`, `SrcPort`, `DstPort`, with byte and packet counters from the record.
+- [x] 3.5 Wire synthetic sampling rate = `10 * FlowProfile.ConcurrentFlows` per design.md §D3. Expose as a named constant for traceability.
+- [x] 3.6 Register `"sflow"` and `"sflow5"` in the `InitFlowExport` switch in `go/simulator/flow_exporter.go`. Update the default-case error message to list all three protocols.
+- [x] 3.7 Update the `-flow-protocol` CLI flag help text in `go/simulator/simulator.go` to include `sflow` as a supported value.
+- [x] 3.8 Confirm `GET /api/v1/flows/status` canonicalizes both `sflow` and `sflow5` to `"sflow"` in its JSON response. Add an API-level test if coverage is missing.
+
+## 4. sFlow Phase 1 tests
+
+- [x] 4.1 Create `go/simulator/sflow_test.go` with an in-process XDR decoder oracle. The oracle decodes datagram header fields, iterates sample records, and exposes the `sampled_header` payload as a parseable IPv4 packet.
+- [x] 4.2 Round-trip test: encode N synthetic `FlowRecord` entries, decode them, assert agent_address / sequence_number / uptime / sample-record 5-tuple match input byte-for-byte.
+- [x] 4.3 MTU test: emit a batch sized to cross the 1500-byte boundary, assert `FlowExporter.Tick` emits multiple datagrams and no single datagram exceeds the buffer capacity.
+- [x] 4.4 Sequence number test: two consecutive ticks from the same device produce datagrams with sequence numbers differing by exactly 1.
+- [x] 4.5 Parallel structure check: `netflow9_test.go`, `ipfix_test.go`, and `sflow_test.go` share the same test-naming conventions and helper patterns where sensible.
+
+## 5. Counter source abstraction — Phase 2
+
+- [x] 5.1 Define `CounterSource` and `CounterRecord` types in a new file (suggested: `go/simulator/counter_source.go`). Keep the interface minimal — `Snapshot(t time.Time) []CounterRecord`.
+- [x] 5.2 Extract interface counter state from `IfCounterCycler` in `go/simulator/if_counters.go` into an `InterfaceCounterSource` adapter implementing `CounterSource`. `IfCounterCycler` keeps its public SNMP surface; internally it delegates math to the new source.
+- [x] 5.3 Regression test: SNMP responses for `ifHCInOctets`, `ifHCOutOctets`, `ifInUcastPkts`, `ifOutUcastPkts`, `ifInErrors`, `ifInDiscards`, broadcast/multicast counters are byte-identical against a fixed device state before and after the refactor.
+- [x] 5.4 Add `CPUCounterSource` — per-device CPU utilization. Idle/user/system/wait percentages × 100 (the sFlow convention). Driven from a new simple cycler or tied to `MetricsCycler`.
+- [x] 5.5 Add `MemoryCounterSource` — per-device memory totals and usage (total, used, free, cached in bytes).
+- [x] 5.6 Wire `InterfaceCounterSource`, `CPUCounterSource`, and `MemoryCounterSource` registration into the device lifecycle in `go/simulator/device.go`.
+
+## 6. sFlow v5 Phase 2 — counter samples
+
+- [x] 6.1 Extend `SFlowEncoder` to emit `COUNTERS_SAMPLE` records (prefer `counters_sample_expanded`). Encode `if_counters`, `processor_information`, and `memory_information` counter-record types.
+- [x] 6.2 Update `FlowExporter.Tick` (sFlow code path) so each tick collects `Snapshot` from all registered `CounterSource`s for the device and includes them as counter samples alongside flow samples in the emitted datagram batch.
+- [x] 6.3 Add counter-sample test cases to `sflow_test.go`: round-trip assertion that decoded `if_counters` equals `InterfaceCounterSource.Snapshot` output at the same time, and similarly for CPU and memory samples.
+- [x] 6.4 Verify counter sample emission respects the 1500-byte MTU: devices with many interfaces SHALL split counter records across multiple datagrams rather than produce an oversize packet.
+
+## 7. Per-device source IP and agent identity
+
+- [x] 7.1 Confirm that the existing per-device socket path in `openFlowConnForDevice` (in `go/simulator/flow_exporter.go`) is reused unchanged by sFlow; the sFlow encoder only needs the device IP it already knows from `fe.domainID`.
+- [x] 7.2 Update the per-device bind-failure warning in `openFlowConnForDevice` to mention that in sFlow mode the collector may observe a mismatch between `agent_address` and the UDP packet source IP.
+- [ ] 7.3 Add an integration-style test that asserts, in per-device mode, the UDP source IP on the wire equals the sFlow `agent_address` inside the datagram. **(Deferred: requires running as root with the opensim network namespace and TUN interfaces; not reachable from `go test` in CI. Addressed in the pre-commit manual smoke tests — task 9.3 / 9.4.)**
+
+## 8. Documentation
+
+- [x] 8.1 Update `CLAUDE.md` flow-export section: add `sflow` (alias `sflow5`) to the `-flow-protocol` flag list. Cite sflow_version_5.txt as the reference spec.
+- [x] 8.2 Update `README.md`: list `sflow` as a supported protocol. Add an explicit sentence that sFlow output is synthesized from `FlowCache` and does not reflect real packet capture or link utilization.
+- [x] 8.3 Note the synthetic sampling rate (`10 × ConcurrentFlows`) in the same README paragraph so operators know what they're looking at.
+
+## 9. Validation
+
+- [x] 9.1 Run `cd go && go mod tidy && go build ./...` and verify no new `go.mod` entries beyond what existed before the change.
+- [x] 9.2 Run `cd go && go test ./...`; assert all NetFlow9, IPFIX, and new sFlow tests pass.
+- [ ] 9.3 Manual smoke test against the OpenNMS Telemetryd sFlow adapter: confirm flows are ingested without decode errors in the Telemetryd log. **(Deferred to maintainer post-merge — requires a running OpenNMS Telemetryd instance.)**
+- [ ] 9.4 Manual smoke test against a second external collector (e.g. Inmon sFlowTrend or `sflowtool`) to confirm the emitted datagrams are protocol-compliant beyond a single collector's parser. **(Deferred to maintainer post-merge — requires external collector tooling.)**
+- [x] 9.5 Run `openspec validate add-sflow-export --strict` and fix any findings.
+
+## 10. Post-merge
+
+- [ ] 10.1 Update project memory (`MEMORY.md`) if appropriate — add an entry documenting sFlow support and the synthetic-sampling caveat so future operator questions can be routed to the README note.
+- [ ] 10.2 Archive the OpenSpec change per the experimental workflow (`openspec archive add-sflow-export`) once it is merged and deployed.


### PR DESCRIPTION
## Summary

- Adds sFlow v5 as a fourth flow-export protocol. Registered as `sflow` / `sflow5` under `-flow-protocol`.
- Extends the `FlowEncoder` contract with `MaxRecordSize() int` to support variable-length XDR records. Fixed-size encoders (v5/v9/IPFIX) return 0 — existing pagination path byte-for-byte unchanged.
- Phase 1 (flow samples): synthetic IPv4 UDP/TCP/ICMP `flow_sample` records at `10 × FlowProfile.ConcurrentFlows` sampling rate (documented as synthetic — the simulator doesn't forward real traffic). Per-datagram agent identity = device IPv4, reuses the existing per-device socket.
- Phase 2 (counter samples): new `CounterSource` interface; `IfCounterCycler` wrapped by `InterfaceCounterSource` adapter with a regression test asserting byte-for-byte SNMP equivalence. Stub CPU + memory sources emit standard `generic_iface` and `processor_information` records.
- Inline XDR primitives — zero new `go.mod` entries. Tests use an in-process XDR decoder oracle.

Closes #42.

OpenSpec change: `openspec/changes/add-sflow-export/` (strict-validated).

## Stacked on

Base branch is **`feat/netflow5-export`** (PR #46). Review #46 first — the diff here is only the sFlow additions.

## Test plan

- [ ] `cd go && go test ./... -count=1 -race` passes locally
- [ ] `go test -run SFlow` — 16 oracle-backed tests pass
- [ ] Manual smoke against OpenNMS Telemetryd sFlow adapter
- [ ] Manual smoke against sflowtool / sFlowTrend
- [ ] Wireshark decode of a captured datagram (agent address matches device IP)

## Notes for reviewer

- DCO: commits not signed off; maintainer will `git rebase --signoff main` before merge.
- CPU / memory counter values are stubbed constants — see `counter_source.go`. Follow-up can wire these to `MetricsCycler` when the ifHC cycling work lands.
- `memory_information` uses a simulator-local format ID (4000) since the sFlow standard registry does not include a freestanding memory record. If collectors object, fold into `processor_information` (which already carries total/free memory fields).