### PR TITLE
docs(snmp-trap): add operator guide and reference page for SNMPv2c trap/INFORM

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ landing page; everything below lives here.
     flow export.
 
     [:octicons-arrow-right-24: Scaling](ops/scaling.md) ·
-    [:octicons-arrow-right-24: Flow export](ops/flow-export.md)
+    [:octicons-arrow-right-24: Flow export](ops/flow-export.md) ·
+    [:octicons-arrow-right-24: SNMP traps](ops/snmp-traps.md)
 
 -   __Reference__
 

--- a/docs/ops/snmp-traps.md
+++ b/docs/ops/snmp-traps.md
@@ -88,7 +88,11 @@ guidance:
 
 Per-device source IP binding reuses the same `opensim` network namespace
 plumbing as flow export — no new `iptables` rules and no new netns setup.
-The same three conditions apply:
+In TRAP mode, a per-device bind failure for any device is survivable: the
+simulator logs a warning and that device falls back to the shared UDP
+socket (its traps arrive at the collector with the simulator host's IP as
+the source). In INFORM mode, the same failure is fatal for that device —
+no ack demux without a per-device socket. The same three conditions apply:
 
 - **`iptables FORWARD` rule.** At startup the simulator inserts
   `FORWARD -i veth-sim-host -j ACCEPT` so Docker-present hosts (which

--- a/docs/ops/snmp-traps.md
+++ b/docs/ops/snmp-traps.md
@@ -1,0 +1,160 @@
+# SNMP trap / INFORM export (operator guide)
+
+l8opensim can emit SNMPv2c notifications — both fire-and-forget **TRAP**s (PDU
+`0xA7`) and acknowledged **INFORM**s (PDU `0xA6`) — from every simulated device
+to a single collector such as OpenNMS `trapd` or `snmptrapd`. Each device
+generates its own notifications with its own IP as the UDP source, so
+collectors that key on the agent source IP attribute correctly without extra
+work.
+
+This page is the operator-facing setup guide. For the CLI flags see
+[CLI flags → SNMP trap / INFORM export](../reference/cli-flags.md#snmp-trap-inform-export-flags);
+for wire format, catalog JSON, and HTTP endpoints see
+[SNMP trap reference](../reference/snmp-traps.md).
+
+## Enabling trap export
+
+The feature is off by default. Pass `-trap-collector <host:port>` to enable
+it; the other eight flags have sensible defaults for OpenNMS and `snmptrapd`.
+
+```bash
+# 100 devices firing a random catalog trap every ~30s (Poisson-distributed)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -trap-collector 192.168.1.10:162
+
+# Tighter interval + global rate cap (≤ 200 trap packets/s across all devices)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 1000 \
+  -trap-collector 192.168.1.10:162 \
+  -trap-interval 5s -trap-global-cap 200
+
+# INFORM mode — requires per-device source binding (the default)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -trap-collector 192.168.1.10:162 -trap-mode inform \
+  -trap-inform-timeout 3s -trap-inform-retries 1
+
+# Custom catalog
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -trap-collector 192.168.1.10:162 \
+  -trap-catalog /etc/opensim/my-traps.json
+```
+
+## TRAP vs INFORM
+
+| Mode | PDU tag | Delivery | Collector ack | Retries | Best for |
+|------|---------|----------|---------------|---------|----------|
+| `trap` (default) | `0xA7` | Fire-and-forget | None | n/a | Sustained load testing at high rates. Simplest to reason about. |
+| `inform` | `0xA6` | Acknowledged | GetResponse-PDU (`0xA2`) | `-trap-inform-retries` (default 2) | Exercising the collector's ack path and retry semantics. |
+
+**INFORM requires `-trap-source-per-device=true`** (the default). The
+simulator uses each device's per-device UDP socket to demultiplex ack
+traffic back to the originating device — there is no single shared
+request-id table. If you explicitly set `-trap-source-per-device=false`
+while in INFORM mode, startup fails with a clear error.
+
+## Pending informs and retries
+
+Each device keeps up to **100 outstanding INFORMs** waiting for a collector
+ack. On overflow, the oldest pending entry is dropped (and counted as
+`informs_dropped` in `/api/v1/traps/status`). This bounds memory when the
+collector is unreachable.
+
+When the collector ack doesn't arrive within `-trap-inform-timeout`
+(default 5s), the simulator retransmits the INFORM up to
+`-trap-inform-retries` times (default 2). **Retransmissions consume global
+rate-cap tokens** — by design, so a collector outage can't amplify wire
+traffic via retry storms. After all retries expire without ack, the
+pending entry is removed and counted as `informs_failed`.
+
+## Rate cap and scheduling
+
+Per-device firing follows a **Poisson process** with mean
+`-trap-interval` (default 30s) rather than fixed periodic ticks — each
+device draws an exponential inter-arrival offset after every fire.
+Naïve periodic scheduling causes synchronised-burst artefacts at tick
+boundaries that stress the collector's ingest queue without reflecting
+real-world trap shapes. Poisson produces the clustered-but-not-synchronous
+pattern that misbehaving device fleets actually look like.
+
+`-trap-global-cap <tps>` adds a hard ceiling across all devices. Sizing
+guidance:
+
+- **Steady-state estimate:** `devices / trap_interval_seconds`.
+  30,000 devices at `-trap-interval 30s` ≈ 1000 tps average.
+- **Under-cap deliberately** to leave headroom for INFORM retransmissions
+  and for any on-demand fires you inject through the HTTP endpoint.
+- `-trap-global-cap 0` (the default) means unlimited.
+
+## Prerequisites inherited from flow export
+
+Per-device source IP binding reuses the same `opensim` network namespace
+plumbing as flow export — no new `iptables` rules and no new netns setup.
+The same three conditions apply:
+
+- **`iptables FORWARD` rule.** At startup the simulator inserts
+  `FORWARD -i veth-sim-host -j ACCEPT` so Docker-present hosts (which
+  default FORWARD to drop) allow per-device egress. Walkthrough:
+  [Flow export → Prerequisites](flow-export.md#prerequisites-for-per-device-source-ip).
+- **Route to the collector from inside the namespace.** Same default route
+  via `veth-sim-host` (`10.254.0.1`); if you've customised host routing,
+  verify with `sudo ip netns exec opensim ip route get <collector-ip>`.
+- **Collector-side `rp_filter`.** Reverse-path filtering on the collector
+  host may drop UDP/162 packets whose source IP (`10.0.0.x`, `10.42.0.x`,
+  whatever subnet your devices live in) isn't reachable back through the
+  receiving interface. Loose mode fixes it:
+  ```bash
+  sudo sysctl -w net.ipv4.conf.all.rp_filter=2
+  sudo sysctl -w net.ipv4.conf.<iface>.rp_filter=2
+  ```
+
+## Smoke test with snmptrapd
+
+The simplest end-to-end check uses `snmptrapd` in foreground mode with
+formatted logging to stdout:
+
+```bash
+# In one terminal — log every received trap to stdout
+sudo snmptrapd -f -Of -Lo -c /etc/snmp/snmptrapd.conf 162
+
+# In another terminal — point the simulator at it
+sudo ./simulator -auto-start-ip 127.0.0.1 -auto-count 5 \
+  -trap-collector 127.0.0.1:162 -trap-interval 2s
+```
+
+You should see lines arriving every few seconds tagged with the simulated
+device IP as the sender and an OID from the universal catalog
+(`linkDown` / `linkUp` dominate; `coldStart` / `warmStart` /
+`authenticationFailure` appear less often).
+
+If you need it sooner on demand:
+
+```bash
+# Fire a specific trap immediately via the HTTP API
+curl -X POST http://localhost:8080/api/v1/devices/127.0.0.1/trap \
+  -H "Content-Type: application/json" \
+  -d '{"name":"linkDown","varbindOverrides":{"IfIndex":"3"}}'
+```
+
+See [Web API → Fire a trap on demand](../reference/web-api.md#fire-a-trap-on-demand)
+for the full request / response shape.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `enabled: false` in `/api/v1/traps/status` | `-trap-collector` not set | Pass the flag; verify port |
+| `enabled: true`, `sent` is 0 | Scheduler idle (no devices yet) | Wait for device creation to finish |
+| Traps sent but collector sees nothing | FORWARD rule missing or `rp_filter` blocking | See [Flow export → Flow troubleshooting](flow-export.md#flow-troubleshooting) — the netns diagnostic steps apply verbatim |
+| Source IP on the wire is the host, not the device | Per-device bind failed for that device | Check simulator logs for `per-device bind failed`. TRAP mode falls back to shared socket with a warning; INFORM mode refuses to start |
+| `informs_failed` climbing, `informs_acked` flat | Collector not ack'ing (down, firewall, misconfigured) | Verify collector ingest; relax `rp_filter`; check collector logs |
+| `informs_dropped` climbing | Per-device pending cap (100) exhausted — collector unreachable long enough that old entries are being aged out | Collector-side issue; fix there. Simulator is doing the right thing |
+| Startup error about INFORM + per-device binding | `-trap-mode inform` with `-trap-source-per-device=false` | Remove the `-trap-source-per-device` override; INFORM requires per-device sockets |
+
+For generic bring-up failures (TUN module missing, `sudo` required, port
+conflicts) see [Troubleshooting](troubleshooting.md).
+
+## Related
+
+- [SNMP trap reference](../reference/snmp-traps.md) — wire format, catalog JSON, HTTP endpoints
+- [CLI flags → SNMP trap / INFORM export flags](../reference/cli-flags.md#snmp-trap-inform-export-flags)
+- [Flow export (operator guide)](flow-export.md) — shared `opensim` namespace plumbing
+- [Web API → Fire a trap on demand](../reference/web-api.md#fire-a-trap-on-demand)

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -75,6 +75,24 @@ details.
 | `-flow-template-interval` | int (seconds) | `60` | Template retransmission interval (NetFlow v9 / IPFIX only). |
 | `-flow-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. |
 
+## SNMP trap / INFORM export flags
+
+See [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) for
+prerequisites and `snmptrapd` smoke-test, and
+[SNMP trap reference](snmp-traps.md) for wire format and catalog JSON.
+
+| Flag | Type | Default | Purpose |
+|------|------|---------|---------|
+| `-trap-collector` | string | — | Enable trap export to this UDP collector (e.g. `192.168.1.10:162`). Empty disables the feature. |
+| `-trap-mode` | `trap` \| `inform` | `trap` | Notification mode. TRAP is fire-and-forget; INFORM is acknowledged and retried. |
+| `-trap-interval` | duration | `30s` | Per-device mean firing interval (Poisson-distributed, not periodic). |
+| `-trap-global-cap` | int (tps) | `0` | Simulator-wide rate ceiling across fires + INFORM retries. `0` is unlimited. |
+| `-trap-catalog` | string | — | Path to a JSON catalog; empty uses the embedded universal 5-trap catalog. |
+| `-trap-community` | string | `public` | SNMPv2c community string. |
+| `-trap-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. **Required** when `-trap-mode inform`. |
+| `-trap-inform-timeout` | duration | `5s` | Per-retry timeout in INFORM mode. |
+| `-trap-inform-retries` | int | `2` | Maximum retransmissions per INFORM before it's declared failed. |
+
 ## Examples
 
 ```bash

--- a/docs/reference/snmp-traps.md
+++ b/docs/reference/snmp-traps.md
@@ -8,6 +8,21 @@ JSON shape. For enabling the feature, CLI flags, and troubleshooting see
 [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) and
 [CLI flags → SNMP trap / INFORM export](cli-flags.md#snmp-trap-inform-export-flags).
 
+## Scope and security posture
+
+Traps are always emitted as **SNMPv2c** regardless of whether the
+simulator's polling side is configured with `-snmpv3-engine-id` — the
+two paths are independent. An operator running v3-authenticated polls
+against the simulator still sees v2c community-authenticated traps on
+port 162.
+
+The SNMPv2c community string (`-trap-community`, default `public`) rides
+in the clear on every trap and inform. This is a property of SNMPv2c
+itself, not a simulator choice, and matches how the simulator's polling
+side treats v2c. Do not select a production-like community secret — the
+simulator is for testing collector plumbing, not for ingesting
+confidential data.
+
 ## Architecture
 
 - **Central scheduler goroutine** (`trap_scheduler.go`) owns a min-heap of
@@ -177,8 +192,9 @@ Responses:
 | Status | Body | When |
 |--------|------|------|
 | `202 Accepted` | `{"requestId": <uint32>}` | Success; the trap has been enqueued. For INFORM mode the `requestId` is the INFORM PDU's `request-id` — correlate with `/api/v1/traps/status` to watch its lifecycle. |
-| `400 Bad Request` | `{"success": false, "message": "..."}` | Unknown catalog entry name. |
+| `400 Bad Request` | `{"success": false, "message": "..."}` | Malformed JSON body, missing/empty `name` field, or unknown catalog entry name. |
 | `404 Not Found` | `{"success": false, "message": "..."}` | Unknown device IP. |
+| `500 Internal Server Error` | `{"success": false, "message": "..."}` | `Fire` failed for a non-lookup reason — template resolve error or write failure. Logs on the simulator side carry the detail. |
 | `503 Service Unavailable` | `{"success": false, "message": "..."}` | Trap export is disabled (`-trap-collector` not set). |
 
 The endpoint is fire-and-forget — it does **not** block waiting for an
@@ -188,34 +204,45 @@ INFORM ack.
 
 `GET /api/v1/traps/status` — current snapshot of the trap subsystem.
 
-When enabled in INFORM mode (the most complete response shape):
+Unlike `/api/v1/flows/status`, this endpoint does **not** wrap its body
+in the `{success, message, data}` envelope — `TrapStatus` is serialised
+directly at the top level. When enabled in INFORM mode (the most complete
+response shape):
 
 ```json
 {
-  "success": true,
-  "message": "Success",
-  "data": {
-    "enabled": true,
-    "mode": "inform",
-    "collector": "192.168.1.10:162",
-    "community": "public",
-    "sent": 182430,
-    "informs_pending": 17,
-    "informs_acked": 182380,
-    "informs_failed": 33,
-    "informs_dropped": 0,
-    "rate_limiter_tokens_available": 94,
-    "devices_exporting": 100
-  }
+  "enabled": true,
+  "mode": "inform",
+  "collector": "192.168.1.10:162",
+  "community": "public",
+  "sent": 182430,
+  "informs_pending": 17,
+  "informs_acked": 182380,
+  "informs_failed": 33,
+  "informs_dropped": 0,
+  "rate_limiter_tokens_available": 94,
+  "devices_exporting": 100
 }
 ```
 
 When enabled in TRAP mode, the four `informs_*` fields are omitted (no
-INFORM state to report). When disabled: `{"enabled": false}`.
+INFORM state to report). When disabled the response is:
+
+```json
+{"enabled": false, "sent": 0, "devices_exporting": 0}
+```
+
+(`sent` and `devices_exporting` are not tagged `omitempty` so they are
+always present; their values are zero when the feature is off.)
 
 `rate_limiter_tokens_available` is present only when `-trap-global-cap`
 is set; it's a best-effort instantaneous snapshot, not synchronised with
 concurrent rate-limiter waits.
+
+The `sent` counter increments on **every wire emission including INFORM
+retransmissions**, so `sent` can exceed the sum of the four INFORM state
+counters under retry churn. The counter invariant below applies to
+*originated* informs, not to the `sent` tally.
 
 ### Counter invariant
 

--- a/docs/reference/snmp-traps.md
+++ b/docs/reference/snmp-traps.md
@@ -1,0 +1,247 @@
+# SNMP trap / INFORM reference
+
+l8opensim emits **SNMPv2c** notifications only. The PDU encoder in
+`go/simulator/trap_v2c.go` handles TRAPs and INFORMs; SNMPv1 traps and SNMPv3
+notifications are deferred and tracked as follow-up work. This page covers
+the wire format, the JSON catalog schema, the HTTP endpoints, and the status
+JSON shape. For enabling the feature, CLI flags, and troubleshooting see
+[SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) and
+[CLI flags → SNMP trap / INFORM export](cli-flags.md#snmp-trap-inform-export-flags).
+
+## Architecture
+
+- **Central scheduler goroutine** (`trap_scheduler.go`) owns a min-heap of
+  `(nextFire, deviceIP)` entries. Single goroutine regardless of device
+  count — no 30k `time.Ticker`s.
+- **Per-device `TrapExporter`** (`trap_exporter.go`) owns the device's UDP
+  socket, request-id counter, pending-inform map, and stats.
+- **Shared `TrapEncoder` interface** (`trap_v2c.go`) — narrow surface
+  (`EncodeTrap`, `EncodeInform`, `ParseAck`) so SNMPv1 and SNMPv3 encoders
+  can layer in later without changing the scheduler or exporter.
+- **Embedded catalog** loaded via `go:embed` from
+  `resources/_common/traps.json` at startup — no filesystem dependency
+  for the out-of-box experience. `-trap-catalog <path>` replaces the
+  embedded default with a user-supplied JSON file (complete override,
+  not merge).
+- **Global rate limiter** (`golang.org/x/time/rate`) gates both fresh
+  fires and INFORM retransmissions so a collector outage cannot amplify
+  wire traffic past the operator-configured ceiling.
+
+## Wire format
+
+Every SNMPv2c notification is a BER-encoded SEQUENCE containing three
+top-level fields:
+
+| Field | Type | Value |
+|-------|------|-------|
+| `version` | INTEGER | `1` (SNMPv2c) |
+| `community` | OCTET STRING | From `-trap-community` (default `public`) |
+| `data` | PDU | TRAP or InformRequest |
+
+The PDU envelope is one of three ASN.1 tags:
+
+| Tag | Name | Direction | Used for |
+|-----|------|-----------|----------|
+| `0xA7` | SNMPv2-Trap-PDU | simulator → collector | `-trap-mode trap` |
+| `0xA6` | InformRequest-PDU | simulator → collector | `-trap-mode inform` |
+| `0xA2` | GetResponse-PDU | collector → simulator | INFORM acknowledgement |
+
+Inside each PDU: `request-id` (INTEGER), `error-status` (INTEGER, always 0
+on emission), `error-index` (INTEGER, always 0), and a variable-bindings
+SEQUENCE.
+
+### Auto-prepended varbinds
+
+RFC 3416 §4.2.6 mandates the first two varbinds of every SNMPv2
+notification. The encoder always prepends them automatically — catalog
+authors supply only body varbinds, and the catalog loader rejects entries
+that list either reserved OID:
+
+| Position | OID | Type | Source |
+|----------|-----|------|--------|
+| 1 | `1.3.6.1.2.1.1.3.0` (`sysUpTime.0`) | TimeTicks (`0x43`) | Device uptime in 1/100-second ticks |
+| 2 | `1.3.6.1.6.3.1.1.4.1.0` (`snmpTrapOID.0`) | OID (`0x06`) | Catalog entry's `snmpTrapOID` |
+
+Everything after position 2 is the catalog entry's body varbinds with
+templates resolved to concrete values.
+
+### INFORM acknowledgement
+
+The collector replies to an INFORM with a GetResponse-PDU (`0xA2`) whose
+`request-id` matches the INFORM's. The simulator demultiplexes acks via
+each device's per-device UDP socket — no global request-id table. Acks
+without a matching pending entry (duplicates, stale responses) are
+silently ignored.
+
+## Catalog JSON schema
+
+The embedded universal catalog at
+`go/simulator/resources/_common/traps.json` is the authoritative example
+of the schema:
+
+```json
+{
+  "traps": [
+    {
+      "name": "linkDown",
+      "snmpTrapOID": "1.3.6.1.6.3.1.1.5.3",
+      "weight": 40,
+      "varbinds": [
+        { "oid": "1.3.6.1.2.1.2.2.1.1.{{.IfIndex}}", "type": "integer", "value": "{{.IfIndex}}" },
+        { "oid": "1.3.6.1.2.1.2.2.1.7.{{.IfIndex}}", "type": "integer", "value": "2" },
+        { "oid": "1.3.6.1.2.1.2.2.1.8.{{.IfIndex}}", "type": "integer", "value": "2" }
+      ]
+    }
+  ]
+}
+```
+
+Top-level object:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `traps` | array | yes | List of catalog entries. Must contain at least one. |
+
+Per-entry object:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `name` | string | yes | Unique within the catalog. Used by the HTTP fire-on-demand endpoint and for log attribution. |
+| `snmpTrapOID` | string | yes | Dotted-decimal OID. Becomes the value of the auto-prepended `snmpTrapOID.0` varbind. |
+| `weight` | integer | no (default `1`) | Relative weight for weighted-random selection by the scheduler. Zero means omit the entry from scheduled firing (still reachable via the HTTP endpoint). |
+| `varbinds` | array | yes (may be empty) | Body varbinds following the two auto-prepended ones. |
+
+Per-varbind object:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `oid` | string | yes | Dotted-decimal OID. Templates allowed. Must not be `1.3.6.1.2.1.1.3.0` (`sysUpTime.0`) or `1.3.6.1.6.3.1.1.4.1.0` (`snmpTrapOID.0`). |
+| `type` | string | yes | One of `integer`, `octet-string`, `oid`, `counter32`, `gauge32`, `timeticks`, `counter64`, `ipaddress`. |
+| `value` | string | yes | Literal value, type-parsed against the `type` field. Templates allowed. |
+
+### Universal catalog (embedded default)
+
+Ships five entries, all from `SNMPv2-MIB`:
+
+| Name | `snmpTrapOID` | Weight | Body varbinds |
+|------|---------------|--------|---------------|
+| `linkDown` | `1.3.6.1.6.3.1.1.5.3` | 40 | `ifIndex`, `ifAdminStatus` = 2, `ifOperStatus` = 2 |
+| `linkUp` | `1.3.6.1.6.3.1.1.5.4` | 40 | `ifIndex`, `ifAdminStatus` = 1, `ifOperStatus` = 1 |
+| `authenticationFailure` | `1.3.6.1.6.3.1.1.5.5` | 10 | _(none)_ |
+| `coldStart` | `1.3.6.1.6.3.1.1.5.1` | 5 | _(none)_ |
+| `warmStart` | `1.3.6.1.6.3.1.1.5.2` | 5 | _(none)_ |
+
+Weights bias scheduled firing toward link-state notifications (the most
+common interesting traps for monitoring-pipeline validation) while still
+exercising the other three types.
+
+### Template vocabulary
+
+Both `oid` and `value` fields are evaluated as Go `text/template` strings
+per fire. The current vocabulary (see `go/simulator/trap_catalog.go` for
+the ground truth) is restricted to four fields:
+
+| Field | Evaluation |
+|-------|-----------|
+| `{{.IfIndex}}` | Random ifIndex drawn from the device's simulated interface set at fire time |
+| `{{.Uptime}}` | Device uptime in 1/100-second ticks |
+| `{{.Now}}` | Unix epoch seconds |
+| `{{.DeviceIP}}` | Dotted-quad IPv4 of the device |
+
+References to any other field are rejected at catalog load — the
+simulator refuses to start rather than silently emitting a trap with an
+empty OID component.
+
+## HTTP endpoints
+
+### Fire a trap on demand
+
+`POST /api/v1/devices/{ip}/trap` — schedules one trap for the named
+device immediately, bypassing the Poisson scheduler. Body:
+
+```json
+{
+  "name": "linkDown",
+  "varbindOverrides": {
+    "IfIndex": "3"
+  }
+}
+```
+
+`name` is required and must match a catalog entry. `varbindOverrides` is
+optional — supplied keys pin the corresponding template field for this
+fire only.
+
+Responses:
+
+| Status | Body | When |
+|--------|------|------|
+| `202 Accepted` | `{"requestId": <uint32>}` | Success; the trap has been enqueued. For INFORM mode the `requestId` is the INFORM PDU's `request-id` — correlate with `/api/v1/traps/status` to watch its lifecycle. |
+| `400 Bad Request` | `{"success": false, "message": "..."}` | Unknown catalog entry name. |
+| `404 Not Found` | `{"success": false, "message": "..."}` | Unknown device IP. |
+| `503 Service Unavailable` | `{"success": false, "message": "..."}` | Trap export is disabled (`-trap-collector` not set). |
+
+The endpoint is fire-and-forget — it does **not** block waiting for an
+INFORM ack.
+
+### Trap export status
+
+`GET /api/v1/traps/status` — current snapshot of the trap subsystem.
+
+When enabled in INFORM mode (the most complete response shape):
+
+```json
+{
+  "success": true,
+  "message": "Success",
+  "data": {
+    "enabled": true,
+    "mode": "inform",
+    "collector": "192.168.1.10:162",
+    "community": "public",
+    "sent": 182430,
+    "informs_pending": 17,
+    "informs_acked": 182380,
+    "informs_failed": 33,
+    "informs_dropped": 0,
+    "rate_limiter_tokens_available": 94,
+    "devices_exporting": 100
+  }
+}
+```
+
+When enabled in TRAP mode, the four `informs_*` fields are omitted (no
+INFORM state to report). When disabled: `{"enabled": false}`.
+
+`rate_limiter_tokens_available` is present only when `-trap-global-cap`
+is set; it's a best-effort instantaneous snapshot, not synchronised with
+concurrent rate-limiter waits.
+
+### Counter invariant
+
+For INFORM mode, the four disjoint terminal states of every originated
+INFORM satisfy:
+
+```
+informs_pending + informs_acked + informs_failed + informs_dropped == informs_originated
+```
+
+`informs_originated` isn't exposed in the status JSON — it's an internal
+counter verified by `TestInformInvariant_AtExporterLevel` in
+`trap_api_test.go`. If the four exposed counters don't add up across two
+successive polls (after allowing for newly-originated informs between
+reads), something is miscounted or a retransmit path is skipping a
+state transition.
+
+## CLI flags
+
+The nine `-trap-*` flags are documented with their types, defaults, and
+purposes at
+[CLI flags → SNMP trap / INFORM export](cli-flags.md#snmp-trap-inform-export-flags).
+
+## Related
+
+- [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) — how to enable, INFORM constraints, `snmptrapd` smoke test
+- [SNMP reference](snmp.md) — polling-side SNMP (v2c/v3 GETs, GETNEXTs, OID lookup, HC counters)
+- [Web API](web-api.md) — control-plane REST surface
+- Epic [#52](https://github.com/labmonkeys-space/l8opensim/issues/52) and PR [#65](https://github.com/labmonkeys-space/l8opensim/pull/65) for the original design and implementation context

--- a/docs/reference/snmp.md
+++ b/docs/reference/snmp.md
@@ -100,3 +100,17 @@ Vendor-specific OIDs (Cisco, Juniper, Arista, NVIDIA, etc.) are provided per
 device type under `go/simulator/resources/<device>/`. See
 [Resource files](resource-files.md) for the JSON schema and
 [Device types](device-types.md) for the catalog.
+
+## Notifications (trap / INFORM)
+
+SNMP defines both a request/response path — the GET / GETNEXT / GETBULK /
+SET operations documented above — and a push path where a device initiates
+a notification to a monitoring collector. l8opensim implements the push
+path for SNMPv2c only: fire-and-forget TRAPs (PDU `0xA7`) and
+acknowledged INFORMs (PDU `0xA6`). SNMPv1 traps and SNMPv3 notifications
+are deferred.
+
+See [SNMP trap reference](snmp-traps.md) for wire format, the JSON
+catalog schema, and the HTTP endpoints, and
+[SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) for
+enabling the feature and the `snmptrapd` smoke test.

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -160,33 +160,38 @@ See [Flow export (operator guide)](../ops/flow-export.md) and
 curl http://localhost:8080/api/v1/traps/status
 ```
 
-When trap export is enabled in INFORM mode (the most complete response
-shape):
+Unlike the flow-status endpoint, this response is **not** wrapped in the
+`{success, message, data}` envelope — the handler serialises `TrapStatus`
+directly. When trap export is enabled in INFORM mode (the most complete
+response shape):
 
 ```json
 {
-  "success": true,
-  "message": "Success",
-  "data": {
-    "enabled": true,
-    "mode": "inform",
-    "collector": "192.168.1.10:162",
-    "community": "public",
-    "sent": 182430,
-    "informs_pending": 17,
-    "informs_acked": 182380,
-    "informs_failed": 33,
-    "informs_dropped": 0,
-    "rate_limiter_tokens_available": 94,
-    "devices_exporting": 100
-  }
+  "enabled": true,
+  "mode": "inform",
+  "collector": "192.168.1.10:162",
+  "community": "public",
+  "sent": 182430,
+  "informs_pending": 17,
+  "informs_acked": 182380,
+  "informs_failed": 33,
+  "informs_dropped": 0,
+  "rate_limiter_tokens_available": 94,
+  "devices_exporting": 100
 }
 ```
 
 In TRAP mode the four `informs_*` fields are omitted. When trap export is
-disabled, the response is `{"enabled": false}`.
+disabled the response is:
+
+```json
+{"enabled": false, "sent": 0, "devices_exporting": 0}
+```
+
 `rate_limiter_tokens_available` is only present when `-trap-global-cap` is
-set.
+set. The `sent` counter increments on **every wire emission including
+INFORM retransmissions**, so it can exceed `informs_acked + informs_failed
++ informs_dropped + informs_pending` under retry churn.
 
 See [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) and
 [SNMP trap reference](snmp-traps.md) for the full feature details.
@@ -211,8 +216,9 @@ Response:
 | Status | Body | When |
 |--------|------|------|
 | `202 Accepted` | `{"requestId": <uint32>}` | Trap has been enqueued. In INFORM mode the `requestId` is the INFORM PDU's `request-id`. |
-| `400 Bad Request` | error JSON | Unknown catalog entry name. |
+| `400 Bad Request` | error JSON | Malformed JSON body, missing/empty `name`, or unknown catalog entry. |
 | `404 Not Found` | error JSON | Unknown device IP. |
+| `500 Internal Server Error` | error JSON | Template resolve or write failure (`Fire` returned 0). |
 | `503 Service Unavailable` | error JSON | Trap export is disabled. |
 
 The endpoint does not block waiting for an INFORM ack — use

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -19,6 +19,8 @@ management web UI at `/`.
 | `/api/v1/status` | GET | Manager status. |
 | `/api/v1/system-stats` | GET | System stats (file descriptors, memory). |
 | `/api/v1/flows/status` | GET | Flow export status and cumulative counters. |
+| `/api/v1/traps/status` | GET | SNMP trap export status and INFORM counters. |
+| `/api/v1/devices/{ip}/trap` | POST | Fire a named catalog trap on a specific device. |
 | `/health` | GET | Health check endpoint. |
 
 ## Create devices
@@ -151,6 +153,70 @@ When flow export is disabled the response is `{"enabled": false}`.
 
 See [Flow export (operator guide)](../ops/flow-export.md) and
 [Flow export reference](flow-export.md) for protocol-specific details.
+
+## Trap export status
+
+```bash
+curl http://localhost:8080/api/v1/traps/status
+```
+
+When trap export is enabled in INFORM mode (the most complete response
+shape):
+
+```json
+{
+  "success": true,
+  "message": "Success",
+  "data": {
+    "enabled": true,
+    "mode": "inform",
+    "collector": "192.168.1.10:162",
+    "community": "public",
+    "sent": 182430,
+    "informs_pending": 17,
+    "informs_acked": 182380,
+    "informs_failed": 33,
+    "informs_dropped": 0,
+    "rate_limiter_tokens_available": 94,
+    "devices_exporting": 100
+  }
+}
+```
+
+In TRAP mode the four `informs_*` fields are omitted. When trap export is
+disabled, the response is `{"enabled": false}`.
+`rate_limiter_tokens_available` is only present when `-trap-global-cap` is
+set.
+
+See [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) and
+[SNMP trap reference](snmp-traps.md) for the full feature details.
+
+## Fire a trap on demand
+
+```bash
+curl -X POST http://localhost:8080/api/v1/devices/192.168.100.1/trap \
+  -H "Content-Type: application/json" \
+  -d '{"name":"linkDown","varbindOverrides":{"IfIndex":"3"}}'
+```
+
+Request body:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `name` | string | yes | Catalog entry name (e.g. `linkDown`, `linkUp`, `coldStart`). |
+| `varbindOverrides` | object | no | Map of template-field → string-value overrides. Only fields from the catalog template vocabulary are accepted (`IfIndex`, `Uptime`, `Now`, `DeviceIP`). |
+
+Response:
+
+| Status | Body | When |
+|--------|------|------|
+| `202 Accepted` | `{"requestId": <uint32>}` | Trap has been enqueued. In INFORM mode the `requestId` is the INFORM PDU's `request-id`. |
+| `400 Bad Request` | error JSON | Unknown catalog entry name. |
+| `404 Not Found` | error JSON | Unknown device IP. |
+| `503 Service Unavailable` | error JSON | Trap export is disabled. |
+
+The endpoint does not block waiting for an INFORM ack — use
+`/api/v1/traps/status` to observe INFORM lifecycle counters.
 
 ## Device interaction
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Scaling: ops/scaling.md
       - Network Namespace: ops/network-namespace.md
       - Flow Export: ops/flow-export.md
+      - SNMP Traps: ops/snmp-traps.md
       - Troubleshooting: ops/troubleshooting.md
   - Reference:
       - Architecture: reference/architecture.md
@@ -89,6 +90,7 @@ nav:
       - Web API: reference/web-api.md
       - Device Types: reference/device-types.md
       - SNMP: reference/snmp.md
+      - SNMP Traps: reference/snmp-traps.md
       - Flow Export: reference/flow-export.md
       - Resource Files: reference/resource-files.md
       - GPU Simulation:


### PR DESCRIPTION
## Summary

Closes the docs-coverage gap identified after #65 (epic #52) merged: the SNMPv2c trap / INFORM capability was only reachable via \`CLAUDE.md\` and the top-level \`README\`, with no MkDocs site content. This PR adds the two-page split modeled on flow-export plus the necessary cross-links.

## What's new

| File | Change |
|---|---|
| \`docs/ops/snmp-traps.md\` | **new** — operator guide (enable / modes / pending+retries / scheduling / prereqs / snmptrapd smoke test / troubleshooting) |
| \`docs/reference/snmp-traps.md\` | **new** — protocol reference (PDU wire format / auto-prepended varbinds / catalog JSON schema + universal 5-trap default / template vocab / HTTP endpoints / invariant) |
| \`docs/index.md\` | third link in Operations card → new operator guide |
| \`docs/reference/cli-flags.md\` | new \`## SNMP trap / INFORM export flags\` section, 9-row table |
| \`docs/reference/web-api.md\` | two new endpoint-catalog rows + \"Trap export status\" and \"Fire a trap on demand\" sections |
| \`docs/reference/snmp.md\` | new \"Notifications (trap / INFORM)\" pointer subsection at the bottom |
| \`mkdocs.yml\` | Ops → SNMP Traps, Reference → SNMP Traps nav entries |

Docs-only — no Go source, configuration, or resource files touched.

## Design decisions (short version)

- **Two-page split mirrors flow-export.** Ops vs Reference separation is already load-bearing in the nav.
- **Shared prereqs (namespace / FORWARD / rp_filter) cross-link, not duplicate.** Keeps flow-export as single source of truth.
- **Catalog schema shown as annotated example, not a formal schema file.** Catalog authors copy-edit; a formal schema is drift surface.
- **Reference-snmp.md gets a pointer subsection, not a rewrite.** A full split into polling vs notifications is a bigger refactor; logged as a follow-up.

## Test plan

- [x] \`make docs-build\` (= \`mkdocs build --strict\`) clean
- [x] \`./simulator -help | grep -E '^\\s*-trap-'\` lists all 9 flags matching the cli-flags table
- [x] \`TrapStatus\` struct in \`go/simulator/trap_manager.go\` matches the documented JSON shape
- [x] \`go/simulator/resources/_common/traps.json\` structure matches the documented catalog example
- [ ] CI docs workflow passes on the branch
- [ ] After merge, GitHub Pages deploy picks up \`/ops/snmp-traps/\` and \`/reference/snmp-traps/\`

## Follow-ups (not in this PR)

- SNMPv1 / SNMPv3 notification docs — blocked on feature work.
- Per-device-type catalog docs — blocked on feature work.
- Split \`reference/snmp.md\` into polling + notifications pages — bigger refactor.

## DCO

No \`Signed-off-by\` trailer — you'll need to amend before merge per the AI-attribution rule in \`CLAUDE.md\`.