### PR TITLE
docs: enable md_in_html and pymdownx.emoji in MkDocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ markdown_extensions:
   - admonition
   - attr_list
   - def_list
+  - md_in_html
   - tables
   - pymdownx.details
   - pymdownx.superfences
@@ -54,6 +55,9 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.tabbed:
       alternate_style: true
   - toc:


### PR DESCRIPTION
## Summary

- Add `md_in_html` so Material's grid cards on the landing page hydrate instead of collapsing into a flat bullet list.
- Add `pymdownx.emoji` wired to Material's Twemoji index + SVG generator so `:octicons-arrow-right-24:` shortcodes render as icons.

## Test plan

- [ ] `mkdocs serve` and verify the "Where to go next" grid on `index.md` renders as four cards
- [ ] Confirm the Octicon arrow icons render next to the link labels
- [ ] `mkdocs build --strict` passes