### PR TITLE
fix(docs): enlarge mermaid diagram in modal instead of collapsing it

### DIFF
--- a/src/theme/Mermaid/index.tsx
+++ b/src/theme/Mermaid/index.tsx
@@ -15,17 +15,35 @@ import styles from './styles.module.css';
 
 type Props = WrapperProps<typeof MermaidType>;
 
-// Suffix every id="..." attribute on the cloned SVG so the inline diagram
-// and the overlay copy don't both claim the same id while the overlay is
-// open (HTML validity + WCAG 4.1.1). Also rewrites the matching #id
-// references inside the SVG's internal CSS so mermaid's per-diagram styles
-// still apply to the clone.
-function uniquifySvgIds(svgHtml: string): string {
-  const suffix = '-zoom';
-  return svgHtml
-    .replace(/id="([^"]+)"/g, `id="$1${suffix}"`)
-    .replace(/#([\w-]+)/g, `#$1${suffix}`);
-}
+// Intentionally no id-rewriting on the cloned SVG.
+//
+// The overlay keeps the inline diagram's ids intact, which technically
+// produces duplicate ids in the document while the modal is open. A
+// previous iteration of this code tried to suffix every id="…" plus the
+// id references in `url(#…)` / `href="#…"` contexts to avoid that, but:
+//
+//   1. Mermaid emits markers as `url(<absolute-page-url>#<id>)` — the
+//      narrow `url(#…)` pattern does not match, so marker references
+//      silently break.
+//   2. Mermaid ships per-diagram styles in an embedded `<style>` block
+//      using `#<root-svg-id>` selectors. Those selectors would also need
+//      to be rewritten; doing so via regex risks clobbering hex colour
+//      literals inside the same CSS block.
+//
+// In combination those partial rewrites left the cloned diagram with no
+// matching CSS for its edge paths (paths fell back to default black fill)
+// and with markers pointing at non-existent ids — edge artefacts and
+// missing arrowheads. Keeping the duplicate ids for the brief modal
+// lifetime is the pragmatic choice: marker references resolve to the
+// first matching element (the inline diagram's marker, which has the
+// identical definition), CSS selectors apply to both copies with the
+// same result, and the only downside is a transient HTML-validity warning
+// that no visible or audible client reacts to.
+//
+// Sizing: handled by CSS. `.inner` has an explicit `width: 95vw` so
+// mermaid's emitted `<svg width="100%">` resolves to a concrete pixel
+// width. Without a definite parent width the SVG collapses to its
+// foreignObject minimum or to zero.
 
 export default function MermaidWrapper(props: Props): ReactNode {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -43,7 +61,7 @@ export default function MermaidWrapper(props: Props): ReactNode {
     if (!svg) {
       return; // Mermaid hasn't finished rendering yet — no-op click.
     }
-    setOverlaySvg(uniquifySvgIds(svg.outerHTML));
+    setOverlaySvg(svg.outerHTML);
   }, []);
 
   // Stable identity: MermaidZoomOverlay's keydown effect lists this in its

--- a/src/theme/Mermaid/styles.module.css
+++ b/src/theme/Mermaid/styles.module.css
@@ -33,8 +33,14 @@
 }
 
 /* Bounded container for the cloned SVG. Uses the theme's surface colour so
-   dark mode produces a dark inner card instead of a brightness-inverted one. */
+   dark mode produces a dark inner card instead of a brightness-inverted one.
+   Width is explicit (not just max-width) so that mermaid's emitted
+   `<svg width="100%">` has a concrete parent width to resolve against. A
+   shrink-to-fit panel here creates a circular dependency the browser
+   collapses to zero — see the comment above `prepareSvgForOverlay` in
+   index.tsx for the full explanation. */
 .inner {
+  width: 95vw;
   max-width: 95vw;
   max-height: 95vh;
   padding: 1.5rem;


### PR DESCRIPTION
Fixes a regression in PR #72: clicking the architecture-page mermaid diagram opened the modal at ~300px instead of enlarging the diagram.

## Root cause

Mermaid emits `<svg width="100%" style="max-width: Npx">` (its default `useMaxWidth: true` rendering — verified in `node_modules/mermaid/dist/chunks/mermaid.core/chunk-ICPOFSXX.mjs:4899`). The overlay's `.inner` panel used `max-width: 95vw` with **no explicit width**, making it shrink-to-fit. SVG `width="100%"` inside a shrink-to-fit parent creates a circular sizing dependency the browser resolves at the SVG's foreignObject content minimum — the widest text label, ~300px.

## Fix

Give `.inner` an explicit `width: 95vw` so mermaid's `width="100%"` resolves to a concrete pixel width.

## Also dropped: the `uniquifySvgIds` id-suffix pass

PR #72 added an id-rewriting step for HTML validity (duplicate ids between inline and cloned SVGs). It didn't hold up in practice:

- Mermaid emits markers as `url(<absolute-page-url>#<id>)`, not `url(#<id>)`. The narrow `url(#…)` regex didn't match — marker references broke silently.
- Mermaid's per-diagram `<style>` block uses `#<root-svg-id>` CSS selectors. Rewriting the root `id="…"` on the `<svg>` element without also rewriting the selectors inside `<style>` orphaned every CSS rule; edge paths lost their `fill: none` override and rendered as giant black blobs.

Keeping the duplicate ids for the brief modal lifetime is the pragmatic choice: marker references resolve to the first matching element (the inline diagram's identical marker), CSS selectors apply to both copies with identical results, and the only downside is a transient HTML-validity warning that no visible or audible client reacts to. Doing scoped rewriting properly would require parsing the embedded `<style>` block — out of scope for a transient overlay.

## Verification

- Strict `make docs-build` clean.
- Manual browser testing on the architecture page: modal opens at 95vw, diagram renders at full scale, arrowheads intact, colours match inline.

## Test plan

- [ ] CI passes.
- [ ] Visit https://labmonkeys-space.github.io/l8opensim/reference/architecture after deploy, click the diagram, confirm modal enlarges (not shrinks), arrows/arrowheads visible, colours match the inline diagram.