### PR TITLE
docs: make landing hero dynamic and document release workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,17 @@ on:
       - '.nvmrc'
       - '.github/workflows/docs.yml'
       - 'Makefile'
+  # Rebuild the site after a release so the landing-page hero eyebrow
+  # (version/license/Go version — resolved at build time in
+  # docusaurus.config.ts) picks up the newly pushed tag.
+  # No `branches:` filter here: Release runs on tag pushes, where the
+  # upstream workflow's head_branch is the tag ref rather than a branch
+  # name, and a `branches: [main]` filter would silently suppress the
+  # trigger. The job-level `if: conclusion == 'success'` guard below is
+  # sufficient protection.
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -35,6 +46,9 @@ jobs:
   build-and-deploy:
     name: Build & deploy
     runs-on: ubuntu-latest
+    # When triggered by the Release workflow, only proceed if that run
+    # succeeded. On direct pushes and manual dispatches this is trivially true.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,5 +88,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Stable tag pushes publish an immutable `:vX.Y.Z` tag plus the floating
+      # `:latest` alias. Release candidates are handled entirely by ci.yml's
+      # `Publish RC image` job (push to main -> `:rc`), so this workflow only
+      # ever sees stable tags.
       - name: Build and push multi-platform image
         run: make docker-push DOCKER_TAGS="ghcr.io/${{ github.repository }}:${{ github.ref_name }} ghcr.io/${{ github.repository }}:latest"

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ gh pr create --repo labmonkeys-space/l8opensim --base main
 5. `git commit -s` each commit.
 6. `gh pr create --repo labmonkeys-space/l8opensim --base main`.
 
+**Cutting a release.** Maintainers: see [`RELEASING.md`](RELEASING.md) for the
+tag-driven release workflow and the short post-tag verification checklist.
+
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,153 @@
+# Releasing l8opensim
+
+There are only two things to know:
+
+- **Stable releases are tag-driven.** Pushing a `vMAJOR.MINOR.PATCH` tag
+  (e.g. `v0.3.2`) to `main` runs `.github/workflows/release.yml`: it builds
+  Linux amd64/arm64 binaries, publishes a GitHub Release with
+  auto-generated notes, and pushes a multi-platform Docker image to
+  `ghcr.io/labmonkeys-space/l8opensim:<tag>` and the floating `:latest`
+  alias. The public landing page advertises this version.
+- **Release candidates are `main`.** Every push to `main` runs
+  `.github/workflows/ci.yml`, which (on success) publishes the floating
+  Docker image `ghcr.io/labmonkeys-space/l8opensim:rc`. There are **no
+  RC git tags, no numbered RCs, no pre-release GitHub Releases** — `:rc`
+  always reflects the latest main and testers pull it to exercise
+  unreleased work. The landing page is unaffected.
+
+The docs site (`.github/workflows/docs.yml`) rebuilds after each successful
+Release run so the landing-page hero eyebrow
+(`v<stable-version> · Apache-2.0 · Go <minor>`) tracks the latest tag.
+
+Values that used to drift between releases are now derived at build time:
+
+| Value                               | Source                                  | Who updates it              |
+| ----------------------------------- | --------------------------------------- | --------------------------- |
+| App version on landing page         | `git describe --tags --abbrev=0`        | **automatic**               |
+| Go version on landing page          | parsed from `go/go.mod`                 | **automatic**               |
+| License on landing page             | constant in `docusaurus.config.ts`      | only on license change      |
+| Release notes on GitHub             | `softprops/action-gh-release` auto      | maintainer may edit post-hoc|
+| Docker `:latest` tag on GHCR        | pushed by `release.yml` on stable tag   | **automatic**               |
+| Docker `:rc` tag on GHCR            | pushed by `ci.yml` on every main push   | **automatic**               |
+
+The checklist below covers only what a human still has to decide or verify.
+
+## Before you tag
+
+1. **`main` is green.** Check the `CI` status on the most recent commit
+   (`Release` only runs after a tag push, so it has nothing to report yet).
+   Don't release on a red main.
+2. **No release-blocking PRs open.** Skim
+   [`gh pr list --repo labmonkeys-space/l8opensim`](https://github.com/labmonkeys-space/l8opensim/pulls)
+   for anything labelled `release-blocker` or in-flight that should ship
+   together with the tag.
+3. **Pick a version.** Follow [SemVer](https://semver.org/):
+   - `MAJOR` — breaking CLI flag or HTTP API changes
+   - `MINOR` — new device types, new protocols, new flags that default off
+   - `PATCH` — bug fixes, doc-only changes, no behavioural surprises
+   Check the last tag with `git describe --tags --abbrev=0` and increment.
+4. **Optional: skim the auto-generated release notes.** On GitHub, draft a
+   release against `main` without publishing to preview what
+   `generate_release_notes: true` will produce. If the output is noisy (lots
+   of `chore:` / `docs:` commits drowning out user-visible changes), plan to
+   edit the notes post-publish.
+
+## Cut a release
+
+Annotated tags don't need their own sign-off — DCO is enforced per-commit on
+`main`, not on the tag object.
+
+```sh
+# Fetch the latest main
+git checkout main
+git pull --ff-only
+
+# Create an annotated tag (annotated, not lightweight — we want metadata)
+git tag -a vX.Y.Z -m "vX.Y.Z"
+
+# Push the tag to origin — this is what fires release.yml
+git push origin vX.Y.Z
+```
+
+> **Note on the fork.** This repo is a fork of `saichler/l8opensim`. Tags live
+> on `labmonkeys-space/l8opensim` (origin). Never push release tags to
+> upstream.
+
+## Exercising pre-release changes
+
+There is no separate RC release step. Every merge to `main` triggers
+`ci.yml`, which on success publishes `ghcr.io/labmonkeys-space/l8opensim:rc`.
+Testers who want the latest unreleased work pull:
+
+```sh
+docker pull ghcr.io/labmonkeys-space/l8opensim:rc
+```
+
+The `:rc` tag is always overwritten in place — it points at whatever `main`
+last built successfully. There are no immutable pre-release tags; rollback
+to a specific pre-release commit is via `@<sha256:...>` digest on the image
+or by rebuilding from the corresponding `main` commit. `:latest` and the
+landing page are never affected by pre-release activity.
+
+## After you tag
+
+Watch the two workflows that run in sequence:
+
+1. **`Release`** (`.github/workflows/release.yml`) — triggered by the tag push.
+   Builds binaries, creates the GH Release, publishes the Docker image. Expect
+   ~5–10 min.
+2. **`Docs`** (`.github/workflows/docs.yml`) — triggered via `workflow_run`
+   after `Release` succeeds. Rebuilds the Docusaurus site and deploys to
+   `gh-pages`. The landing-page hero eyebrow will now read `vX.Y.Z`.
+
+Verify:
+
+- [ ] GitHub Release exists with the correct tag and attached
+      `simulator-linux-amd64` + `simulator-linux-arm64` binaries.
+- [ ] Release notes are acceptable — edit on GitHub if the auto-generated
+      content bundled in too much noise.
+- [ ] `ghcr.io/labmonkeys-space/l8opensim:vX.Y.Z` and `:latest` both updated
+      (check the "Packages" panel on the repo page).
+- [ ] <https://labmonkeys-space.github.io/l8opensim/> hero eyebrow shows
+      `vX.Y.Z · Apache-2.0 · Go <minor>`. If the site didn't refresh,
+      retrigger the docs workflow manually:
+      `gh workflow run docs.yml --repo labmonkeys-space/l8opensim`.
+
+## Troubleshooting
+
+**Release workflow failed halfway through.** Delete the tag and re-cut:
+
+```sh
+git push origin :refs/tags/vX.Y.Z   # delete remote tag
+git tag -d vX.Y.Z                   # delete local tag
+# fix the underlying issue, then tag + push again
+```
+
+Do **not** force-push over a tag whose Release was already published —
+downstreams may have pulled binaries. Bump the patch version instead
+(`vX.Y.Z+1`).
+
+**Docs site shows the old version after release succeeded.** The docs workflow
+is triggered by `workflow_run` which runs on the default branch context. If
+`main` advanced past the release commit and the latest tag is no longer
+reachable from `HEAD` (rare — would require a revert), `git describe --tags
+--abbrev=0` could resolve to an earlier tag. Check
+<https://github.com/labmonkeys-space/l8opensim/actions/workflows/docs.yml> for
+the last docs run's resolved version, and retrigger manually with
+`gh workflow run docs.yml` if needed.
+
+**Need a hotfix release against an older minor.** This project currently does
+not maintain release branches; all releases are cut from `main`. If that
+changes, update this document.
+
+## What is *not* a manual step
+
+If you find yourself editing any of the following during a release, stop and
+fix the automation instead — drift here is exactly what this document exists
+to prevent:
+
+- A version string hardcoded in `src/**` or `docs/**`.
+- A Go version hardcoded in any docs page (parse from `go/go.mod`).
+- A `:latest` or `:rc` Docker tag pushed from a workstation.
+- A pre-release Git tag (`-rc`, `-beta`, etc.). The `:rc` image is fed by
+  main pushes in `ci.yml`; there is no corresponding tag to cut.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,39 @@
+import {execSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+
+// Resolved at build time and exposed to the landing page via `customFields`.
+// Precedence: APP_VERSION env (CI override) > latest git tag > 'dev' (shallow
+// clone or pre-tag checkout). Keeping this logic in config avoids shipping a
+// hardcoded version string that drifts from releases. Only stable `vX.Y.Z`
+// tags are ever published (RCs live on the floating `:rc` Docker tag pushed
+// from main by ci.yml, not as git tags), so no pre-release filter is needed.
+function resolveAppVersion(): string {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION;
+  try {
+    return execSync('git describe --tags --abbrev=0', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return 'dev';
+  }
+}
+
+// Parsed from go/go.mod so the landing page tracks the toolchain the binary
+// is actually built against. We surface only MAJOR.MINOR to match the marketing
+// style used elsewhere on the page (e.g. "go 1.26+").
+function resolveGoVersion(): string {
+  const modPath = path.join(__dirname, 'go', 'go.mod');
+  const src = fs.readFileSync(modPath, 'utf8');
+  const match = src.match(/^go\s+(\d+\.\d+)(?:\.\d+)?/m);
+  if (!match) throw new Error(`Could not parse Go version from ${modPath}`);
+  return `Go ${match[1]}`;
+}
 
 const config: Config = {
   title: 'l8opensim',
@@ -52,6 +85,12 @@ const config: Config = {
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
+  },
+
+  customFields: {
+    appVersion: resolveAppVersion(),
+    license: 'Apache-2.0',
+    goVersion: resolveGoVersion(),
   },
 
   presets: [

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -1,7 +1,10 @@
 import React, {useState} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Terminal from './Terminal';
 import {FEATURES, CATEGORIES, DOCS, STATUS} from './data';
+
+type HeroMeta = {appVersion: string; license: string; goVersion: string};
 
 function Panel({title, meta, children}: {title?: string; meta?: string; children: React.ReactNode}) {
   return (
@@ -95,6 +98,8 @@ function DocLink({to, t, h}: {to: string; t: string; h: string}) {
 
 export default function Landing(): JSX.Element {
   const quickStart = useBaseUrl('/getting-started/quick-start');
+  const {siteConfig} = useDocusaurusContext();
+  const {appVersion, license, goVersion} = siteConfig.customFields as HeroMeta;
 
   return (
     <main className="l8-page">
@@ -104,7 +109,7 @@ export default function Landing(): JSX.Element {
           <div className="l8-hero__grid">
             <div>
               <div className="l8-hero__eyebrow">
-                <span className="l8-dot" /> v0.1.1 · Apache-2.0 · Go 1.26
+                <span className="l8-dot" /> {appVersion} · {license} · {goVersion}
               </div>
               <h1 className="l8-hero__title">
                 A network load target<br />


### PR DESCRIPTION
## Summary

- Landing-page hero eyebrow (version / license / Go version) now resolves at build time instead of being a hardcoded string — it had drifted four releases out of date (`v0.1.1` vs current `v0.3.1`).
- Docs workflow now rebuilds after a successful `Release` workflow, so tag-only pushes refresh the site.
- New `RELEASING.md` documents the remaining manual steps so future release cuts stay consistent.

## What changed

| File | Change |
| --- | --- |
| `docusaurus.config.ts` | Added `resolveAppVersion()` (`git describe --tags --abbrev=0`, override via `APP_VERSION` env, fallback `dev`) and `resolveGoVersion()` (parses `go/go.mod`); exposed via `customFields`. |
| `src/components/Landing/index.tsx` | Hero eyebrow reads `customFields` via `useDocusaurusContext()`. |
| `.github/workflows/docs.yml` | Added `workflow_run` trigger on `Release` + `if: conclusion == 'success'` guard. |
| `RELEASING.md` | New — preconditions, SemVer guidance, tag-and-push, post-release verification, re-cut procedure. |
| `README.md` | One-line pointer to `RELEASING.md` from the Contributing section. |

## Verified locally

- `make docs-build` renders hero as `v0.3.1 · Apache-2.0 · Go 1.26` (derived from repo tag + `go/go.mod`).
- Strict Docusaurus build still passes (`onBrokenLinks: throw`).

## Test plan

- [ ] CI passes on this PR (docs workflow builds on the `src/**` + `.github/workflows/docs.yml` path triggers).
- [ ] On the next release tag push, confirm `Release` → `Docs` workflow chain runs and the live site updates to the new version.
- [ ] Spot-check that `git describe --tags --abbrev=0` returns the expected tag in CI (checkout uses `fetch-depth: 0`, so tags are available).

## Follow-ups (not in this PR)

- Consider whether the `License` constant should also be derived (e.g. from `LICENSE` first line) — kept as `'Apache-2.0'` literal for now since license changes are rare and worth a deliberate PR.