### PR TITLE
docs(architecture): add C4 container diagram + enable Mermaid rendering

### DIFF
--- a/docs/javascripts/mermaid-zoom.js
+++ b/docs/javascripts/mermaid-zoom.js
@@ -1,0 +1,92 @@
+(function () {
+  'use strict';
+
+  // Material 9.x renders Mermaid into a closed shadow DOM
+  // (`attachShadow({mode: "closed"})`), which blocks both external CSS
+  // from styling the SVG and external JS from querying it. Force
+  // `mode: "open"` so the overlay can clone the rendered SVG. Scoped in
+  // practice because Material only calls attachShadow for Mermaid.
+  const origAttachShadow = Element.prototype.attachShadow;
+  Element.prototype.attachShadow = function (opts) {
+    return origAttachShadow.call(this, Object.assign({}, opts, { mode: 'open' }));
+  };
+
+  let overlay;
+  let lastFocus;
+
+  function ensureOverlay() {
+    if (overlay) return overlay;
+    overlay = document.createElement('div');
+    overlay.className = 'mermaid-zoom-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-label', 'Enlarged diagram');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('tabindex', '-1');
+    overlay.innerHTML = '<div class="mermaid-zoom-inner"></div>';
+    overlay.addEventListener('click', closeOverlay);
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  function openOverlay(host) {
+    const svg = host.shadowRoot && host.shadowRoot.querySelector('svg');
+    if (!svg) return;
+    const o = ensureOverlay();
+    const inner = o.querySelector('.mermaid-zoom-inner');
+    inner.innerHTML = '';
+    const clone = svg.cloneNode(true);
+    clone.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    clone.removeAttribute('style');
+    inner.appendChild(clone);
+    lastFocus = document.activeElement;
+    o.classList.add('open');
+    o.focus();
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeOverlay() {
+    if (!overlay) return;
+    overlay.classList.remove('open');
+    overlay.querySelector('.mermaid-zoom-inner').innerHTML = '';
+    document.body.style.overflow = '';
+    if (lastFocus && typeof lastFocus.focus === 'function') lastFocus.focus();
+    lastFocus = null;
+  }
+
+  function enhance(host) {
+    if (host.dataset.zoomEnhanced === '1') return;
+    if (!host.shadowRoot || !host.shadowRoot.querySelector('svg')) return;
+    host.dataset.zoomEnhanced = '1';
+    host.addEventListener('click', function (e) {
+      e.stopPropagation();
+      openOverlay(host);
+    });
+  }
+
+  function enhanceAll() {
+    document.querySelectorAll('div.mermaid').forEach(enhance);
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && overlay && overlay.classList.contains('open')) closeOverlay();
+  });
+
+  new MutationObserver(function (mutations) {
+    for (const m of mutations) {
+      for (const node of m.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (node.matches && node.matches('div.mermaid')) {
+          enhance(node);
+        } else if (node.querySelectorAll) {
+          node.querySelectorAll('div.mermaid').forEach(enhance);
+        }
+      }
+    }
+  }).observe(document.body, { childList: true, subtree: true });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', enhanceAll);
+  } else {
+    enhanceAll();
+  }
+})();

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -8,6 +8,46 @@ server, and — for storage devices — its own HTTPS REST endpoint.
 This page covers the package layout, core components, and the key design
 decisions that make the 30,000-device target tractable.
 
+## System overview
+
+The diagram below is laid out as a [C4 container](https://c4model.com/#ContainerDiagram)
+view (rendered as a Mermaid flowchart): it shows what lives inside the
+l8opensim process boundary, the host-side Linux infrastructure it depends on,
+and how operators and monitoring systems interact with it.
+
+```mermaid
+%%{init: {'themeVariables': {'fontSize': '18px'}}}%%
+flowchart LR
+    operator(["Operator<br/><small>human</small>"]):::person
+    nms(["NMS / Monitoring<br/><small>OpenNMS, Prometheus,<br/>flow collectors</small>"]):::ext
+
+    subgraph l8opensim ["l8opensim (Go process)"]
+        simulator["<b>Simulator</b><br/><small>Go binary</small><br/>Device lifecycle,<br/>SNMP v2c/v3 + SSH + HTTPS REST,<br/>metrics engine, flow exporter"]
+        l8["<b>L8 Overlay</b><br/><small>Go</small><br/>Optional vnet mesh +<br/>HTTPS web proxy :9095"]
+        proxy["<b>Reverse Proxy</b><br/><small>Go</small><br/>L8 frontend to<br/>simulator backend"]
+        resources[("<b>Resources</b><br/><small>379 JSON files</small><br/>28 device-type directories<br/>SNMP / SSH / REST fixtures")]
+    end
+
+    subgraph kernel ["Linux kernel (host)"]
+        netns["<b>opensim netns</b><br/><small>network namespace</small><br/>Isolated routing,<br/>iptables FORWARD rule"]
+        tun["<b>TUN interfaces</b><br/><small>Linux TUN</small><br/>Per-device IP,<br/>pre-allocated in parallel"]
+    end
+
+    operator -->|"CLI flags, REST API<br/><small>HTTP :8080</small>"| simulator
+    operator -->|"Web UI<br/><small>HTTPS :9095</small>"| l8
+    l8 --> proxy --> simulator
+    simulator -->|loads on startup| resources
+    simulator -->|creates, writes<br/><small>ioctl</small>| tun
+    simulator -->|runs inside| netns
+    nms -->|"polls devices<br/><small>SNMP / SSH / HTTPS</small>"| tun
+    simulator -->|"exports flows<br/><small>NetFlow v5/v9,<br/>IPFIX, sFlow v5</small>"| nms
+
+    classDef person fill:#08427b,stroke:#052e56,color:#fff
+    classDef ext fill:#999,stroke:#666,color:#fff
+    classDef default fill:#438dd5,stroke:#2e6da4,color:#fff
+    class simulator,l8,proxy,resources,netns,tun default
+```
+
 ## Package layout
 
 | Path | Purpose |

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,44 @@
+.md-typeset .mermaid {
+  text-align: center;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.md-typeset .mermaid[data-zoom-enhanced="1"] {
+  cursor: zoom-in;
+}
+
+.mermaid-zoom-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  cursor: zoom-out;
+}
+
+.mermaid-zoom-overlay.open {
+  display: flex;
+}
+
+.mermaid-zoom-inner {
+  background: var(--md-default-bg-color);
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+  box-sizing: border-box;
+  max-width: 95vw;
+  max-height: 95vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mermaid-zoom-inner svg {
+  width: calc(95vw - 3rem);
+  height: calc(95vh - 3rem);
+  cursor: zoom-out;
+  display: block;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,12 @@ repo_url: https://github.com/labmonkeys-space/l8opensim
 repo_name: labmonkeys-space/l8opensim
 edit_uri: edit/main/docs/
 
+extra_css:
+  - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/mermaid-zoom.js
+
 theme:
   name: material
   features:
@@ -48,7 +54,11 @@ markdown_extensions:
   - md_in_html
   - tables
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
## Summary

- Enable Mermaid in MkDocs by registering a `mermaid` custom fence in `pymdownx.superfences`. Material auto-loads Mermaid.js when it sees the `.mermaid` class, so no extra theme wiring is needed.
- Add a C4 container diagram to `docs/reference/architecture.md` showing the l8opensim process boundary (simulator, L8 overlay, reverse proxy, resource fixtures), host-side Linux infrastructure (opensim netns, TUN interfaces), and operator / NMS interactions.

## Test plan

- [ ] `mkdocs serve` and open `/reference/architecture/` — verify the C4 diagram renders (not a raw code block)
- [ ] Confirm the `mermaid` code-fence block is replaced with an SVG in the browser
- [ ] `mkdocs build --strict` passes