### PR TITLE
feat(simulator): add syslog catalog and wire encoders (PR1/3)

### DIFF
--- a/go/simulator/resources/_common/syslog.json
+++ b/go/simulator/resources/_common/syslog.json
@@ -1,0 +1,67 @@
+{
+  "comment": "Universal generic syslog catalog (RFC 5424 and RFC 3164 compatible). Loaded via embed.FS from syslog_catalog.go when no -syslog-catalog override is supplied. Weights are resolved per design.md §D10. Facility and severity accept either canonical string names or integers 0..23 / 0..7. Templates support the six fields listed in design.md §D4: DeviceIP, SysName, IfIndex, IfName, Now, Uptime. Spec intent: exercise OpenNMS syslogd ingestion queues, source-IP→node mapping, rate handling, PRI parsing — NOT vendor-idiomatic UEI matchers (per-device-type catalogs are a follow-up).",
+  "entries": [
+    {
+      "name": "interface-up",
+      "weight": 40,
+      "facility": "local7",
+      "severity": "notice",
+      "appName": "IFMGR",
+      "msgId": "LINKUP",
+      "structuredData": {
+        "ifIndex": "{{.IfIndex}}",
+        "ifName": "{{.IfName}}"
+      },
+      "template": "Interface {{.IfName}} (ifIndex={{.IfIndex}}) changed state to up"
+    },
+    {
+      "name": "interface-down",
+      "weight": 40,
+      "facility": "local7",
+      "severity": "error",
+      "appName": "IFMGR",
+      "msgId": "LINKDOWN",
+      "structuredData": {
+        "ifIndex": "{{.IfIndex}}",
+        "ifName": "{{.IfName}}"
+      },
+      "template": "Interface {{.IfName}} (ifIndex={{.IfIndex}}) changed state to down"
+    },
+    {
+      "name": "auth-success",
+      "weight": 20,
+      "facility": "authpriv",
+      "severity": "info",
+      "appName": "sshd",
+      "msgId": "LOGIN",
+      "template": "Accepted password for admin from 10.0.0.1 port 54321 ssh2"
+    },
+    {
+      "name": "auth-failure",
+      "weight": 20,
+      "facility": "authpriv",
+      "severity": "warning",
+      "appName": "sshd",
+      "msgId": "FAIL",
+      "template": "Failed password for admin from 10.0.0.1 port 54321 ssh2"
+    },
+    {
+      "name": "config-change",
+      "weight": 10,
+      "facility": "local7",
+      "severity": "notice",
+      "appName": "SYSMGR",
+      "msgId": "CONFIG",
+      "template": "Configuration changed by admin from console"
+    },
+    {
+      "name": "system-restart",
+      "weight": 5,
+      "facility": "local7",
+      "severity": "warning",
+      "appName": "SYSMGR",
+      "msgId": "RESTART",
+      "template": "System restart requested by admin"
+    }
+  ]
+}

--- a/go/simulator/syslog_catalog.go
+++ b/go/simulator/syslog_catalog.go
@@ -35,8 +35,10 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
+	"time"
 )
 
 //go:embed resources/_common/syslog.json
@@ -195,28 +197,41 @@ type syslogCatalogJSON struct {
 	Entries []syslogCatalogEntryJSON `json:"entries"`
 }
 
+// syslogSDEntry is one pre-compiled structured-data key/value pair. `Tmpl`
+// is non-nil when the source value contained a template directive; in that
+// case `Raw` is kept only for error messages. When `Tmpl` is nil the source
+// was a literal and `Raw` is used verbatim. Order is fixed at catalog load
+// so RFC 5424 output is deterministic across renders.
+type syslogSDEntry struct {
+	Key  string
+	Tmpl *template.Template
+	Raw  string
+}
+
 // SyslogCatalogEntry is one parsed catalog entry. `TemplateTmpl` and
 // `HostnameTmpl` are nil when the corresponding source string was empty;
-// callers must check before invoking Execute. `StructuredData` is flattened
-// to a stable sorted slice of [key, value] pairs so RFC 5424 output is
-// deterministic across renders.
+// callers must check before invoking Execute.
 type SyslogCatalogEntry struct {
-	Name               string
-	Weight             int
-	Facility           SyslogFacility
-	Severity           SyslogSeverity
-	AppName            string
-	MsgID              string
-	StructuredDataKeys []string          // sorted; empty when no SD
-	StructuredData     map[string]string // same data, by key
-	Hostname           string            // raw source — empty means "use default derivation"
-	HostnameTmpl       *template.Template
-	Template           string // raw source — may be empty
-	TemplateTmpl       *template.Template
+	Name           string
+	Weight         int
+	Facility       SyslogFacility
+	Severity       SyslogSeverity
+	AppName        string
+	MsgID          string
+	StructuredData []syslogSDEntry // sorted by Key; pre-compiled
+	Hostname       string          // raw source — empty means "use default derivation"
+	HostnameTmpl   *template.Template
+	Template       string // raw source — may be empty
+	TemplateTmpl   *template.Template
 }
 
 // SyslogCatalog is the whole parsed catalog plus cached weight metadata for
 // Pick. Immutable after load; safe for concurrent read.
+//
+// Concurrency note: the catalog is safe to share across goroutines, but
+// the `*rand.Rand` argument to `Pick` is NOT — math/rand's Rand is not
+// concurrency-safe. Scheduler code must own a per-goroutine Rand or
+// protect a shared one with a mutex.
 type SyslogCatalog struct {
 	Entries     []*SyslogCatalogEntry
 	ByName      map[string]*SyslogCatalogEntry
@@ -324,7 +339,14 @@ func compileSyslogEntry(raw syslogCatalogEntryJSON, source string, idx int) (*Sy
 	if !raw.Severity.set {
 		return nil, fmt.Errorf("syslog catalog: %s entry %q: severity is required", source, raw.Name)
 	}
+	if raw.AppName == "" {
+		return nil, fmt.Errorf("syslog catalog: %s entry %q: appName is required "+
+			"(RFC 3164 has no NILVALUE — every entry must name the emitting app)",
+			source, raw.Name)
+	}
 	weight := raw.Weight
+	// weight == 0 is coerced to 1 for consistency with trap_catalog.go behaviour.
+	// Operators who want "never pick" should omit the entry rather than set weight 0.
 	if weight == 0 {
 		weight = 1
 	}
@@ -341,15 +363,6 @@ func compileSyslogEntry(raw syslogCatalogEntryJSON, source string, idx int) (*Sy
 		MsgID:    raw.MsgID,
 		Hostname: raw.Hostname,
 		Template: raw.Template,
-	}
-	if len(raw.StructuredData) > 0 {
-		entry.StructuredData = make(map[string]string, len(raw.StructuredData))
-		entry.StructuredDataKeys = make([]string, 0, len(raw.StructuredData))
-		for k, v := range raw.StructuredData {
-			entry.StructuredData[k] = v
-			entry.StructuredDataKeys = append(entry.StructuredDataKeys, k)
-		}
-		sort.Strings(entry.StructuredDataKeys)
 	}
 
 	// Validate template fields in every templatable string before parsing
@@ -369,11 +382,6 @@ func compileSyslogEntry(raw syslogCatalogEntryJSON, source string, idx int) (*Sy
 			return nil, err
 		}
 	}
-	for k, v := range raw.StructuredData {
-		if err := validateSyslogTemplateFields(v, raw.Name, "structuredData."+k); err != nil {
-			return nil, err
-		}
-	}
 
 	if raw.Template != "" {
 		tmpl, err := template.New(raw.Name + ".template").Parse(raw.Template)
@@ -390,15 +398,68 @@ func compileSyslogEntry(raw syslogCatalogEntryJSON, source string, idx int) (*Sy
 		entry.HostnameTmpl = tmpl
 	}
 
-	// MTU-safety dry-render (design.md §D12). We render with worst-case values
-	// for every template field and reject the entry at load time if the total
-	// 5424 message bytes exceed maxSyslogMessageBytes. 5424 is always at least
-	// as large as 3164 for the same inputs (structured data + BOM overhead),
-	// so checking 5424 is sufficient.
+	// Structured-data: validate each key against RFC 5424 §6.3.3 SD-NAME,
+	// field-validate the value, and pre-compile its template at load time
+	// (spec Requirement "Varbind templating" — templates parsed once at
+	// catalog load, not at every fire).
+	if len(raw.StructuredData) > 0 {
+		entry.StructuredData = make([]syslogSDEntry, 0, len(raw.StructuredData))
+		keys := make([]string, 0, len(raw.StructuredData))
+		for k := range raw.StructuredData {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if err := validateSyslogSDName(k, raw.Name); err != nil {
+				return nil, err
+			}
+			v := raw.StructuredData[k]
+			if err := validateSyslogTemplateFields(v, raw.Name, "structuredData."+k); err != nil {
+				return nil, err
+			}
+			sd := syslogSDEntry{Key: k, Raw: v}
+			if strings.Contains(v, "{{") {
+				tmpl, err := template.New(raw.Name + ".sd." + k).Parse(v)
+				if err != nil {
+					return nil, fmt.Errorf("syslog catalog: %s entry %q structuredData[%s] parse: %w",
+						source, raw.Name, k, err)
+				}
+				sd.Tmpl = tmpl
+			}
+			entry.StructuredData = append(entry.StructuredData, sd)
+		}
+	}
+
+	// MTU-safety dry-render (design.md §D12). Render with worst-case values
+	// for every template field using the *actual* 5424 encoder — an earlier
+	// implementation used an approximation that underestimated in two ways
+	// (SD-value escape expansion was ignored; per-SD-pair leading space
+	// wasn't counted). Running the real encoder gives an exact upper bound
+	// for the worst-case context, which is what the spec requires.
 	if err := validateSyslogEntrySize(entry, source); err != nil {
 		return nil, err
 	}
 	return entry, nil
+}
+
+// validateSyslogSDName rejects SD-NAME values that violate RFC 5424 §6.3.3.
+// SD-NAME = 1*32PRINTUSASCII excluding `=`, SP, `]`, `"`.
+func validateSyslogSDName(name, entryName string) error {
+	if len(name) == 0 || len(name) > 32 {
+		return fmt.Errorf("syslog catalog: entry %q structuredData key %q: length %d "+
+			"violates RFC 5424 §6.3.3 (SD-NAME must be 1..32 characters)",
+			entryName, name, len(name))
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c < 33 || c > 126 || c == '=' || c == ']' || c == '"' {
+			return fmt.Errorf("syslog catalog: entry %q structuredData key %q: invalid "+
+				"character %q at position %d (RFC 5424 §6.3.3 SD-NAME excludes "+
+				"SP, `=`, `]`, `\"` and non-printable ASCII)",
+				entryName, name, string(c), i)
+		}
+	}
+	return nil
 }
 
 // validateSyslogTemplateFields scans s for `{{.Ident}}` tokens and rejects
@@ -434,10 +495,12 @@ func validateSyslogTemplateFields(s, entryName, which string) error {
 	}
 }
 
-// validateSyslogEntrySize renders the entry against a worst-case context and
-// rejects it if the 5424 byte length exceeds maxSyslogMessageBytes. The
-// worst-case context uses the longest plausible values for every template
-// field (design.md §D12) so the check is an upper bound across all devices.
+// validateSyslogEntrySize renders the entry against a worst-case context
+// using the actual 5424 encoder and rejects it if the encoded size exceeds
+// maxSyslogMessageBytes. Using the real encoder (not an approximation)
+// means the check accounts for SD-value escape expansion, per-pair
+// leading spaces, header token sanitisation, and every other format
+// detail the encoder performs.
 func validateSyslogEntrySize(entry *SyslogCatalogEntry, source string) error {
 	worst := SyslogTemplateCtx{
 		DeviceIP: "255.255.255.255",
@@ -451,36 +514,30 @@ func validateSyslogEntrySize(entry *SyslogCatalogEntry, source string) error {
 	if err != nil {
 		return fmt.Errorf("syslog catalog: %s entry %q dry-render: %w", source, entry.Name, err)
 	}
-	// The 5424 encoder is the heavier of the two formats; use it to size.
-	size := estimateRFC5424Size(resolved, worst.SysName)
-	if size > maxSyslogMessageBytes {
+	// When the catalog entry has no hostname template, simulate the
+	// exporter-level fallback to sysName so the worst-case bytes include
+	// a realistic HOSTNAME.
+	if resolved.Hostname == "" {
+		resolved.Hostname = worst.SysName
+	}
+
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	// Use a fixed worst-case timestamp — the exact value doesn't matter,
+	// TIMESTAMP width is constant for the 5424 format.
+	if err := enc.Encode(&buf, resolved, time.Unix(worst.Now, 0).UTC()); err != nil {
+		// The encoder itself enforces MaxMessageSize; surface that error
+		// with the catalog context so operators know which entry tripped.
+		return fmt.Errorf("syslog catalog: %s entry %q: dry-encoded size exceeds MTU-safety "+
+			"ceiling (%w) — shorten the template or structured-data fields",
+			source, entry.Name, err)
+	}
+	if buf.Len() > maxSyslogMessageBytes {
 		return fmt.Errorf("syslog catalog: %s entry %q: dry-rendered size %d exceeds MTU-safety "+
 			"ceiling of %d bytes — shorten the template or structured-data fields",
-			source, entry.Name, size, maxSyslogMessageBytes)
+			source, entry.Name, buf.Len(), maxSyslogMessageBytes)
 	}
 	return nil
-}
-
-// estimateRFC5424Size computes a reasonable upper bound on the emitted 5424
-// datagram size for `r`. It doesn't do the full format pass (that's in
-// syslog_wire.go); it just sums the field lengths plus conservative per-field
-// overhead. Used only for catalog-load MTU validation.
-func estimateRFC5424Size(r SyslogResolved, fallbackHost string) int {
-	host := r.Hostname
-	if host == "" {
-		host = fallbackHost
-	}
-	// `<PRI>` up to 5 bytes, version+timestamp+BOM ≈ 34 bytes, 5 separator
-	// spaces, 4 NILVALUE dashes on a bare message. Round to 64 for safety.
-	overhead := 64
-	sdLen := 0
-	for _, kv := range r.StructuredData {
-		sdLen += len(kv.Key) + len(kv.Value) + 4 // `key="..."`
-	}
-	if sdLen > 0 {
-		sdLen += 32 // `[meta@32473 ...]` wrapping
-	}
-	return overhead + len(host) + len(r.AppName) + len(r.MsgID) + sdLen + len(r.Message)
 }
 
 // Pick selects a catalog entry via weighted-random draw. rnd must be non-nil.
@@ -567,32 +624,30 @@ func (e *SyslogCatalogEntry) resolveAgainst(ctx SyslogTemplateCtx, _ map[string]
 		}
 		out.Hostname = buf.String()
 	}
-	if len(e.StructuredDataKeys) > 0 {
-		out.StructuredData = make([]SyslogSDPair, 0, len(e.StructuredDataKeys))
-		for _, k := range e.StructuredDataKeys {
-			raw := e.StructuredData[k]
-			// Structured-data values may contain templates too.
-			if strings.Contains(raw, "{{") {
-				tmpl, err := template.New(e.Name + ".sd." + k).Parse(raw)
-				if err != nil {
-					return SyslogResolved{}, fmt.Errorf("syslog %q structuredData[%s]: %w", e.Name, k, err)
-				}
-				buf.Reset()
-				if err := tmpl.Execute(&buf, ctx); err != nil {
-					return SyslogResolved{}, fmt.Errorf("syslog %q structuredData[%s]: %w", e.Name, k, err)
-				}
-				out.StructuredData = append(out.StructuredData, SyslogSDPair{Key: k, Value: buf.String()})
-			} else {
-				out.StructuredData = append(out.StructuredData, SyslogSDPair{Key: k, Value: raw})
+	if len(e.StructuredData) > 0 {
+		out.StructuredData = make([]SyslogSDPair, 0, len(e.StructuredData))
+		for _, sd := range e.StructuredData {
+			if sd.Tmpl == nil {
+				out.StructuredData = append(out.StructuredData, SyslogSDPair{Key: sd.Key, Value: sd.Raw})
+				continue
 			}
+			buf.Reset()
+			if err := sd.Tmpl.Execute(&buf, ctx); err != nil {
+				return SyslogResolved{}, fmt.Errorf("syslog %q structuredData[%s]: %w", e.Name, sd.Key, err)
+			}
+			out.StructuredData = append(out.StructuredData, SyslogSDPair{Key: sd.Key, Value: buf.String()})
 		}
 	}
 	return out, nil
 }
 
+// parseIntFieldSyslog is a strict decimal-integer parser for HTTP override
+// payloads. Unlike `fmt.Sscanf("%d")`, which accepts trailing non-numeric
+// bytes silently (`"3abc"` → 3), `strconv.Atoi` requires the entire string
+// to be a well-formed integer.
 func parseIntFieldSyslog(s, name string) (int, error) {
-	var n int
-	if _, err := fmt.Sscanf(s, "%d", &n); err != nil {
+	n, err := strconv.Atoi(s)
+	if err != nil {
 		return 0, fmt.Errorf("syslog template override %s: expected integer, got %q", name, s)
 	}
 	return n, nil

--- a/go/simulator/syslog_catalog.go
+++ b/go/simulator/syslog_catalog.go
@@ -1,0 +1,599 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Syslog catalog loader and selector.
+//
+// Mirrors the shape of trap_catalog.go — same embedded FS pattern, same
+// weighted-random Pick, same strict text/template field validation. Key
+// differences from the trap catalog:
+//   - entries carry RFC 5424 / 3164 metadata (facility, severity, appName,
+//     msgId, structuredData) instead of SNMP varbinds
+//   - the "varbind template" vocabulary is six fields instead of four
+//     (adds SysName, IfName)
+//   - an MTU-safety dry-render at load time rejects catalog entries whose
+//     rendered output could exceed 1400 bytes (design.md §D12)
+
+package main
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+//go:embed resources/_common/syslog.json
+var embeddedSyslogCatalogFS embed.FS
+
+const embeddedSyslogCatalogPath = "resources/_common/syslog.json"
+
+// maxSyslogMessageBytes is the dry-render ceiling enforced at catalog load
+// time (design.md §D12). 1400 leaves headroom below the typical 1500-byte
+// Ethernet MTU for IP + UDP headers and any small collector-side framing.
+const maxSyslogMessageBytes = 1400
+
+// allowedSyslogTemplateFields enumerates the six template fields the catalog
+// grammar supports (design.md §D4). Any other {{.Name}} reference in
+// `template` or `hostname` strings is rejected at load time.
+var allowedSyslogTemplateFields = map[string]struct{}{
+	"DeviceIP": {},
+	"SysName":  {},
+	"IfIndex":  {},
+	"IfName":   {},
+	"Now":      {},
+	"Uptime":   {},
+}
+
+// SyslogFacility is an RFC 5424 facility value (0..23). We store the numeric
+// form post-parse; the catalog JSON accepts either canonical names or ints.
+type SyslogFacility uint8
+
+// SyslogSeverity is an RFC 5424 severity value (0..7).
+type SyslogSeverity uint8
+
+// Canonical facility names per RFC 5424 Table 1. The map is used to translate
+// the catalog's string form into the numeric form stored on parsed entries.
+var syslogFacilityNames = map[string]SyslogFacility{
+	"kern":     0,
+	"user":     1,
+	"mail":     2,
+	"daemon":   3,
+	"auth":     4,
+	"syslog":   5,
+	"lpr":      6,
+	"news":     7,
+	"uucp":     8,
+	"cron":     9,
+	"authpriv": 10,
+	"ftp":      11,
+	"ntp":      12,
+	"audit":    13,
+	"alert":    14,
+	"clock":    15,
+	"local0":   16,
+	"local1":   17,
+	"local2":   18,
+	"local3":   19,
+	"local4":   20,
+	"local5":   21,
+	"local6":   22,
+	"local7":   23,
+}
+
+// Canonical severity names per RFC 5424 Table 2. Keys are lowercase so the
+// catalog accepts "error" and "err" interchangeably.
+var syslogSeverityNames = map[string]SyslogSeverity{
+	"emerg":   0,
+	"alert":   1,
+	"crit":    2,
+	"err":     3,
+	"error":   3,
+	"warning": 4,
+	"warn":    4,
+	"notice":  5,
+	"info":    6,
+	"debug":   7,
+}
+
+// syslogFacilityJSON is the JSON-friendly form of a facility value: accepts
+// either an integer (0..23) or a canonical string name. We implement
+// UnmarshalJSON rather than forcing the catalog author to pick one form.
+type syslogFacilityJSON struct {
+	value SyslogFacility
+	set   bool
+}
+
+func (f *syslogFacilityJSON) UnmarshalJSON(data []byte) error {
+	var asInt int
+	if err := json.Unmarshal(data, &asInt); err == nil {
+		if asInt < 0 || asInt > 23 {
+			return fmt.Errorf("facility integer %d out of range (0..23)", asInt)
+		}
+		f.value = SyslogFacility(asInt)
+		f.set = true
+		return nil
+	}
+	var asStr string
+	if err := json.Unmarshal(data, &asStr); err != nil {
+		return fmt.Errorf("facility must be a string name or integer (got %s)", string(data))
+	}
+	v, ok := syslogFacilityNames[strings.ToLower(asStr)]
+	if !ok {
+		return fmt.Errorf("unknown facility name %q (valid: kern, user, mail, daemon, auth, "+
+			"syslog, lpr, news, uucp, cron, authpriv, ftp, ntp, audit, alert, clock, "+
+			"local0..local7)", asStr)
+	}
+	f.value = v
+	f.set = true
+	return nil
+}
+
+// syslogSeverityJSON mirrors syslogFacilityJSON for severities (0..7).
+type syslogSeverityJSON struct {
+	value SyslogSeverity
+	set   bool
+}
+
+func (s *syslogSeverityJSON) UnmarshalJSON(data []byte) error {
+	var asInt int
+	if err := json.Unmarshal(data, &asInt); err == nil {
+		if asInt < 0 || asInt > 7 {
+			return fmt.Errorf("severity integer %d out of range (0..7)", asInt)
+		}
+		s.value = SyslogSeverity(asInt)
+		s.set = true
+		return nil
+	}
+	var asStr string
+	if err := json.Unmarshal(data, &asStr); err != nil {
+		return fmt.Errorf("severity must be a string name or integer (got %s)", string(data))
+	}
+	v, ok := syslogSeverityNames[strings.ToLower(asStr)]
+	if !ok {
+		return fmt.Errorf("unknown severity name %q (valid: emerg, alert, crit, err/error, "+
+			"warning/warn, notice, info, debug)", asStr)
+	}
+	s.value = v
+	s.set = true
+	return nil
+}
+
+// syslogCatalogEntryJSON is the on-disk shape of one catalog entry.
+type syslogCatalogEntryJSON struct {
+	Name           string              `json:"name"`
+	Weight         int                 `json:"weight"`
+	Facility       syslogFacilityJSON  `json:"facility"`
+	Severity       syslogSeverityJSON  `json:"severity"`
+	AppName        string              `json:"appName"`
+	MsgID          string              `json:"msgId"`
+	StructuredData map[string]string   `json:"structuredData"`
+	Hostname       string              `json:"hostname"`
+	Template       string              `json:"template"`
+}
+
+// syslogCatalogJSON is the on-disk shape of the whole catalog file. The
+// "comment" field is ignored so authors can annotate files.
+type syslogCatalogJSON struct {
+	Comment string                   `json:"comment,omitempty"`
+	Entries []syslogCatalogEntryJSON `json:"entries"`
+}
+
+// SyslogCatalogEntry is one parsed catalog entry. `TemplateTmpl` and
+// `HostnameTmpl` are nil when the corresponding source string was empty;
+// callers must check before invoking Execute. `StructuredData` is flattened
+// to a stable sorted slice of [key, value] pairs so RFC 5424 output is
+// deterministic across renders.
+type SyslogCatalogEntry struct {
+	Name               string
+	Weight             int
+	Facility           SyslogFacility
+	Severity           SyslogSeverity
+	AppName            string
+	MsgID              string
+	StructuredDataKeys []string          // sorted; empty when no SD
+	StructuredData     map[string]string // same data, by key
+	Hostname           string            // raw source — empty means "use default derivation"
+	HostnameTmpl       *template.Template
+	Template           string // raw source — may be empty
+	TemplateTmpl       *template.Template
+}
+
+// SyslogCatalog is the whole parsed catalog plus cached weight metadata for
+// Pick. Immutable after load; safe for concurrent read.
+type SyslogCatalog struct {
+	Entries     []*SyslogCatalogEntry
+	ByName      map[string]*SyslogCatalogEntry
+	cumulativeW []int
+	totalWeight int
+}
+
+// SyslogTemplateCtx is the data passed to text/template at fire time (design
+// §D4). Must match `allowedSyslogTemplateFields` exactly.
+type SyslogTemplateCtx struct {
+	DeviceIP string
+	SysName  string
+	IfIndex  int
+	IfName   string
+	Now      int64  // Unix epoch seconds
+	Uptime   uint32 // 1/100s ticks since device start
+}
+
+// SyslogResolved is a catalog entry rendered against a concrete context. It
+// is the direct input to the wire encoders in syslog_wire.go.
+type SyslogResolved struct {
+	Facility       SyslogFacility
+	Severity       SyslogSeverity
+	AppName        string
+	MsgID          string
+	Hostname       string // empty means "caller derives from SysName/DeviceIP"
+	StructuredData []SyslogSDPair
+	Message        string
+}
+
+// SyslogSDPair is one structured-data key/value after template resolution.
+type SyslogSDPair struct {
+	Key   string
+	Value string
+}
+
+// LoadEmbeddedSyslogCatalog parses the universal catalog compiled into the
+// binary via //go:embed. The feature works out-of-box — no -syslog-catalog
+// flag or filesystem access is needed for the default catalog.
+func LoadEmbeddedSyslogCatalog() (*SyslogCatalog, error) {
+	data, err := embeddedSyslogCatalogFS.ReadFile(embeddedSyslogCatalogPath)
+	if err != nil {
+		return nil, fmt.Errorf("syslog catalog: embedded read failed: %w", err)
+	}
+	return parseSyslogCatalog(data, "<embedded "+embeddedSyslogCatalogPath+">")
+}
+
+// LoadSyslogCatalogFromFile parses a user-supplied catalog file. Replaces the
+// embedded catalog entirely — there is no merge (design.md §D11).
+func LoadSyslogCatalogFromFile(path string) (*SyslogCatalog, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("syslog catalog: reading %q: %w", path, err)
+	}
+	return parseSyslogCatalog(data, path)
+}
+
+func parseSyslogCatalog(data []byte, source string) (*SyslogCatalog, error) {
+	var doc syslogCatalogJSON
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("syslog catalog: parsing %s: %w", source, err)
+	}
+	if len(doc.Entries) == 0 {
+		return nil, fmt.Errorf("syslog catalog: %s has no entries", source)
+	}
+
+	cat := &SyslogCatalog{
+		Entries: make([]*SyslogCatalogEntry, 0, len(doc.Entries)),
+		ByName:  make(map[string]*SyslogCatalogEntry, len(doc.Entries)),
+	}
+	for i, raw := range doc.Entries {
+		entry, err := compileSyslogEntry(raw, source, i)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := cat.ByName[entry.Name]; dup {
+			return nil, fmt.Errorf("syslog catalog: %s entry %d: duplicate name %q", source, i, entry.Name)
+		}
+		cat.Entries = append(cat.Entries, entry)
+		cat.ByName[entry.Name] = entry
+	}
+
+	running := 0
+	cat.cumulativeW = make([]int, len(cat.Entries))
+	for i, e := range cat.Entries {
+		running += e.Weight
+		cat.cumulativeW[i] = running
+	}
+	cat.totalWeight = running
+	if cat.totalWeight <= 0 {
+		return nil, fmt.Errorf("syslog catalog: %s total weight must be > 0", source)
+	}
+	return cat, nil
+}
+
+func compileSyslogEntry(raw syslogCatalogEntryJSON, source string, idx int) (*SyslogCatalogEntry, error) {
+	if raw.Name == "" {
+		return nil, fmt.Errorf("syslog catalog: %s entry %d: name is required", source, idx)
+	}
+	if !raw.Facility.set {
+		return nil, fmt.Errorf("syslog catalog: %s entry %q: facility is required", source, raw.Name)
+	}
+	if !raw.Severity.set {
+		return nil, fmt.Errorf("syslog catalog: %s entry %q: severity is required", source, raw.Name)
+	}
+	weight := raw.Weight
+	if weight == 0 {
+		weight = 1
+	}
+	if weight < 0 {
+		return nil, fmt.Errorf("syslog catalog: %s entry %q: weight must be non-negative", source, raw.Name)
+	}
+
+	entry := &SyslogCatalogEntry{
+		Name:     raw.Name,
+		Weight:   weight,
+		Facility: raw.Facility.value,
+		Severity: raw.Severity.value,
+		AppName:  raw.AppName,
+		MsgID:    raw.MsgID,
+		Hostname: raw.Hostname,
+		Template: raw.Template,
+	}
+	if len(raw.StructuredData) > 0 {
+		entry.StructuredData = make(map[string]string, len(raw.StructuredData))
+		entry.StructuredDataKeys = make([]string, 0, len(raw.StructuredData))
+		for k, v := range raw.StructuredData {
+			entry.StructuredData[k] = v
+			entry.StructuredDataKeys = append(entry.StructuredDataKeys, k)
+		}
+		sort.Strings(entry.StructuredDataKeys)
+	}
+
+	// Validate template fields in every templatable string before parsing
+	// the templates themselves. This gives a clearer error than
+	// text/template's "undefined variable" message at evaluation time.
+	for _, pair := range []struct {
+		value string
+		which string
+	}{
+		{raw.Template, "template"},
+		{raw.Hostname, "hostname"},
+	} {
+		if pair.value == "" {
+			continue
+		}
+		if err := validateSyslogTemplateFields(pair.value, raw.Name, pair.which); err != nil {
+			return nil, err
+		}
+	}
+	for k, v := range raw.StructuredData {
+		if err := validateSyslogTemplateFields(v, raw.Name, "structuredData."+k); err != nil {
+			return nil, err
+		}
+	}
+
+	if raw.Template != "" {
+		tmpl, err := template.New(raw.Name + ".template").Parse(raw.Template)
+		if err != nil {
+			return nil, fmt.Errorf("syslog catalog: %s entry %q template parse: %w", source, raw.Name, err)
+		}
+		entry.TemplateTmpl = tmpl
+	}
+	if raw.Hostname != "" {
+		tmpl, err := template.New(raw.Name + ".hostname").Parse(raw.Hostname)
+		if err != nil {
+			return nil, fmt.Errorf("syslog catalog: %s entry %q hostname parse: %w", source, raw.Name, err)
+		}
+		entry.HostnameTmpl = tmpl
+	}
+
+	// MTU-safety dry-render (design.md §D12). We render with worst-case values
+	// for every template field and reject the entry at load time if the total
+	// 5424 message bytes exceed maxSyslogMessageBytes. 5424 is always at least
+	// as large as 3164 for the same inputs (structured data + BOM overhead),
+	// so checking 5424 is sufficient.
+	if err := validateSyslogEntrySize(entry, source); err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// validateSyslogTemplateFields scans s for `{{.Ident}}` tokens and rejects
+// any Ident outside the approved six fields. Pipelines, functions, and
+// ranges are out of grammar.
+func validateSyslogTemplateFields(s, entryName, which string) error {
+	rest := s
+	for {
+		open := strings.Index(rest, "{{")
+		if open < 0 {
+			return nil
+		}
+		closeIdx := strings.Index(rest[open:], "}}")
+		if closeIdx < 0 {
+			return fmt.Errorf("syslog catalog: entry %q %s: unterminated %q", entryName, which, "{{")
+		}
+		expr := strings.TrimSpace(rest[open+2 : open+closeIdx])
+		if !strings.HasPrefix(expr, ".") {
+			return fmt.Errorf("syslog catalog: entry %q %s: only simple field access is allowed "+
+				"(e.g. {{.IfIndex}}); got %q", entryName, which, expr)
+		}
+		field := strings.TrimPrefix(expr, ".")
+		if strings.ContainsAny(field, " \t\n|(){}") {
+			return fmt.Errorf("syslog catalog: entry %q %s: only simple field access is allowed "+
+				"(e.g. {{.IfIndex}}); got %q", entryName, which, expr)
+		}
+		if _, ok := allowedSyslogTemplateFields[field]; !ok {
+			return fmt.Errorf("syslog catalog: entry %q %s: unknown template field %q "+
+				"(allowed: DeviceIP, SysName, IfIndex, IfName, Now, Uptime)",
+				entryName, which, field)
+		}
+		rest = rest[open+closeIdx+2:]
+	}
+}
+
+// validateSyslogEntrySize renders the entry against a worst-case context and
+// rejects it if the 5424 byte length exceeds maxSyslogMessageBytes. The
+// worst-case context uses the longest plausible values for every template
+// field (design.md §D12) so the check is an upper bound across all devices.
+func validateSyslogEntrySize(entry *SyslogCatalogEntry, source string) error {
+	worst := SyslogTemplateCtx{
+		DeviceIP: "255.255.255.255",
+		SysName:  strings.Repeat("H", 64),
+		IfIndex:  65535,
+		IfName:   strings.Repeat("X", 32),
+		Now:      9999999999,
+		Uptime:   0xFFFFFFFF,
+	}
+	resolved, err := entry.resolveAgainst(worst, nil)
+	if err != nil {
+		return fmt.Errorf("syslog catalog: %s entry %q dry-render: %w", source, entry.Name, err)
+	}
+	// The 5424 encoder is the heavier of the two formats; use it to size.
+	size := estimateRFC5424Size(resolved, worst.SysName)
+	if size > maxSyslogMessageBytes {
+		return fmt.Errorf("syslog catalog: %s entry %q: dry-rendered size %d exceeds MTU-safety "+
+			"ceiling of %d bytes — shorten the template or structured-data fields",
+			source, entry.Name, size, maxSyslogMessageBytes)
+	}
+	return nil
+}
+
+// estimateRFC5424Size computes a reasonable upper bound on the emitted 5424
+// datagram size for `r`. It doesn't do the full format pass (that's in
+// syslog_wire.go); it just sums the field lengths plus conservative per-field
+// overhead. Used only for catalog-load MTU validation.
+func estimateRFC5424Size(r SyslogResolved, fallbackHost string) int {
+	host := r.Hostname
+	if host == "" {
+		host = fallbackHost
+	}
+	// `<PRI>` up to 5 bytes, version+timestamp+BOM ≈ 34 bytes, 5 separator
+	// spaces, 4 NILVALUE dashes on a bare message. Round to 64 for safety.
+	overhead := 64
+	sdLen := 0
+	for _, kv := range r.StructuredData {
+		sdLen += len(kv.Key) + len(kv.Value) + 4 // `key="..."`
+	}
+	if sdLen > 0 {
+		sdLen += 32 // `[meta@32473 ...]` wrapping
+	}
+	return overhead + len(host) + len(r.AppName) + len(r.MsgID) + sdLen + len(r.Message)
+}
+
+// Pick selects a catalog entry via weighted-random draw. rnd must be non-nil.
+func (c *SyslogCatalog) Pick(rnd *rand.Rand) *SyslogCatalogEntry {
+	if c == nil || len(c.Entries) == 0 || c.totalWeight <= 0 {
+		return nil
+	}
+	r := rnd.Intn(c.totalWeight)
+	for i, cum := range c.cumulativeW {
+		if r < cum {
+			return c.Entries[i]
+		}
+	}
+	return c.Entries[len(c.Entries)-1]
+}
+
+// Resolve evaluates the entry's templates against ctx and overrides, producing
+// a SyslogResolved ready for the wire encoder. overrides, when non-nil,
+// replace the corresponding fields in ctx — used by the on-demand HTTP
+// endpoint to pin specific template values for CI/test-harness fires.
+func (e *SyslogCatalogEntry) Resolve(ctx SyslogTemplateCtx, overrides map[string]string) (SyslogResolved, error) {
+	if len(overrides) > 0 {
+		if v, ok := overrides["DeviceIP"]; ok {
+			ctx.DeviceIP = v
+		}
+		if v, ok := overrides["SysName"]; ok {
+			ctx.SysName = v
+		}
+		if v, ok := overrides["IfIndex"]; ok {
+			n, err := parseIntFieldSyslog(v, "IfIndex")
+			if err != nil {
+				return SyslogResolved{}, err
+			}
+			ctx.IfIndex = n
+		}
+		if v, ok := overrides["IfName"]; ok {
+			ctx.IfName = v
+		}
+		if v, ok := overrides["Now"]; ok {
+			n, err := parseIntFieldSyslog(v, "Now")
+			if err != nil {
+				return SyslogResolved{}, err
+			}
+			ctx.Now = int64(n)
+		}
+		if v, ok := overrides["Uptime"]; ok {
+			n, err := parseIntFieldSyslog(v, "Uptime")
+			if err != nil {
+				return SyslogResolved{}, err
+			}
+			ctx.Uptime = uint32(n)
+		}
+		for k := range overrides {
+			if _, ok := allowedSyslogTemplateFields[k]; !ok {
+				return SyslogResolved{}, fmt.Errorf("syslog template override: unknown field %q", k)
+			}
+		}
+	}
+	return e.resolveAgainst(ctx, nil)
+}
+
+// resolveAgainst does the template-execute pass. It is separate from Resolve
+// so the catalog-load MTU check can reuse it with the worst-case context
+// without re-applying overrides.
+func (e *SyslogCatalogEntry) resolveAgainst(ctx SyslogTemplateCtx, _ map[string]string) (SyslogResolved, error) {
+	out := SyslogResolved{
+		Facility: e.Facility,
+		Severity: e.Severity,
+		AppName:  e.AppName,
+		MsgID:    e.MsgID,
+	}
+	var buf bytes.Buffer
+	if e.TemplateTmpl != nil {
+		buf.Reset()
+		if err := e.TemplateTmpl.Execute(&buf, ctx); err != nil {
+			return SyslogResolved{}, fmt.Errorf("syslog %q template: %w", e.Name, err)
+		}
+		out.Message = buf.String()
+	}
+	if e.HostnameTmpl != nil {
+		buf.Reset()
+		if err := e.HostnameTmpl.Execute(&buf, ctx); err != nil {
+			return SyslogResolved{}, fmt.Errorf("syslog %q hostname: %w", e.Name, err)
+		}
+		out.Hostname = buf.String()
+	}
+	if len(e.StructuredDataKeys) > 0 {
+		out.StructuredData = make([]SyslogSDPair, 0, len(e.StructuredDataKeys))
+		for _, k := range e.StructuredDataKeys {
+			raw := e.StructuredData[k]
+			// Structured-data values may contain templates too.
+			if strings.Contains(raw, "{{") {
+				tmpl, err := template.New(e.Name + ".sd." + k).Parse(raw)
+				if err != nil {
+					return SyslogResolved{}, fmt.Errorf("syslog %q structuredData[%s]: %w", e.Name, k, err)
+				}
+				buf.Reset()
+				if err := tmpl.Execute(&buf, ctx); err != nil {
+					return SyslogResolved{}, fmt.Errorf("syslog %q structuredData[%s]: %w", e.Name, k, err)
+				}
+				out.StructuredData = append(out.StructuredData, SyslogSDPair{Key: k, Value: buf.String()})
+			} else {
+				out.StructuredData = append(out.StructuredData, SyslogSDPair{Key: k, Value: raw})
+			}
+		}
+	}
+	return out, nil
+}
+
+func parseIntFieldSyslog(s, name string) (int, error) {
+	var n int
+	if _, err := fmt.Sscanf(s, "%d", &n); err != nil {
+		return 0, fmt.Errorf("syslog template override %s: expected integer, got %q", name, s)
+	}
+	return n, nil
+}

--- a/go/simulator/syslog_catalog_test.go
+++ b/go/simulator/syslog_catalog_test.go
@@ -7,6 +7,8 @@ package main
 
 import (
 	"math/rand"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -59,12 +61,12 @@ func TestSyslogCatalogOutOfRangeSeverity(t *testing.T) {
 	}{
 		{
 			name: "int too high",
-			body: `{"entries":[{"name":"x","facility":"user","severity":8,"template":"m"}]}`,
+			body: `{"entries":[{"name":"x","facility":"user","severity":8,"appName":"a","template":"m"}]}`,
 			want: "out of range",
 		},
 		{
 			name: "unknown string",
-			body: `{"entries":[{"name":"x","facility":"user","severity":"notASeverity","template":"m"}]}`,
+			body: `{"entries":[{"name":"x","facility":"user","severity":"notASeverity","appName":"a","template":"m"}]}`,
 			want: "unknown severity name",
 		},
 	}
@@ -83,7 +85,7 @@ func TestSyslogCatalogOutOfRangeSeverity(t *testing.T) {
 
 // TestSyslogCatalogUnknownFacility covers the facility side of the enum check.
 func TestSyslogCatalogUnknownFacility(t *testing.T) {
-	body := `{"entries":[{"name":"x","facility":"notAFacility","severity":"info","template":"m"}]}`
+	body := `{"entries":[{"name":"x","facility":"notAFacility","severity":"info","appName":"a","template":"m"}]}`
 	_, err := parseSyslogCatalog([]byte(body), "<test>")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -95,7 +97,7 @@ func TestSyslogCatalogUnknownFacility(t *testing.T) {
 
 // TestSyslogCatalogUnknownTemplateField rejects {{.NotAField}} at load.
 func TestSyslogCatalogUnknownTemplateField(t *testing.T) {
-	body := `{"entries":[{"name":"x","facility":"user","severity":"info","template":"hi {{.NotAField}}"}]}`
+	body := `{"entries":[{"name":"x","facility":"user","severity":"info","appName":"a","template":"hi {{.NotAField}}"}]}`
 	_, err := parseSyslogCatalog([]byte(body), "<test>")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -110,7 +112,7 @@ func TestSyslogCatalogUnknownTemplateField(t *testing.T) {
 // load time rather than producing truncated wire output at fire time.
 func TestSyslogCatalogOversizeRejected(t *testing.T) {
 	big := strings.Repeat("A", maxSyslogMessageBytes+100)
-	body := `{"entries":[{"name":"x","facility":"user","severity":"info","template":"` + big + `"}]}`
+	body := `{"entries":[{"name":"x","facility":"user","severity":"info","appName":"a","template":"` + big + `"}]}`
 	_, err := parseSyslogCatalog([]byte(body), "<test>")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -125,8 +127,8 @@ func TestSyslogCatalogOversizeRejected(t *testing.T) {
 // see the heavier entry ~8000 times (+/- a few %).
 func TestSyslogCatalogPickDistribution(t *testing.T) {
 	body := `{"entries":[
-		{"name":"heavy","facility":"user","severity":"info","template":"h","weight":40},
-		{"name":"light","facility":"user","severity":"info","template":"l","weight":10}
+		{"name":"heavy","facility":"user","severity":"info","appName":"a","template":"h","weight":40},
+		{"name":"light","facility":"user","severity":"info","appName":"a","template":"l","weight":10}
 	]}`
 	cat, err := parseSyslogCatalog([]byte(body), "<test>")
 	if err != nil {
@@ -233,8 +235,8 @@ func TestSyslogCatalogResolveUnknownOverride(t *testing.T) {
 // TestSyslogCatalogDuplicateName rejects two entries with the same name.
 func TestSyslogCatalogDuplicateName(t *testing.T) {
 	body := `{"entries":[
-		{"name":"dup","facility":"user","severity":"info","template":"a"},
-		{"name":"dup","facility":"user","severity":"info","template":"b"}
+		{"name":"dup","facility":"user","severity":"info","appName":"a","template":"a"},
+		{"name":"dup","facility":"user","severity":"info","appName":"a","template":"b"}
 	]}`
 	_, err := parseSyslogCatalog([]byte(body), "<test>")
 	if err == nil {
@@ -249,7 +251,7 @@ func TestSyslogCatalogDuplicateName(t *testing.T) {
 // integer syntax parse for facility (same for severity, implicitly covered
 // by the out-of-range tests above).
 func TestSyslogCatalogFacilityIntegerAccepted(t *testing.T) {
-	body := `{"entries":[{"name":"x","facility":23,"severity":3,"template":"m"}]}`
+	body := `{"entries":[{"name":"x","facility":23,"severity":3,"appName":"a","template":"m"}]}`
 	cat, err := parseSyslogCatalog([]byte(body), "<test>")
 	if err != nil {
 		t.Fatal(err)
@@ -259,5 +261,151 @@ func TestSyslogCatalogFacilityIntegerAccepted(t *testing.T) {
 	}
 	if cat.Entries[0].Severity != 3 {
 		t.Errorf("severity: got %d, want 3", cat.Entries[0].Severity)
+	}
+}
+
+// TestSyslogCatalogEmptyAppNameRejected — empty `appName` is a catalog
+// error because RFC 3164 has no NILVALUE for the TAG field.
+func TestSyslogCatalogEmptyAppNameRejected(t *testing.T) {
+	body := `{"entries":[{"name":"x","facility":"user","severity":"info","template":"m"}]}`
+	_, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "appName is required") {
+		t.Errorf("error %q: want mention of appName required", err.Error())
+	}
+}
+
+// TestSyslogCatalogSDNameInvalid covers the RFC 5424 §6.3.3 SD-NAME
+// grammar rejection: keys containing SP, =, ], ", or non-printable ASCII.
+func TestSyslogCatalogSDNameInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"space in key", "has space"},
+		{"equals in key", "a=b"},
+		{"quote in key", `bad"`},
+		{"bracket in key", "bad]"},
+		{"empty key", ""},
+		{"too long", strings.Repeat("x", 33)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"entries":[{"name":"x","facility":"user","severity":"info","appName":"a","structuredData":{"` +
+				strings.ReplaceAll(strings.ReplaceAll(tc.key, `\`, `\\`), `"`, `\"`) +
+				`":"v"},"template":"m"}]}`
+			_, err := parseSyslogCatalog([]byte(body), "<test>")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "SD-NAME") {
+				t.Errorf("error %q: want SD-NAME mention", err.Error())
+			}
+		})
+	}
+}
+
+// TestSyslogCatalogParseIntStrict covers the strconv.Atoi tightening —
+// `fmt.Sscanf` previously accepted `"3abc"` as 3 silently.
+func TestSyslogCatalogParseIntStrict(t *testing.T) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := cat.ByName["interface-down"]
+	for _, bad := range []string{"3abc", "", " 3", "3 ", "12.5"} {
+		if _, err := e.Resolve(SyslogTemplateCtx{}, map[string]string{"IfIndex": bad}); err == nil {
+			t.Errorf("expected error on IfIndex=%q, got nil", bad)
+		}
+	}
+	// Negative numbers are still accepted (they parse as valid integers).
+	// If the app wants to reject negatives it must do so at a higher layer.
+	if _, err := e.Resolve(SyslogTemplateCtx{}, map[string]string{"IfIndex": "-1"}); err != nil {
+		t.Errorf("negative IfIndex should parse: %v", err)
+	}
+}
+
+// TestSyslogCatalogSDTemplatesPreCompiled verifies that SD templates are
+// parsed at catalog load — the pre-compiled `*template.Template` is stored
+// on the entry, not re-parsed at every Resolve call.
+func TestSyslogCatalogSDTemplatesPreCompiled(t *testing.T) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := cat.ByName["interface-down"]
+	if len(e.StructuredData) == 0 {
+		t.Fatal("interface-down has no structured data")
+	}
+	// At least one SD entry has a templated value (ifIndex -> "{{.IfIndex}}");
+	// assert it has a non-nil pre-compiled template.
+	foundTmpl := false
+	for _, sd := range e.StructuredData {
+		if sd.Tmpl != nil {
+			foundTmpl = true
+		}
+	}
+	if !foundTmpl {
+		t.Error("expected at least one pre-compiled SD template on interface-down")
+	}
+}
+
+// TestSyslogCatalogFileOverrideReplaces covers the spec scenario
+// "File override replaces embedded catalog" (Requirement "Syslog catalog
+// structure and loading"). Writes a minimal catalog file with three
+// custom entries and asserts the six universal entries are absent.
+func TestSyslogCatalogFileOverrideReplaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.json")
+	body := `{"entries":[
+		{"name":"alpha","facility":"user","severity":"info","appName":"a","template":"A"},
+		{"name":"beta","facility":"user","severity":"info","appName":"a","template":"B"},
+		{"name":"gamma","facility":"user","severity":"info","appName":"a","template":"C"}
+	]}`
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := LoadSyslogCatalogFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(cat.Entries), 3; got != want {
+		t.Fatalf("entry count: got %d, want %d", got, want)
+	}
+	for _, name := range []string{"interface-up", "interface-down", "auth-success", "auth-failure", "config-change", "system-restart"} {
+		if _, ok := cat.ByName[name]; ok {
+			t.Errorf("universal entry %q unexpectedly present in file-override catalog", name)
+		}
+	}
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if _, ok := cat.ByName[name]; !ok {
+			t.Errorf("custom entry %q missing from file-override catalog", name)
+		}
+	}
+}
+
+// BenchmarkSyslogResolve covers the spec scenario "Template evaluation
+// is not N² at scale" — mean per-fire Resolve SHALL be < 50 µs.
+func BenchmarkSyslogResolve(b *testing.B) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		b.Fatal(err)
+	}
+	e := cat.ByName["interface-down"]
+	ctx := SyslogTemplateCtx{
+		DeviceIP: "10.42.0.1",
+		SysName:  "rtr-edge-01",
+		IfIndex:  3,
+		IfName:   "GigabitEthernet0/3",
+		Now:      1700000000,
+		Uptime:   123456,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := e.Resolve(ctx, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/go/simulator/syslog_catalog_test.go
+++ b/go/simulator/syslog_catalog_test.go
@@ -1,0 +1,263 @@
+/*
+ * © 2025 Labmonkeys Space
+ * Apache-2.0 — see LICENSE.
+ */
+
+package main
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedSyslogCatalogParses is the primary smoke test: the default
+// catalog shipped via //go:embed must load with no errors and contain exactly
+// the six universal entries listed in design.md §D10.
+func TestEmbeddedSyslogCatalogParses(t *testing.T) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedSyslogCatalog: %v", err)
+	}
+	wantNames := []string{
+		"interface-up", "interface-down",
+		"auth-success", "auth-failure",
+		"config-change", "system-restart",
+	}
+	if got, want := len(cat.Entries), len(wantNames); got != want {
+		t.Fatalf("entry count: got %d, want %d", got, want)
+	}
+	for _, n := range wantNames {
+		if _, ok := cat.ByName[n]; !ok {
+			t.Errorf("entry %q missing from embedded catalog", n)
+		}
+	}
+	// Total weight per design.md §D10 = 40 + 40 + 20 + 20 + 10 + 5 = 135.
+	if got := cat.totalWeight; got != 135 {
+		t.Errorf("totalWeight: got %d, want 135", got)
+	}
+}
+
+// TestSyslogCatalogInvalidJSON ensures malformed JSON gives a clear error.
+func TestSyslogCatalogInvalidJSON(t *testing.T) {
+	_, err := parseSyslogCatalog([]byte(`{"entries": [`), "<test>")
+	if err == nil {
+		t.Fatal("parseSyslogCatalog: expected error on malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing") {
+		t.Errorf("error text: got %q, want mention of parsing", err.Error())
+	}
+}
+
+// TestSyslogCatalogOutOfRangeSeverity exercises both the integer-range
+// check and the unknown-name check on severity.
+func TestSyslogCatalogOutOfRangeSeverity(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "int too high",
+			body: `{"entries":[{"name":"x","facility":"user","severity":8,"template":"m"}]}`,
+			want: "out of range",
+		},
+		{
+			name: "unknown string",
+			body: `{"entries":[{"name":"x","facility":"user","severity":"notASeverity","template":"m"}]}`,
+			want: "unknown severity name",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseSyslogCatalog([]byte(tc.body), "<test>")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q: want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestSyslogCatalogUnknownFacility covers the facility side of the enum check.
+func TestSyslogCatalogUnknownFacility(t *testing.T) {
+	body := `{"entries":[{"name":"x","facility":"notAFacility","severity":"info","template":"m"}]}`
+	_, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown facility name") {
+		t.Errorf("error %q: want 'unknown facility name'", err.Error())
+	}
+}
+
+// TestSyslogCatalogUnknownTemplateField rejects {{.NotAField}} at load.
+func TestSyslogCatalogUnknownTemplateField(t *testing.T) {
+	body := `{"entries":[{"name":"x","facility":"user","severity":"info","template":"hi {{.NotAField}}"}]}`
+	_, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown template field") || !strings.Contains(err.Error(), "NotAField") {
+		t.Errorf("error %q: want mention of unknown template field and field name", err.Error())
+	}
+}
+
+// TestSyslogCatalogOversizeRejected exercises the §D12 MTU-safety guard. A
+// template that renders beyond maxSyslogMessageBytes must be rejected at
+// load time rather than producing truncated wire output at fire time.
+func TestSyslogCatalogOversizeRejected(t *testing.T) {
+	big := strings.Repeat("A", maxSyslogMessageBytes+100)
+	body := `{"entries":[{"name":"x","facility":"user","severity":"info","template":"` + big + `"}]}`
+	_, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "MTU-safety") {
+		t.Errorf("error %q: want mention of MTU-safety", err.Error())
+	}
+}
+
+// TestSyslogCatalogPickDistribution verifies that Pick honours weights
+// within a reasonable tolerance. 10000 draws over a 40/10 split should
+// see the heavier entry ~8000 times (+/- a few %).
+func TestSyslogCatalogPickDistribution(t *testing.T) {
+	body := `{"entries":[
+		{"name":"heavy","facility":"user","severity":"info","template":"h","weight":40},
+		{"name":"light","facility":"user","severity":"info","template":"l","weight":10}
+	]}`
+	cat, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rnd := rand.New(rand.NewSource(0xC0FFEE))
+	counts := map[string]int{}
+	const draws = 10000
+	for i := 0; i < draws; i++ {
+		e := cat.Pick(rnd)
+		counts[e.Name]++
+	}
+	// Expected ratio: heavy:light = 40:10 = 4:1 → heavy ≈ 8000, light ≈ 2000.
+	// Tolerance: ±5% of draws = ±500 in absolute count.
+	const tol = 500
+	if got := counts["heavy"]; got < 8000-tol || got > 8000+tol {
+		t.Errorf("heavy count %d outside 8000±%d", got, tol)
+	}
+	if got := counts["light"]; got < 2000-tol || got > 2000+tol {
+		t.Errorf("light count %d outside 2000±%d", got, tol)
+	}
+}
+
+// TestSyslogCatalogResolveNoOverrides renders a template with IfIndex/IfName.
+func TestSyslogCatalogResolveNoOverrides(t *testing.T) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := cat.ByName["interface-down"]
+	if e == nil {
+		t.Fatal("interface-down missing from embedded catalog")
+	}
+	ctx := SyslogTemplateCtx{
+		DeviceIP: "10.42.0.1",
+		IfIndex:  3,
+		IfName:   "GigabitEthernet0/3",
+		Now:      1700000000,
+		Uptime:   123456,
+	}
+	msg, err := e.Resolve(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(msg.Message, "GigabitEthernet0/3") {
+		t.Errorf("resolved message %q missing IfName", msg.Message)
+	}
+	if !strings.Contains(msg.Message, "ifIndex=3") {
+		t.Errorf("resolved message %q missing IfIndex", msg.Message)
+	}
+	// Structured data should be populated with the same two fields.
+	if len(msg.StructuredData) != 2 {
+		t.Fatalf("structuredData pairs: got %d, want 2", len(msg.StructuredData))
+	}
+	gotSD := map[string]string{}
+	for _, kv := range msg.StructuredData {
+		gotSD[kv.Key] = kv.Value
+	}
+	if gotSD["ifIndex"] != "3" || gotSD["ifName"] != "GigabitEthernet0/3" {
+		t.Errorf("structuredData resolved wrong: %v", gotSD)
+	}
+}
+
+// TestSyslogCatalogResolveOverrides shows that templateOverrides from the
+// HTTP endpoint pin template fields deterministically.
+func TestSyslogCatalogResolveOverrides(t *testing.T) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := cat.ByName["interface-down"]
+	ctx := SyslogTemplateCtx{IfIndex: 1, IfName: "lo"}
+	msg, err := e.Resolve(ctx, map[string]string{
+		"IfIndex": "7",
+		"IfName":  "GigabitEthernet0/7",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(msg.Message, "ifIndex=7") {
+		t.Errorf("override did not apply: %q", msg.Message)
+	}
+	if !strings.Contains(msg.Message, "GigabitEthernet0/7") {
+		t.Errorf("IfName override did not apply: %q", msg.Message)
+	}
+}
+
+// TestSyslogCatalogResolveUnknownOverride rejects unknown override keys.
+func TestSyslogCatalogResolveUnknownOverride(t *testing.T) {
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := cat.ByName["interface-down"]
+	_, err = e.Resolve(SyslogTemplateCtx{}, map[string]string{"NotAField": "v"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "NotAField") {
+		t.Errorf("error %q: want mention of NotAField", err.Error())
+	}
+}
+
+// TestSyslogCatalogDuplicateName rejects two entries with the same name.
+func TestSyslogCatalogDuplicateName(t *testing.T) {
+	body := `{"entries":[
+		{"name":"dup","facility":"user","severity":"info","template":"a"},
+		{"name":"dup","facility":"user","severity":"info","template":"b"}
+	]}`
+	_, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate name") {
+		t.Errorf("error %q: want 'duplicate name'", err.Error())
+	}
+}
+
+// TestSyslogCatalogFacilityIntegerAccepted verifies both string name and
+// integer syntax parse for facility (same for severity, implicitly covered
+// by the out-of-range tests above).
+func TestSyslogCatalogFacilityIntegerAccepted(t *testing.T) {
+	body := `{"entries":[{"name":"x","facility":23,"severity":3,"template":"m"}]}`
+	cat, err := parseSyslogCatalog([]byte(body), "<test>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cat.Entries[0].Facility != 23 {
+		t.Errorf("facility: got %d, want 23", cat.Entries[0].Facility)
+	}
+	if cat.Entries[0].Severity != 3 {
+		t.Errorf("severity: got %d, want 3", cat.Entries[0].Severity)
+	}
+}

--- a/go/simulator/syslog_wire.go
+++ b/go/simulator/syslog_wire.go
@@ -1,0 +1,290 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Syslog wire encoders. Two RFC-defined formats, one interface.
+//
+// Decision log:
+//   - No trailing LF on UDP datagrams (design.md §OQ#1). Some legacy
+//     syslog-ng configurations expect a terminator; operators hitting that
+//     should file an issue and a -syslog-trailing-lf flag can be added.
+//   - RFC 5424 BOM is OMITTED from the emitted MSG. RFC 5424 §6.4 makes it
+//     optional; omitting keeps the wire bytes ASCII-clean and avoids the
+//     "is this UTF-8 or Latin-1?" adventure downstream parsers have with
+//     lone BOMs. Enable with a future flag if required.
+//   - Timestamps are rendered in UTC. RFC 5424 §6.2.3 allows local offset
+//     but UTC produces comparable timestamps across a 30k-device fleet.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SyslogFormat identifies which wire encoder to use.
+type SyslogFormat string
+
+const (
+	SyslogFormat5424 SyslogFormat = "5424"
+	SyslogFormat3164 SyslogFormat = "3164"
+)
+
+// ParseSyslogFormat validates the operator-supplied -syslog-format value.
+func ParseSyslogFormat(s string) (SyslogFormat, error) {
+	switch s {
+	case string(SyslogFormat5424):
+		return SyslogFormat5424, nil
+	case string(SyslogFormat3164):
+		return SyslogFormat3164, nil
+	default:
+		return "", fmt.Errorf("invalid -syslog-format %q (valid: 5424, 3164)", s)
+	}
+}
+
+// SyslogEncoder encodes one resolved catalog entry into its wire datagram.
+// Implementations are stateless and safe for concurrent use.
+type SyslogEncoder interface {
+	// Encode appends the complete syslog datagram to buf. `now` is the
+	// wall-clock time for the TIMESTAMP field. For RFC 3164, msg.Hostname
+	// MUST be non-empty (the caller resolves the sysName / DeviceIP fallback
+	// before calling); empty Hostname in RFC 5424 renders as NILVALUE `-`.
+	Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Time) error
+
+	// MaxMessageSize returns the recommended upper bound on encoded
+	// datagram bytes. Exporter write-buffers are sized against this.
+	MaxMessageSize() int
+}
+
+// NewSyslogEncoder returns the encoder for the given format.
+func NewSyslogEncoder(f SyslogFormat) (SyslogEncoder, error) {
+	switch f {
+	case SyslogFormat5424:
+		return &RFC5424Encoder{}, nil
+	case SyslogFormat3164:
+		return &RFC3164Encoder{}, nil
+	default:
+		return nil, fmt.Errorf("unknown syslog format %q", f)
+	}
+}
+
+// calculatePRI computes the RFC 5424 §6.2.1 PRI value as `<N>` with no
+// leading zeros, where N = facility*8 + severity. Range: 0..191.
+func calculatePRI(facility SyslogFacility, severity SyslogSeverity) string {
+	// Bounds are already checked at catalog load; this is belt-and-braces.
+	f := uint16(facility) & 0x1F
+	s := uint16(severity) & 0x07
+	return fmt.Sprintf("<%d>", f*8+s)
+}
+
+// sanitiseHostToken replaces whitespace with hyphens and rejects empty
+// strings. Both RFC 3164 (§4.1.2) and RFC 5424 (§6.2.4) treat HOSTNAME as a
+// single printable token; embedded whitespace breaks field parsing
+// downstream. Caller pre-normalisation keeps the wire bytes predictable.
+func sanitiseHostToken(s string) string {
+	if s == "" {
+		return ""
+	}
+	// Avoid allocating if there's nothing to do (common case).
+	if strings.IndexAny(s, " \t\n\r") < 0 {
+		return s
+	}
+	r := strings.NewReplacer(" ", "-", "\t", "-", "\n", "-", "\r", "-")
+	return r.Replace(s)
+}
+
+// -----------------------------------------------------------------------------
+// RFC 5424 encoder
+// -----------------------------------------------------------------------------
+
+// RFC5424Encoder emits structured syslog messages per RFC 5424 §6:
+//
+//	<PRI>1 TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA [BOM-MSG]
+//
+// Empty fields are rendered as the NILVALUE `-`. TIMESTAMP is ISO 8601 UTC
+// with millisecond precision.
+type RFC5424Encoder struct{}
+
+// StructuredDataEnterpriseID is the IANA-assigned private enterprise number
+// used in the SD-ID (e.g. `meta@32473`). 32473 is the reserved value from
+// RFC 5612 for documentation / example use. Operators who want a real
+// enterprise number should fork the encoder; this is a simulator, the SD-ID
+// is cosmetic for downstream parsers.
+const syslogSDEnterpriseID = 32473
+
+// syslogSDID is the SD-ID used in emitted STRUCTURED-DATA elements. Kept as
+// a single element because the v1 catalog schema ships a flat key/value map
+// without per-key SD-ID partitioning.
+const syslogSDID = "meta@32473"
+
+// MaxMessageSize returns the MTU-safe encoding ceiling. Catalog entries are
+// validated at load time against this bound (design.md §D12).
+func (*RFC5424Encoder) MaxMessageSize() int { return maxSyslogMessageBytes }
+
+func (*RFC5424Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Time) error {
+	if buf == nil {
+		return fmt.Errorf("syslog 5424: buf is nil")
+	}
+	// PRI + VERSION
+	buf.WriteString(calculatePRI(msg.Facility, msg.Severity))
+	buf.WriteByte('1')
+	buf.WriteByte(' ')
+
+	// TIMESTAMP: RFC 3339 with millisecond precision, UTC ('Z').
+	// `time.RFC3339Nano` is too precise; build manually for ms.
+	ts := now.UTC()
+	fmt.Fprintf(buf, "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
+		ts.Year(), ts.Month(), ts.Day(),
+		ts.Hour(), ts.Minute(), ts.Second(),
+		ts.Nanosecond()/1_000_000,
+	)
+	buf.WriteByte(' ')
+
+	// HOSTNAME / APP-NAME / PROCID / MSGID (NILVALUE `-` when empty).
+	writeSyslog5424Field(buf, sanitiseHostToken(msg.Hostname))
+	buf.WriteByte(' ')
+	writeSyslog5424Field(buf, msg.AppName)
+	buf.WriteByte(' ')
+	// PROCID not yet in scope (design §D4); always NILVALUE.
+	buf.WriteByte('-')
+	buf.WriteByte(' ')
+	writeSyslog5424Field(buf, msg.MsgID)
+	buf.WriteByte(' ')
+
+	// STRUCTURED-DATA.
+	if len(msg.StructuredData) == 0 {
+		buf.WriteByte('-')
+	} else {
+		buf.WriteByte('[')
+		buf.WriteString(syslogSDID)
+		for _, kv := range msg.StructuredData {
+			buf.WriteByte(' ')
+			buf.WriteString(kv.Key)
+			buf.WriteString(`="`)
+			// Escape backslash, double-quote, and close-bracket per RFC 5424
+			// §6.3.3 (PARAM-VALUE) — these are the only reserved characters
+			// inside the quoted value.
+			writeSyslog5424SDParamValue(buf, kv.Value)
+			buf.WriteByte('"')
+		}
+		buf.WriteByte(']')
+	}
+
+	// MSG (no BOM — decision at top of file).
+	if msg.Message != "" {
+		buf.WriteByte(' ')
+		buf.WriteString(msg.Message)
+	}
+	return nil
+}
+
+// writeSyslog5424Field emits a single syslog 5424 header field value,
+// substituting NILVALUE `-` for empty input.
+func writeSyslog5424Field(buf *bytes.Buffer, v string) {
+	if v == "" {
+		buf.WriteByte('-')
+		return
+	}
+	// Header fields are tokens (no spaces permitted per RFC 5424 ABNF). The
+	// catalog's StringsLoader already rejects fields that contain spaces;
+	// this is an additional guard for operator-supplied content.
+	if strings.ContainsAny(v, " \t\n") {
+		// Replace rather than error — at fire time we can't fail the write
+		// and lose the message; substitute safer characters.
+		v = strings.NewReplacer(" ", "_", "\t", "_", "\n", "_").Replace(v)
+	}
+	buf.WriteString(v)
+}
+
+// writeSyslog5424SDParamValue escapes reserved characters per RFC 5424
+// §6.3.3. Inside PARAM-VALUE the characters `"`, `\`, and `]` must be
+// backslash-escaped; all others pass through verbatim.
+func writeSyslog5424SDParamValue(buf *bytes.Buffer, v string) {
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c == '"' || c == '\\' || c == ']' {
+			buf.WriteByte('\\')
+		}
+		buf.WriteByte(c)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RFC 3164 encoder
+// -----------------------------------------------------------------------------
+
+// RFC3164Encoder emits BSD-style syslog messages per RFC 3164 §4:
+//
+//	<PRI>TIMESTAMP HOSTNAME TAG: MSG
+//
+// TIMESTAMP uses `Mmm DD HH:MM:SS` with a double-space pad between the
+// month abbreviation and single-digit day-of-month values.
+type RFC3164Encoder struct{}
+
+// syslogTagMaxLen is the maximum TAG field length per RFC 3164 §5.3.
+const syslogTagMaxLen = 32
+
+// MaxMessageSize returns the MTU-safe encoding ceiling. 3164 is always
+// smaller than 5424 for the same inputs, so the shared ceiling applies.
+func (*RFC3164Encoder) MaxMessageSize() int { return maxSyslogMessageBytes }
+
+func (*RFC3164Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Time) error {
+	if buf == nil {
+		return fmt.Errorf("syslog 3164: buf is nil")
+	}
+	if msg.Hostname == "" {
+		return fmt.Errorf("syslog 3164: hostname is required")
+	}
+	// PRI
+	buf.WriteString(calculatePRI(msg.Facility, msg.Severity))
+
+	// TIMESTAMP — `Mmm DD HH:MM:SS` with two-space pad for single-digit DD.
+	ts := now.UTC()
+	day := ts.Day()
+	if day < 10 {
+		fmt.Fprintf(buf, "%s  %d %02d:%02d:%02d",
+			ts.Month().String()[:3], day,
+			ts.Hour(), ts.Minute(), ts.Second())
+	} else {
+		fmt.Fprintf(buf, "%s %d %02d:%02d:%02d",
+			ts.Month().String()[:3], day,
+			ts.Hour(), ts.Minute(), ts.Second())
+	}
+	buf.WriteByte(' ')
+
+	// HOSTNAME
+	buf.WriteString(sanitiseHostToken(msg.Hostname))
+	buf.WriteByte(' ')
+
+	// TAG — truncated to 32 characters. RFC 5424-only fields (msgId,
+	// structuredData) are silently ignored (design.md Requirement
+	// "RFC 3164 wire format").
+	tag := msg.AppName
+	if tag == "" {
+		// 3164 has no NILVALUE; use a placeholder token.
+		tag = "unknown"
+	}
+	if len(tag) > syslogTagMaxLen {
+		tag = tag[:syslogTagMaxLen]
+	}
+	buf.WriteString(tag)
+	buf.WriteByte(':')
+	if msg.Message != "" {
+		buf.WriteByte(' ')
+		buf.WriteString(msg.Message)
+	}
+	return nil
+}

--- a/go/simulator/syslog_wire.go
+++ b/go/simulator/syslog_wire.go
@@ -31,7 +31,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -90,20 +89,86 @@ func calculatePRI(facility SyslogFacility, severity SyslogSeverity) string {
 	return fmt.Sprintf("<%d>", f*8+s)
 }
 
-// sanitiseHostToken replaces whitespace with hyphens and rejects empty
-// strings. Both RFC 3164 (§4.1.2) and RFC 5424 (§6.2.4) treat HOSTNAME as a
-// single printable token; embedded whitespace breaks field parsing
-// downstream. Caller pre-normalisation keeps the wire bytes predictable.
-func sanitiseHostToken(s string) string {
+// sanitiseHostname normalises HOSTNAME for both RFC formats. Spaces and
+// tabs become hyphens (spec Requirement "HOSTNAME derivation" — spaces
+// replaced to preserve the single-token structure); any other byte that
+// would break the header-token grammar (<, >, [, ], ", control chars)
+// becomes `_`. Empty input returns empty so the encoder's NILVALUE branch
+// can fire.
+func sanitiseHostname(s string) string {
 	if s == "" {
 		return ""
 	}
-	// Avoid allocating if there's nothing to do (common case).
-	if strings.IndexAny(s, " \t\n\r") < 0 {
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == ' ' || c == '\t':
+			b = append(b, '-')
+		case c < 33 || c > 126 || c == '<' || c == '>' || c == '[' || c == ']' || c == '"':
+			b = append(b, '_')
+		default:
+			b = append(b, c)
+		}
+	}
+	return string(b)
+}
+
+// sanitiseHeaderField normalises APP-NAME, MSGID, and TAG values. Any byte
+// that breaks the header-token grammar (non-printable ASCII, or PRI / SD
+// framing delimiters) becomes `_`. Unlike HOSTNAME, spaces are *not*
+// converted to hyphens — the surrounding format already disallows spaces,
+// so they collapse to `_` along with other disallowed bytes.
+func sanitiseHeaderField(s string) string {
+	if s == "" {
+		return ""
+	}
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 33 || c > 126 || c == '<' || c == '>' || c == '[' || c == ']' || c == '"' {
+			b = append(b, '_')
+		} else {
+			b = append(b, c)
+		}
+	}
+	return string(b)
+}
+
+// sanitiseMessageBody strips injection-enabling control bytes from MSG and
+// STRUCTURED-DATA param values. Newlines / carriage returns / NULs get
+// replaced with spaces so a crafted catalog or HTTP-override cannot inject
+// a fake `<PRI>` line into the collector's stream after a newline.
+// Everything else — punctuation, whitespace other than CR/LF, high-bit
+// bytes — passes through. The 5424 SD-value path does its own
+// `" \ ]` backslash-escape on top of this.
+func sanitiseMessageBody(s string) string {
+	if s == "" {
+		return ""
+	}
+	// Fast path — if no control bytes, no allocation.
+	clean := true
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == 0x00 || c == '\r' || c == '\n' {
+			clean = false
+			break
+		}
+	}
+	if clean {
 		return s
 	}
-	r := strings.NewReplacer(" ", "-", "\t", "-", "\n", "-", "\r", "-")
-	return r.Replace(s)
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case 0x00, '\r', '\n':
+			b[i] = ' '
+		default:
+			b[i] = c
+		}
+	}
+	return string(b)
 }
 
 // -----------------------------------------------------------------------------
@@ -138,6 +203,8 @@ func (*RFC5424Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 	if buf == nil {
 		return fmt.Errorf("syslog 5424: buf is nil")
 	}
+	startLen := buf.Len()
+
 	// PRI + VERSION
 	buf.WriteString(calculatePRI(msg.Facility, msg.Severity))
 	buf.WriteByte('1')
@@ -154,14 +221,14 @@ func (*RFC5424Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 	buf.WriteByte(' ')
 
 	// HOSTNAME / APP-NAME / PROCID / MSGID (NILVALUE `-` when empty).
-	writeSyslog5424Field(buf, sanitiseHostToken(msg.Hostname))
+	writeSyslog5424Field(buf, sanitiseHostname(msg.Hostname))
 	buf.WriteByte(' ')
-	writeSyslog5424Field(buf, msg.AppName)
+	writeSyslog5424Field(buf, sanitiseHeaderField(msg.AppName))
 	buf.WriteByte(' ')
 	// PROCID not yet in scope (design §D4); always NILVALUE.
 	buf.WriteByte('-')
 	buf.WriteByte(' ')
-	writeSyslog5424Field(buf, msg.MsgID)
+	writeSyslog5424Field(buf, sanitiseHeaderField(msg.MsgID))
 	buf.WriteByte(' ')
 
 	// STRUCTURED-DATA.
@@ -172,12 +239,12 @@ func (*RFC5424Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 		buf.WriteString(syslogSDID)
 		for _, kv := range msg.StructuredData {
 			buf.WriteByte(' ')
+			// Keys are validated at catalog load against RFC 5424 SD-NAME.
 			buf.WriteString(kv.Key)
 			buf.WriteString(`="`)
-			// Escape backslash, double-quote, and close-bracket per RFC 5424
-			// §6.3.3 (PARAM-VALUE) — these are the only reserved characters
-			// inside the quoted value.
-			writeSyslog5424SDParamValue(buf, kv.Value)
+			// Strip injection-enabling control bytes first, then escape the
+			// RFC 5424 §6.3.3 reserved characters.
+			writeSyslog5424SDParamValue(buf, sanitiseMessageBody(kv.Value))
 			buf.WriteByte('"')
 		}
 		buf.WriteByte(']')
@@ -186,25 +253,27 @@ func (*RFC5424Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 	// MSG (no BOM — decision at top of file).
 	if msg.Message != "" {
 		buf.WriteByte(' ')
-		buf.WriteString(msg.Message)
+		buf.WriteString(sanitiseMessageBody(msg.Message))
+	}
+
+	// MTU safety: the catalog MTU guard uses this same encoder, but HTTP
+	// overrides or future exporter paths can still produce oversize content.
+	// Fail loudly rather than sending a truncated or fragmented datagram.
+	if encoded := buf.Len() - startLen; encoded > maxSyslogMessageBytes {
+		return fmt.Errorf("syslog 5424: encoded size %d exceeds MaxMessageSize %d",
+			encoded, maxSyslogMessageBytes)
 	}
 	return nil
 }
 
 // writeSyslog5424Field emits a single syslog 5424 header field value,
-// substituting NILVALUE `-` for empty input.
+// substituting NILVALUE `-` for empty input. Callers are responsible for
+// passing a value that has already been run through sanitiseHeaderField /
+// sanitiseHostname — this function trusts its input.
 func writeSyslog5424Field(buf *bytes.Buffer, v string) {
 	if v == "" {
 		buf.WriteByte('-')
 		return
-	}
-	// Header fields are tokens (no spaces permitted per RFC 5424 ABNF). The
-	// catalog's StringsLoader already rejects fields that contain spaces;
-	// this is an additional guard for operator-supplied content.
-	if strings.ContainsAny(v, " \t\n") {
-		// Replace rather than error — at fire time we can't fail the write
-		// and lose the message; substitute safer characters.
-		v = strings.NewReplacer(" ", "_", "\t", "_", "\n", "_").Replace(v)
 	}
 	buf.WriteString(v)
 }
@@ -248,6 +317,8 @@ func (*RFC3164Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 	if msg.Hostname == "" {
 		return fmt.Errorf("syslog 3164: hostname is required")
 	}
+	startLen := buf.Len()
+
 	// PRI
 	buf.WriteString(calculatePRI(msg.Facility, msg.Severity))
 
@@ -266,15 +337,16 @@ func (*RFC3164Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 	buf.WriteByte(' ')
 
 	// HOSTNAME
-	buf.WriteString(sanitiseHostToken(msg.Hostname))
+	buf.WriteString(sanitiseHostname(msg.Hostname))
 	buf.WriteByte(' ')
 
-	// TAG — truncated to 32 characters. RFC 5424-only fields (msgId,
-	// structuredData) are silently ignored (design.md Requirement
-	// "RFC 3164 wire format").
-	tag := msg.AppName
+	// TAG — sanitised to ASCII-token form and truncated to 32 characters.
+	// RFC 5424-only fields (msgId, structuredData) are silently ignored
+	// (design.md Requirement "RFC 3164 wire format").
+	tag := sanitiseHeaderField(msg.AppName)
 	if tag == "" {
-		// 3164 has no NILVALUE; use a placeholder token.
+		// 3164 has no NILVALUE; the catalog loader rejects empty AppName
+		// so this path is defensive only.
 		tag = "unknown"
 	}
 	if len(tag) > syslogTagMaxLen {
@@ -284,7 +356,12 @@ func (*RFC3164Encoder) Encode(buf *bytes.Buffer, msg SyslogResolved, now time.Ti
 	buf.WriteByte(':')
 	if msg.Message != "" {
 		buf.WriteByte(' ')
-		buf.WriteString(msg.Message)
+		buf.WriteString(sanitiseMessageBody(msg.Message))
+	}
+
+	if encoded := buf.Len() - startLen; encoded > maxSyslogMessageBytes {
+		return fmt.Errorf("syslog 3164: encoded size %d exceeds MaxMessageSize %d",
+			encoded, maxSyslogMessageBytes)
 	}
 	return nil
 }

--- a/go/simulator/syslog_wire_test.go
+++ b/go/simulator/syslog_wire_test.go
@@ -1,0 +1,330 @@
+/*
+ * © 2025 Labmonkeys Space
+ * Apache-2.0 — see LICENSE.
+ */
+
+package main
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedNow is the canonical timestamp used by byte-pinned and round-trip
+// tests. Chosen to include single-digit day and non-zero milliseconds so
+// the 3164 double-space-pad and 5424 millisecond precision are exercised.
+func fixedNow() time.Time {
+	return time.Date(2026, time.April, 5, 12, 34, 56, 789_000_000, time.UTC)
+}
+
+// Small helpers to build a resolved message for test isolation.
+func makeResolved(msg string) SyslogResolved {
+	return SyslogResolved{
+		Facility: 23, // local7
+		Severity: 3,  // error
+		AppName:  "IFMGR",
+		MsgID:    "LINKDOWN",
+		Hostname: "rtr-edge-01",
+		Message:  msg,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// PRI calculation
+// -----------------------------------------------------------------------------
+
+func TestSyslogPRITable(t *testing.T) {
+	cases := []struct {
+		facility SyslogFacility
+		severity SyslogSeverity
+		want     string
+	}{
+		{23, 3, "<187>"}, // local7.error
+		{10, 6, "<86>"},  // authpriv.info
+		{0, 0, "<0>"},    // kern.emerg
+		{4, 7, "<39>"},   // auth.debug
+		{16, 5, "<133>"}, // local0.notice
+	}
+	for _, c := range cases {
+		got := calculatePRI(c.facility, c.severity)
+		if got != c.want {
+			t.Errorf("facility=%d severity=%d: got %q, want %q", c.facility, c.severity, got, c.want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RFC 5424
+// -----------------------------------------------------------------------------
+
+// rfc5424Fields is a minimal RFC 5424 header splitter used for round-trip
+// testing. It extracts the first seven header tokens (PRI+VERSION, TIMESTAMP,
+// HOSTNAME, APP-NAME, PROCID, MSGID, STRUCTURED-DATA) and the trailing MSG.
+// Not a full parser; good enough to assert field equality in tests.
+func rfc5424Fields(s string) (pri, version, ts, host, app, procid, msgid, sd, msg string, err error) {
+	re := regexp.MustCompile(`^(<\d+>)(\d+) (\S+) (\S+) (\S+) (\S+) (\S+) (\[[^\]]*\]|-)(?: (.*))?$`)
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return "", "", "", "", "", "", "", "", "", fmt.Errorf("rfc5424Fields: no match on %q", s)
+	}
+	return m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], nil
+}
+
+func TestRFC5424RoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	resolved := makeResolved("Interface GigabitEthernet0/3 (ifIndex=3) changed state to down")
+	resolved.StructuredData = []SyslogSDPair{
+		{Key: "ifIndex", Value: "3"},
+		{Key: "ifName", Value: "GigabitEthernet0/3"},
+	}
+	if err := enc.Encode(&buf, resolved, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	pri, ver, ts, host, app, procid, msgid, sd, msg, err := rfc5424Fields(got)
+	if err != nil {
+		t.Fatalf("parse: %v\nwire: %q", err, got)
+	}
+	checks := []struct{ name, got, want string }{
+		{"PRI", pri, "<187>"},
+		{"VERSION", ver, "1"},
+		{"TIMESTAMP", ts, "2026-04-05T12:34:56.789Z"},
+		{"HOSTNAME", host, "rtr-edge-01"},
+		{"APP-NAME", app, "IFMGR"},
+		{"PROCID", procid, "-"},
+		{"MSGID", msgid, "LINKDOWN"},
+		{"MSG", msg, resolved.Message},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+	if !strings.HasPrefix(sd, "[meta@32473 ") {
+		t.Errorf("STRUCTURED-DATA: %q does not start with [meta@32473", sd)
+	}
+	if !strings.Contains(sd, `ifIndex="3"`) {
+		t.Errorf("STRUCTURED-DATA: %q missing ifIndex", sd)
+	}
+	if !strings.Contains(sd, `ifName="GigabitEthernet0/3"`) {
+		t.Errorf("STRUCTURED-DATA: %q missing ifName", sd)
+	}
+}
+
+func TestRFC5424EmptyFieldsRenderNILVALUE(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	// Deliberately empty AppName, MsgID, Hostname, and SD.
+	msg := SyslogResolved{Facility: 1, Severity: 6}
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	pri, _, _, host, app, procid, msgid, sd, _, err := rfc5424Fields(got)
+	if err != nil {
+		t.Fatalf("parse: %v\nwire: %q", err, got)
+	}
+	if pri != "<14>" {
+		t.Errorf("PRI: got %q, want <14>", pri)
+	}
+	for name, v := range map[string]string{"HOSTNAME": host, "APP-NAME": app, "PROCID": procid, "MSGID": msgid, "STRUCTURED-DATA": sd} {
+		if v != "-" {
+			t.Errorf("%s: got %q, want NILVALUE -", name, v)
+		}
+	}
+}
+
+func TestRFC5424HostnameSpacesReplaced(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	msg := makeResolved("body")
+	msg.Hostname = "some host with spaces"
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "some-host-with-spaces") {
+		t.Errorf("wire: %q missing hyphenated hostname", buf.String())
+	}
+}
+
+func TestRFC5424SDValueEscaping(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	msg := makeResolved("body")
+	msg.StructuredData = []SyslogSDPair{
+		{Key: "note", Value: `has "quote" and \ backslash and ] bracket`},
+	}
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	want := `note="has \"quote\" and \\ backslash and \] bracket"`
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("SD escaping: wire=%q, want substring %q", buf.String(), want)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// RFC 3164
+// -----------------------------------------------------------------------------
+
+func TestRFC3164RoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC3164Encoder{}
+	msg := makeResolved("Interface GigabitEthernet0/3 changed state to down")
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	// Expected exact form; double-space before the day-of-month since 5 is
+	// single-digit.
+	want := "<187>Apr  5 12:34:56 rtr-edge-01 IFMGR: Interface GigabitEthernet0/3 changed state to down"
+	if got != want {
+		t.Errorf("\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestRFC3164DoubleDigitDayUsesSingleSpace(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC3164Encoder{}
+	msg := makeResolved("body")
+	ts := time.Date(2026, time.April, 20, 12, 34, 56, 0, time.UTC)
+	if err := enc.Encode(&buf, msg, ts); err != nil {
+		t.Fatal(err)
+	}
+	want := "<187>Apr 20 12:34:56 rtr-edge-01 IFMGR: body"
+	if got := buf.String(); got != want {
+		t.Errorf("\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestRFC3164TagTruncation(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC3164Encoder{}
+	msg := makeResolved("body")
+	msg.AppName = strings.Repeat("X", 40) // 40 > 32
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	// Expect exactly 32 Xs followed by `:`.
+	want := strings.Repeat("X", 32) + ":"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("wire: %q missing %q", buf.String(), want)
+	}
+	// Ensure the 33rd X is not present.
+	if strings.Contains(buf.String(), strings.Repeat("X", 33)) {
+		t.Errorf("TAG not truncated — 33 Xs present in %q", buf.String())
+	}
+}
+
+func TestRFC3164MissingHostnameIsError(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC3164Encoder{}
+	msg := makeResolved("body")
+	msg.Hostname = ""
+	if err := enc.Encode(&buf, msg, fixedNow()); err == nil {
+		t.Fatal("expected error for empty hostname in 3164")
+	}
+}
+
+func TestRFC3164Ignores5424OnlyFields(t *testing.T) {
+	// RFC 3164 has no slot for MSGID or STRUCTURED-DATA; the encoder must
+	// silently drop them even if the catalog populated them.
+	var buf bytes.Buffer
+	enc := &RFC3164Encoder{}
+	msg := makeResolved("body")
+	msg.MsgID = "SHOULD-NOT-APPEAR"
+	msg.StructuredData = []SyslogSDPair{{Key: "k", Value: "v"}}
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "SHOULD-NOT-APPEAR") {
+		t.Errorf("3164 leaked MSGID: %q", buf.String())
+	}
+	if strings.Contains(buf.String(), `k="v"`) || strings.Contains(buf.String(), "[meta@") {
+		t.Errorf("3164 leaked STRUCTURED-DATA: %q", buf.String())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Format factory and parser helpers
+// -----------------------------------------------------------------------------
+
+func TestParseSyslogFormat(t *testing.T) {
+	if f, err := ParseSyslogFormat("5424"); err != nil || f != SyslogFormat5424 {
+		t.Errorf("ParseSyslogFormat(5424): (%v, %v)", f, err)
+	}
+	if f, err := ParseSyslogFormat("3164"); err != nil || f != SyslogFormat3164 {
+		t.Errorf("ParseSyslogFormat(3164): (%v, %v)", f, err)
+	}
+	if _, err := ParseSyslogFormat("notAFormat"); err == nil {
+		t.Error("ParseSyslogFormat(notAFormat): expected error, got nil")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Byte-pinned regression tests
+// -----------------------------------------------------------------------------
+
+// TestByteIdentity5424 pins the MD5 of a canonical RFC 5424 encode. Any
+// change to the encoder that affects wire bytes will flip the hash and
+// force a review.
+func TestByteIdentity5424(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	msg := SyslogResolved{
+		Facility: 23,
+		Severity: 3,
+		AppName:  "IFMGR",
+		MsgID:    "LINKDOWN",
+		Hostname: "rtr-edge-01",
+		StructuredData: []SyslogSDPair{
+			{Key: "ifIndex", Value: "3"},
+			{Key: "ifName", Value: "GigabitEthernet0/3"},
+		},
+		Message: "Interface GigabitEthernet0/3 (ifIndex=3) changed state to down",
+	}
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	sum := md5.Sum(buf.Bytes())
+	const want = "6aed253d55e20c3e1134d033574b7855"
+	if got := hex.EncodeToString(sum[:]); got != want {
+		t.Errorf("byte-identity MD5 changed — review wire format\n"+
+			"  got:  %s\n"+
+			"  want: %s\n"+
+			"  wire: %q",
+			got, want, buf.String())
+	}
+}
+
+// TestByteIdentity3164 pins the MD5 of a canonical RFC 3164 encode.
+func TestByteIdentity3164(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC3164Encoder{}
+	msg := SyslogResolved{
+		Facility: 23,
+		Severity: 3,
+		AppName:  "IFMGR",
+		Hostname: "rtr-edge-01",
+		Message:  "Interface GigabitEthernet0/3 changed state to down",
+	}
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	sum := md5.Sum(buf.Bytes())
+	const want = "390c2315542cdcbf1e95d5068b04631e"
+	if got := hex.EncodeToString(sum[:]); got != want {
+		t.Errorf("byte-identity MD5 changed — review wire format\n"+
+			"  got:  %s\n"+
+			"  want: %s\n"+
+			"  wire: %q",
+			got, want, buf.String())
+	}
+}

--- a/go/simulator/syslog_wire_test.go
+++ b/go/simulator/syslog_wire_test.go
@@ -304,6 +304,104 @@ func TestByteIdentity5424(t *testing.T) {
 	}
 }
 
+// TestEncoderMaxMessageSizeEnforced — oversize messages must fail at
+// encode time rather than being sent as truncated/fragmented datagrams.
+// Exercises both 5424 and 3164.
+func TestEncoderMaxMessageSizeEnforced(t *testing.T) {
+	oversize := strings.Repeat("A", maxSyslogMessageBytes+50)
+
+	t.Run("5424", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := &RFC5424Encoder{}
+		msg := makeResolved(oversize)
+		if err := enc.Encode(&buf, msg, fixedNow()); err == nil {
+			t.Fatal("expected size-exceeded error, got nil")
+		}
+	})
+	t.Run("3164", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := &RFC3164Encoder{}
+		msg := makeResolved(oversize)
+		if err := enc.Encode(&buf, msg, fixedNow()); err == nil {
+			t.Fatal("expected size-exceeded error, got nil")
+		}
+	})
+}
+
+// TestEncoderMSGInjectionSanitised — CR / LF / NUL in MSG or SD values
+// MUST NOT pass through verbatim; otherwise an attacker or catalog author
+// could inject a fake `<PRI>` line into the collector's stream.
+func TestEncoderMSGInjectionSanitised(t *testing.T) {
+	t.Run("5424 MSG strips newline", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := &RFC5424Encoder{}
+		msg := makeResolved("real msg\n<0>fake injection")
+		if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+			t.Fatal(err)
+		}
+		wire := buf.String()
+		if strings.Contains(wire, "\n") {
+			t.Errorf("literal newline leaked to wire: %q", wire)
+		}
+		// The fake PRI characters are still in the message but no longer on
+		// a new line — downstream parsers see one contiguous message.
+		if !strings.Contains(wire, "real msg <0>fake injection") {
+			t.Errorf("expected newline -> space replacement, got: %q", wire)
+		}
+	})
+	t.Run("5424 SD value strips CRLF/NUL", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := &RFC5424Encoder{}
+		msg := makeResolved("body")
+		msg.StructuredData = []SyslogSDPair{{Key: "k", Value: "v1\r\nv2\x00v3"}}
+		if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+			t.Fatal(err)
+		}
+		wire := buf.String()
+		if strings.ContainsAny(wire, "\r\n\x00") {
+			t.Errorf("control bytes leaked to SD wire: %q", wire)
+		}
+	})
+	t.Run("3164 MSG strips newline", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := &RFC3164Encoder{}
+		msg := makeResolved("real\n<0>fake")
+		if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(buf.String(), "\n") {
+			t.Errorf("literal newline leaked to wire: %q", buf.String())
+		}
+	})
+}
+
+// TestEncoderHeaderFramingCharsSanitised — `<`, `>`, `[`, `]`, `"` in
+// HOSTNAME / APP-NAME / MSGID must not pass through verbatim; those
+// characters carry framing meaning in RFC 5424 and can desync parsers.
+func TestEncoderHeaderFramingCharsSanitised(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &RFC5424Encoder{}
+	msg := makeResolved("body")
+	msg.AppName = "IF<MGR>"
+	msg.MsgID = "LINK[DOWN]"
+	msg.Hostname = "host[fake]"
+	if err := enc.Encode(&buf, msg, fixedNow()); err != nil {
+		t.Fatal(err)
+	}
+	wire := buf.String()
+	for _, bad := range []string{"<MGR>", "[DOWN]", "[fake]"} {
+		if strings.Contains(wire, bad) {
+			t.Errorf("framing char leaked to wire: %q contains %q", wire, bad)
+		}
+	}
+	// Each disallowed char should have been replaced with `_`.
+	for _, good := range []string{"IF_MGR_", "LINK_DOWN_", "host_fake_"} {
+		if !strings.Contains(wire, good) {
+			t.Errorf("wire %q missing expected sanitised token %q", wire, good)
+		}
+	}
+}
+
 // TestByteIdentity3164 pins the MD5 of a canonical RFC 3164 encode.
 func TestByteIdentity3164(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
First of three PRs implementing the `add-syslog-udp` OpenSpec change — epic #76. Self-contained: no scheduler, exporter, CLI, or HTTP wiring yet, so the diff is reviewable on its own.

## Closes

- Sub-issue #78 — Catalog subsystem (tasks 2.1-2.9)
- Sub-issue #79 — Syslog wire encoder (tasks 3.1-3.7)
- Resolves pre-flight items 1.1 and 1.3 from #77 (items 1.2 and 1.4 deferred to later PRs)

## What's in it

| File | Lines | Purpose |
|---|---|---|
| \`go/simulator/syslog_catalog.go\` | 599 | Schema + embedded/file loaders + validation + Pick + Resolve |
| \`go/simulator/syslog_catalog_test.go\` | 263 | 12 tests — parse, validation, weights, overrides |
| \`go/simulator/syslog_wire.go\` | 290 | RFC 5424 + 3164 encoders, PRI calc, helpers |
| \`go/simulator/syslog_wire_test.go\` | 330 | 13 tests — PRI table, round-trip, NILVALUE, TAG truncation, byte-pinned MD5 |
| \`go/simulator/resources/_common/syslog.json\` | 67 | Six universal entries (weights sum to 135) |
| **Total** | **1,549** | |

## Design conformance

- Template vocabulary exactly the six fields from design.md §D4: \`DeviceIP\`, \`SysName\`, \`IfIndex\`, \`IfName\`, \`Now\`, \`Uptime\`.
- Facility / severity accept canonical string names OR integers in range (design §D6, spec Requirement \"PRI calculation\").
- MTU-safety dry-render at load time rejects entries that would exceed 1400 bytes (§D12).
- \`<PRI>\` calculation is \`facility*8 + severity\` with no leading zeros.
- RFC 5424: ISO 8601 ms timestamp, NILVALUE \`-\` for empty header fields, SD-value escaping per §6.3.3.
- RFC 3164: \`Mmm DD HH:MM:SS\` with double-space pad on single-digit days, TAG truncation at 32 chars.
- Duplicate names rejected at load; weights must be non-negative.

## Verified

- \`cd go && go test ./...\` passes on darwin — 25 new tests, all green (including byte-pinned MD5 regressions).
- \`go build ./simulator\` clean.
- \`openspec validate add-syslog-udp --strict\` passes.

## Deferred to follow-up PRs

- **PR2**: scheduler, per-device exporter, manager integration, device lifecycle wiring. Adds sysName caching on device struct (pre-flight 1.2).
- **PR3**: CLI flags, HTTP handlers (including on-demand bypass of rate limiter — pre-flight 1.4), CLAUDE.md + README.

## Test plan

- [ ] CI passes on this PR.
- [ ] \`openspec validate add-syslog-udp --strict\` passes (already verified locally).
- [ ] On merge, the catalog + encoders are unused but importable — sanity-check that \`go build\` of downstream packages doesn't flag unused imports.