### PR TITLE
feat(simulator): add syslog scheduler and per-device exporter (PR2/3)

### DIFF
--- a/go/simulator/syslog_exporter.go
+++ b/go/simulator/syslog_exporter.go
@@ -31,6 +31,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"log"
 	"net"
 	"sync/atomic"
@@ -99,7 +101,17 @@ type SyslogExporterOptions struct {
 // NewSyslogExporter builds a SyslogExporter. The per-device conn is not
 // opened here — callers call SetConn once the socket is bound inside the
 // device's netns (see openSyslogConnForDevice below).
+//
+// Panics on invalid options (nil/zero DeviceIP, nil Collector). Matches the
+// panic-on-misconfiguration style of NewSyslogScheduler and NewTrapScheduler:
+// these are programmer errors at construction time, not runtime faults.
 func NewSyslogExporter(opts SyslogExporterOptions) *SyslogExporter {
+	if len(opts.DeviceIP) == 0 {
+		panic("NewSyslogExporter: DeviceIP required")
+	}
+	if opts.Collector == nil {
+		panic("NewSyslogExporter: Collector required")
+	}
 	if opts.Encoder == nil {
 		// Default to RFC 5424 so a constructor typo doesn't ship RFC 3164
 		// by accident. In practice the manager always passes one explicitly.
@@ -128,8 +140,15 @@ func NewSyslogExporter(opts SyslogExporterOptions) *SyslogExporter {
 // exporter is registered with the scheduler if per-device source IPs are
 // desired. Passing nil unsets the socket; subsequent Fire calls fall back
 // to the shared socket if one was configured.
+//
+// If a previous conn was installed, it is closed here — callers do not
+// need to close it themselves, and forgetting to would leak a file
+// descriptor per rebind.
 func (e *SyslogExporter) SetConn(c *net.UDPConn) {
-	e.conn.Store(c)
+	old := e.conn.Swap(c)
+	if old != nil && old != c {
+		_ = old.Close()
+	}
 }
 
 // Stats returns a pointer to the exporter's atomic stats. The underlying
@@ -186,6 +205,13 @@ func (e *SyslogExporter) Fire(entry *SyslogCatalogEntry, overrides map[string]st
 	}
 
 	if err := e.writeDatagram(buf.Bytes()); err != nil {
+		// Shutdown race: Close may have invalidated the socket we captured
+		// before the write. The message was lost, but not because of an
+		// actual send failure — attributing it to SendFailures confuses
+		// operator dashboards. Silently drop.
+		if e.closing.Load() {
+			return nil
+		}
 		e.stats.SendFailures.Add(1)
 		return err
 	}
@@ -194,29 +220,45 @@ func (e *SyslogExporter) Fire(entry *SyslogCatalogEntry, overrides map[string]st
 }
 
 // writeDatagram sends pdu to the collector using the per-device socket
-// (preferred) or the shared fallback. Returns nil on success, the last
-// error on failure.
+// (preferred) or the shared fallback.
+//
+// Error reporting: on fallback, if the per-device write fails but the
+// shared write succeeds, the per-device error is LOGGED (so operators can
+// debug the primary failure) but nil is returned so the caller's counter
+// treats it as a successful send. If both writes fail, a joined error is
+// returned carrying both causes so callers don't lose the primary
+// diagnostic.
 func (e *SyslogExporter) writeDatagram(pdu []byte) error {
+	var primaryErr error
 	conn := e.conn.Load()
 	if conn != nil {
 		if _, err := conn.WriteToUDP(pdu, e.collector); err == nil {
 			return nil
 		} else {
-			// Per-device write failed; try shared fallback below. Retain
-			// the error for the case where fallback is nil.
-			if e.sharedConn == nil {
-				return err
-			}
+			primaryErr = fmt.Errorf("per-device socket: %w", err)
 		}
 	}
-	if e.sharedConn != nil {
-		if _, err := e.sharedConn.WriteToUDP(pdu, e.collector); err == nil {
-			return nil
-		} else {
-			return err
+	if e.sharedConn == nil {
+		if primaryErr != nil {
+			return primaryErr
 		}
+		return errNoSyslogSocket
 	}
-	return errNoSyslogSocket
+	_, err := e.sharedConn.WriteToUDP(pdu, e.collector)
+	if err == nil {
+		if primaryErr != nil {
+			// Fallback succeeded — log the primary failure so the operator
+			// can diagnose why the per-device path stopped working.
+			log.Printf("syslog: %s per-device write failed, sent via shared socket: %v",
+				e.deviceIP, primaryErr)
+		}
+		return nil
+	}
+	sharedErr := fmt.Errorf("shared socket: %w", err)
+	if primaryErr != nil {
+		return errors.Join(primaryErr, sharedErr)
+	}
+	return sharedErr
 }
 
 // uptimeHundredths returns device uptime in 1/100-second ticks, matching

--- a/go/simulator/syslog_exporter.go
+++ b/go/simulator/syslog_exporter.go
@@ -1,0 +1,273 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Per-device syslog exporter.
+//
+// One SyslogExporter per DeviceSimulator owns the device's UDP socket and a
+// shared SyslogEncoder. The scheduler calls Fire() to emit a scheduled
+// message; the HTTP endpoint also calls Fire() for on-demand sends.
+//
+// This is intentionally simpler than TrapExporter: UDP syslog is fire-and-
+// forget (no INFORM analog), so there is no pending-state map, no ack
+// reader goroutine, no retry loop, and no request-id counter. Everything
+// happens inline on the Fire() call path.
+//
+// Design references: design.md §D7 (per-device UDP source), §D8 (encoder
+// interface). See specs/syslog-export/spec.md for SHALL requirements.
+
+package main
+
+import (
+	"bytes"
+	"log"
+	"net"
+	"sync/atomic"
+	"time"
+)
+
+// SyslogStats holds cumulative counters for a SyslogExporter. Fields are
+// atomic so they're safe to read concurrently with Fire.
+type SyslogStats struct {
+	// Sent counts every datagram successfully written to the wire.
+	Sent atomic.Uint64
+	// SendFailures counts Fire invocations that failed to write (encoder
+	// error, UDP write error, closed socket, etc.).
+	SendFailures atomic.Uint64
+}
+
+// SyslogExporter is owned by one DeviceSimulator. Construct via
+// NewSyslogExporter and call SetConn once the per-device UDP socket has
+// been bound inside the device's network namespace. Close releases the
+// socket and marks the exporter as closing (subsequent Fire calls no-op).
+type SyslogExporter struct {
+	deviceIP  net.IP
+	encoder   SyslogEncoder
+	collector *net.UDPAddr
+
+	// conn is the per-device UDP socket. Nil when per-device binding was
+	// disabled or failed and the fallback shared socket is used. Stored as
+	// atomic.Pointer so Close / Fire can observe writes safely without
+	// holding a mutex in the hot path.
+	conn atomic.Pointer[net.UDPConn]
+
+	// sharedConn is the fallback UDP socket used when per-device bind is
+	// disabled or failed. Read-only after construction.
+	sharedConn *net.UDPConn
+
+	// sysName is the device's SNMP sysName.0 value, captured once at
+	// construction. Pre-flight 1.2 deferred the catalog-level caching
+	// question to PR3 (device lifecycle wiring); for PR2 the value is
+	// injected by the caller so the exporter never touches the SNMP stack.
+	sysName string
+
+	// ifIndexFn / ifNameFn return template-context values per fire.
+	// ifIndexFn may be nil — in that case IfIndex = 0. ifNameFn receives
+	// the index returned by ifIndexFn and yields the matching interface
+	// name (empty if no mapping exists).
+	ifIndexFn func() int
+	ifNameFn  func(ifIndex int) string
+
+	startTime time.Time
+	stats     *SyslogStats
+
+	closing atomic.Bool
+}
+
+// SyslogExporterOptions bundles per-device exporter configuration.
+type SyslogExporterOptions struct {
+	DeviceIP   net.IP
+	Encoder    SyslogEncoder
+	Collector  *net.UDPAddr
+	SharedConn *net.UDPConn // fallback; may be nil
+	SysName    string       // device's sysName.0 value — empty falls back to DeviceIP at encode time
+	IfIndexFn  func() int
+	IfNameFn   func(ifIndex int) string
+}
+
+// NewSyslogExporter builds a SyslogExporter. The per-device conn is not
+// opened here — callers call SetConn once the socket is bound inside the
+// device's netns (see openSyslogConnForDevice below).
+func NewSyslogExporter(opts SyslogExporterOptions) *SyslogExporter {
+	if opts.Encoder == nil {
+		// Default to RFC 5424 so a constructor typo doesn't ship RFC 3164
+		// by accident. In practice the manager always passes one explicitly.
+		opts.Encoder = &RFC5424Encoder{}
+	}
+	if opts.IfIndexFn == nil {
+		opts.IfIndexFn = func() int { return 0 }
+	}
+	if opts.IfNameFn == nil {
+		opts.IfNameFn = func(int) string { return "" }
+	}
+	return &SyslogExporter{
+		deviceIP:   append(net.IP(nil), opts.DeviceIP...),
+		encoder:    opts.Encoder,
+		collector:  opts.Collector,
+		sharedConn: opts.SharedConn,
+		sysName:    opts.SysName,
+		ifIndexFn:  opts.IfIndexFn,
+		ifNameFn:   opts.IfNameFn,
+		startTime:  time.Now(),
+		stats:      &SyslogStats{},
+	}
+}
+
+// SetConn installs the per-device UDP socket. Must be called before the
+// exporter is registered with the scheduler if per-device source IPs are
+// desired. Passing nil unsets the socket; subsequent Fire calls fall back
+// to the shared socket if one was configured.
+func (e *SyslogExporter) SetConn(c *net.UDPConn) {
+	e.conn.Store(c)
+}
+
+// Stats returns a pointer to the exporter's atomic stats. The underlying
+// counters are safe to read concurrently; the pointer is stable for the
+// exporter's lifetime.
+func (e *SyslogExporter) Stats() *SyslogStats { return e.stats }
+
+// Fire emits one syslog message for the given catalog entry. Implements
+// syslogFirer for the scheduler. Safe for concurrent calls and safe to
+// call on a closing exporter (silently no-ops).
+//
+// overrides, when non-nil, force specific template field values (used by
+// POST /api/v1/devices/{ip}/syslog). Returns an error only on encode or
+// write failure; nil return implies a datagram reached the socket's
+// send path (UDP transmission beyond that point is fire-and-forget).
+func (e *SyslogExporter) Fire(entry *SyslogCatalogEntry, overrides map[string]string) error {
+	if e == nil || entry == nil || e.closing.Load() {
+		return nil
+	}
+
+	ifIndex := e.ifIndexFn()
+	ctx := SyslogTemplateCtx{
+		DeviceIP: e.deviceIP.String(),
+		SysName:  e.sysName,
+		IfIndex:  ifIndex,
+		IfName:   e.ifNameFn(ifIndex),
+		Now:      time.Now().Unix(),
+		Uptime:   e.uptimeHundredths(),
+	}
+	resolved, err := entry.Resolve(ctx, overrides)
+	if err != nil {
+		e.stats.SendFailures.Add(1)
+		log.Printf("syslog: resolve %s for %s: %v", entry.Name, e.deviceIP, err)
+		return err
+	}
+
+	// Hostname fallback per design.md §D5: catalog template (if any) wins,
+	// otherwise sysName, otherwise DeviceIP. The catalog-template case has
+	// already filled resolved.Hostname inside entry.Resolve.
+	if resolved.Hostname == "" {
+		if ctx.SysName != "" {
+			resolved.Hostname = ctx.SysName
+		} else {
+			resolved.Hostname = ctx.DeviceIP
+		}
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(e.encoder.MaxMessageSize())
+	if err := e.encoder.Encode(&buf, resolved, time.Now()); err != nil {
+		e.stats.SendFailures.Add(1)
+		log.Printf("syslog: encode %s for %s: %v", entry.Name, e.deviceIP, err)
+		return err
+	}
+
+	if err := e.writeDatagram(buf.Bytes()); err != nil {
+		e.stats.SendFailures.Add(1)
+		return err
+	}
+	e.stats.Sent.Add(1)
+	return nil
+}
+
+// writeDatagram sends pdu to the collector using the per-device socket
+// (preferred) or the shared fallback. Returns nil on success, the last
+// error on failure.
+func (e *SyslogExporter) writeDatagram(pdu []byte) error {
+	conn := e.conn.Load()
+	if conn != nil {
+		if _, err := conn.WriteToUDP(pdu, e.collector); err == nil {
+			return nil
+		} else {
+			// Per-device write failed; try shared fallback below. Retain
+			// the error for the case where fallback is nil.
+			if e.sharedConn == nil {
+				return err
+			}
+		}
+	}
+	if e.sharedConn != nil {
+		if _, err := e.sharedConn.WriteToUDP(pdu, e.collector); err == nil {
+			return nil
+		} else {
+			return err
+		}
+	}
+	return errNoSyslogSocket
+}
+
+// uptimeHundredths returns device uptime in 1/100-second ticks, matching
+// SNMP TimeTicks semantics so templates can share `{{.Uptime}}` with the
+// trap capability.
+func (e *SyslogExporter) uptimeHundredths() uint32 {
+	return uint32(time.Since(e.startTime) / (10 * time.Millisecond))
+}
+
+// Close marks the exporter as closing and releases the per-device socket.
+// Safe for concurrent Close / Fire; idempotent.
+func (e *SyslogExporter) Close() error {
+	if e == nil {
+		return nil
+	}
+	e.closing.Store(true)
+	conn := e.conn.Swap(nil)
+	if conn != nil {
+		return conn.Close()
+	}
+	return nil
+}
+
+// errNoSyslogSocket is returned by Fire when neither a per-device nor a
+// shared UDP socket is configured.
+var errNoSyslogSocket = newSyslogErr("no UDP socket configured for syslog export")
+
+// syslogErr is a typed error so callers can branch on it if needed.
+type syslogErr struct{ msg string }
+
+func (e *syslogErr) Error() string { return e.msg }
+func newSyslogErr(m string) error  { return &syslogErr{msg: m} }
+
+// openSyslogConnForDevice opens a per-device UDP socket bound to the
+// device's IP inside the opensim netns. Mirrors openTrapConnForDevice:
+// per design.md §D1 each subsystem owns its own socket lifecycle — sharing
+// a helper would require subsystem-kind parameters and would still result
+// in two sockets at runtime.
+//
+// Returns nil + logs on failure; the caller decides whether that's fatal
+// (it isn't for syslog — fall back to the shared socket per design §D7).
+func openSyslogConnForDevice(device *DeviceSimulator) *net.UDPConn {
+	if device == nil || device.netNamespace == nil {
+		return nil
+	}
+	addr := &net.UDPAddr{IP: device.IP, Port: 0}
+	conn, err := device.netNamespace.ListenUDPInNamespace(addr)
+	if err != nil {
+		log.Printf("syslog export: device %s per-device bind failed: %v", device.IP, err)
+		return nil
+	}
+	_ = conn.SetWriteBuffer(65536)
+	return conn
+}

--- a/go/simulator/syslog_exporter_test.go
+++ b/go/simulator/syslog_exporter_test.go
@@ -1,0 +1,275 @@
+/*
+ * © 2025 Labmonkeys Space
+ * Apache-2.0 — see LICENSE.
+ */
+
+package main
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newLocalUDPCollector starts a UDP listener on 127.0.0.1 and returns it
+// plus its address. The caller is responsible for closing it via t.Cleanup.
+func newLocalUDPCollector(t *testing.T) (*net.UDPConn, *net.UDPAddr) {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen collector: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn, conn.LocalAddr().(*net.UDPAddr)
+}
+
+// readNextDatagram blocks up to timeout for one UDP datagram on conn.
+// Returns the payload bytes, the sender address, or fails the test.
+func readNextDatagram(t *testing.T, conn *net.UDPConn, timeout time.Duration) ([]byte, *net.UDPAddr) {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	buf := make([]byte, 2048)
+	n, addr, err := conn.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("read datagram: %v", err)
+	}
+	return buf[:n], addr
+}
+
+// newTestSharedSocket creates a UDP socket for the exporter to transmit
+// from. We don't use openSyslogConnForDevice because tests don't run in a
+// network namespace.
+func newTestSharedSocket(t *testing.T) *net.UDPConn {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen shared: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// TestSyslogExporter_Fire5424 — a 5424 emission lands on the collector
+// with the expected PRI, HOSTNAME, and message body, and Sent increments.
+func TestSyslogExporter_Fire5424(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["interface-down"]
+	if entry == nil {
+		t.Fatal("interface-down missing from embedded catalog")
+	}
+
+	collector, collectorAddr := newLocalUDPCollector(t)
+	shared := newTestSharedSocket(t)
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC5424Encoder{},
+		Collector:  collectorAddr,
+		SharedConn: shared,
+		SysName:    "rtr-edge-07",
+		IfIndexFn:  func() int { return 3 },
+		IfNameFn:   func(i int) string { return "GigabitEthernet0/3" },
+	})
+	t.Cleanup(func() { _ = exporter.Close() })
+
+	if err := exporter.Fire(entry, nil); err != nil {
+		t.Fatalf("Fire: %v", err)
+	}
+	if got := exporter.Stats().Sent.Load(); got != 1 {
+		t.Errorf("Sent: got %d, want 1", got)
+	}
+	if got := exporter.Stats().SendFailures.Load(); got != 0 {
+		t.Errorf("SendFailures: got %d, want 0", got)
+	}
+
+	payload, _ := readNextDatagram(t, collector, 500*time.Millisecond)
+	wire := string(payload)
+	// PRI for local7 (23) + error (3) = 187.
+	if !strings.HasPrefix(wire, "<187>1 ") {
+		t.Errorf("wire does not start with expected PRI: %q", wire)
+	}
+	if !strings.Contains(wire, "rtr-edge-07") {
+		t.Errorf("wire missing hostname: %q", wire)
+	}
+	if !strings.Contains(wire, "IFMGR") {
+		t.Errorf("wire missing appName: %q", wire)
+	}
+	if !strings.Contains(wire, "LINKDOWN") {
+		t.Errorf("wire missing msgId: %q", wire)
+	}
+	if !strings.Contains(wire, "GigabitEthernet0/3") {
+		t.Errorf("wire missing ifName from body: %q", wire)
+	}
+}
+
+// TestSyslogExporter_Fire3164 — 3164 format lands on the collector with
+// the single-digit-day timestamp and truncated TAG path exercised.
+func TestSyslogExporter_Fire3164(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["auth-failure"]
+
+	collector, collectorAddr := newLocalUDPCollector(t)
+	shared := newTestSharedSocket(t)
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC3164Encoder{},
+		Collector:  collectorAddr,
+		SharedConn: shared,
+		SysName:    "rtr-edge-07",
+	})
+	t.Cleanup(func() { _ = exporter.Close() })
+
+	if err := exporter.Fire(entry, nil); err != nil {
+		t.Fatalf("Fire: %v", err)
+	}
+	payload, _ := readNextDatagram(t, collector, 500*time.Millisecond)
+	wire := string(payload)
+	// authpriv (10) * 8 + warning (4) = 84.
+	if !strings.HasPrefix(wire, "<84>") {
+		t.Errorf("wire does not start with expected PRI: %q", wire)
+	}
+	if !strings.Contains(wire, "rtr-edge-07") {
+		t.Errorf("wire missing hostname: %q", wire)
+	}
+	if !strings.Contains(wire, "sshd:") {
+		t.Errorf("wire missing tag: %q", wire)
+	}
+}
+
+// TestSyslogExporter_HostnameFallback — when sysName is empty, the
+// exporter falls back to DeviceIP for HOSTNAME (design.md §D5 priority 3).
+func TestSyslogExporter_HostnameFallback(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["interface-up"]
+
+	collector, collectorAddr := newLocalUDPCollector(t)
+	shared := newTestSharedSocket(t)
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC5424Encoder{},
+		Collector:  collectorAddr,
+		SharedConn: shared,
+		// SysName deliberately empty.
+	})
+	t.Cleanup(func() { _ = exporter.Close() })
+
+	if err := exporter.Fire(entry, nil); err != nil {
+		t.Fatalf("Fire: %v", err)
+	}
+	payload, _ := readNextDatagram(t, collector, 500*time.Millisecond)
+	if !strings.Contains(string(payload), "10.42.0.7") {
+		t.Errorf("wire missing DeviceIP fallback hostname: %q", string(payload))
+	}
+}
+
+// TestSyslogExporter_FireAfterCloseIsNoOp — Close marks the exporter and
+// subsequent Fires must not write and must not crash.
+func TestSyslogExporter_FireAfterCloseIsNoOp(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["interface-up"]
+
+	_, collectorAddr := newLocalUDPCollector(t)
+	shared := newTestSharedSocket(t)
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC5424Encoder{},
+		Collector:  collectorAddr,
+		SharedConn: shared,
+		SysName:    "host",
+	})
+	if err := exporter.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Idempotent.
+	if err := exporter.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+	if err := exporter.Fire(entry, nil); err != nil {
+		t.Errorf("Fire after Close should no-op without error, got: %v", err)
+	}
+	if got := exporter.Stats().Sent.Load(); got != 0 {
+		t.Errorf("Sent after Close: got %d, want 0", got)
+	}
+}
+
+// TestSyslogExporter_SendFailureCounterIncrements — an encoder that
+// returns an error bumps SendFailures without crashing.
+func TestSyslogExporter_SendFailureCounterIncrements(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["interface-up"]
+
+	shared := newTestSharedSocket(t)
+	// Bad collector: a non-listening port on a blackhole address triggers
+	// a write error on many systems, but on others UDP writes to closed
+	// ports silently succeed. Instead, force failure by closing the
+	// shared socket before Fire.
+	_ = shared.Close()
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC5424Encoder{},
+		Collector:  &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9},
+		SharedConn: shared,
+		SysName:    "host",
+	})
+	if err := exporter.Fire(entry, nil); err == nil {
+		t.Error("Fire on closed socket should return error")
+	}
+	if got := exporter.Stats().SendFailures.Load(); got != 1 {
+		t.Errorf("SendFailures: got %d, want 1", got)
+	}
+	if got := exporter.Stats().Sent.Load(); got != 0 {
+		t.Errorf("Sent: got %d, want 0", got)
+	}
+}
+
+// TestSyslogExporter_ImplementsFirer verifies the scheduler firer contract
+// at compile time. If someone breaks the Fire signature this won't compile.
+func TestSyslogExporter_ImplementsFirer(t *testing.T) {
+	var _ syslogFirer = (*SyslogExporter)(nil)
+}
+
+// TestSyslogExporter_TemplateOverrides — HTTP-style overrides pin the
+// per-fire context fields so on-demand fires can target a specific
+// interface or user.
+func TestSyslogExporter_TemplateOverrides(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["interface-down"]
+
+	collector, collectorAddr := newLocalUDPCollector(t)
+	shared := newTestSharedSocket(t)
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC5424Encoder{},
+		Collector:  collectorAddr,
+		SharedConn: shared,
+		SysName:    "host",
+		IfIndexFn:  func() int { return 1 },
+		IfNameFn:   func(i int) string { return "FastEthernet0/1" },
+	})
+	t.Cleanup(func() { _ = exporter.Close() })
+
+	err := exporter.Fire(entry, map[string]string{
+		"IfIndex": "42",
+		"IfName":  "GigabitEthernet7/42",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, _ := readNextDatagram(t, collector, 500*time.Millisecond)
+	wire := string(payload)
+	if !strings.Contains(wire, "GigabitEthernet7/42") {
+		t.Errorf("override IfName did not apply: %q", wire)
+	}
+	if !strings.Contains(wire, "ifIndex=42") {
+		t.Errorf("override IfIndex did not apply: %q", wire)
+	}
+	if strings.Contains(wire, "FastEthernet0/1") {
+		t.Errorf("pre-override value leaked into wire: %q", wire)
+	}
+}

--- a/go/simulator/syslog_exporter_test.go
+++ b/go/simulator/syslog_exporter_test.go
@@ -233,6 +233,103 @@ func TestSyslogExporter_ImplementsFirer(t *testing.T) {
 	var _ syslogFirer = (*SyslogExporter)(nil)
 }
 
+// TestSyslogExporter_FallbackToSharedConn — spec Requirement "Per-device
+// source IP binding" Scenario "Per-device bind failure falls back with
+// warning". When the per-device conn is absent (never SetConn'd, or
+// SetConn(nil) called), Fire must transmit via the shared socket and
+// still count as Sent.
+func TestSyslogExporter_FallbackToSharedConn(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	entry := cat.ByName["interface-up"]
+
+	collector, collectorAddr := newLocalUDPCollector(t)
+	shared := newTestSharedSocket(t)
+
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   net.IPv4(10, 42, 0, 7),
+		Encoder:    &RFC5424Encoder{},
+		Collector:  collectorAddr,
+		SharedConn: shared,
+		SysName:    "fallback-host",
+	})
+	t.Cleanup(func() { _ = exporter.Close() })
+	// SetConn is intentionally never called — per-device conn stays nil.
+
+	if err := exporter.Fire(entry, nil); err != nil {
+		t.Fatalf("Fire with shared-only conn: %v", err)
+	}
+	payload, _ := readNextDatagram(t, collector, 500*time.Millisecond)
+	if !strings.Contains(string(payload), "fallback-host") {
+		t.Errorf("wire missing expected hostname: %q", string(payload))
+	}
+	if got := exporter.Stats().Sent.Load(); got != 1 {
+		t.Errorf("Sent: got %d, want 1", got)
+	}
+	if got := exporter.Stats().SendFailures.Load(); got != 0 {
+		t.Errorf("SendFailures: got %d, want 0 (fallback must not count as failure)", got)
+	}
+}
+
+// TestSyslogExporter_SetConnClosesOld — replacing the per-device conn
+// via SetConn must close the previous conn to prevent fd leaks on rebind.
+func TestSyslogExporter_SetConnClosesOld(t *testing.T) {
+	_, collectorAddr := newLocalUDPCollector(t)
+	exporter := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:  net.IPv4(10, 42, 0, 7),
+		Encoder:   &RFC5424Encoder{},
+		Collector: collectorAddr,
+	})
+	t.Cleanup(func() { _ = exporter.Close() })
+
+	c1, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exporter.SetConn(c1)
+	c2, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		_ = c1.Close()
+		t.Fatal(err)
+	}
+	exporter.SetConn(c2)
+	// c1 must be closed by SetConn — reading from it should now fail.
+	_ = c1.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	buf := make([]byte, 16)
+	if _, _, err := c1.ReadFromUDP(buf); err == nil {
+		t.Error("c1 still usable after SetConn replaced it; expected close")
+	}
+	// c2 is still in use by the exporter; Close() will close it.
+}
+
+// TestSyslogExporter_ConstructorPanicsOnNilCollector — programmer-error
+// guard at construction (matches NewSyslogScheduler's panic pattern).
+func TestSyslogExporter_ConstructorPanicsOnNilCollector(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil Collector")
+		}
+	}()
+	_ = NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP: net.IPv4(10, 42, 0, 7),
+		Encoder:  &RFC5424Encoder{},
+		// Collector intentionally nil
+	})
+}
+
+// TestSyslogExporter_ConstructorPanicsOnZeroDeviceIP — same guard for DeviceIP.
+func TestSyslogExporter_ConstructorPanicsOnZeroDeviceIP(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on zero DeviceIP")
+		}
+	}()
+	_ = NewSyslogExporter(SyslogExporterOptions{
+		// DeviceIP intentionally omitted
+		Encoder:   &RFC5424Encoder{},
+		Collector: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 514},
+	})
+}
+
 // TestSyslogExporter_TemplateOverrides — HTTP-style overrides pin the
 // per-fire context fields so on-demand fires can target a specific
 // interface or user.

--- a/go/simulator/syslog_scheduler.go
+++ b/go/simulator/syslog_scheduler.go
@@ -127,8 +127,13 @@ func NewSyslogScheduler(opts SyslogSchedulerOptions) *SyslogScheduler {
 	if opts.Catalog == nil {
 		panic("NewSyslogScheduler: Catalog required")
 	}
-	if opts.MeanInterval <= 0 {
-		panic("NewSyslogScheduler: MeanInterval must be positive")
+	// Sub-millisecond intervals busy-loop the scheduler with no global cap.
+	// 1ms is a generous floor — the 30k-device steady-state with cap=3k tps
+	// (design.md §D2 default operating point) implies mean interval = 10s
+	// per device, so a 1ms floor is well below any realistic production
+	// setting and catches misconfiguration early.
+	if opts.MeanInterval < time.Millisecond {
+		panic("NewSyslogScheduler: MeanInterval must be >= 1ms")
 	}
 	s := &SyslogScheduler{
 		byIP:         make(map[string]*syslogHeapEntry),
@@ -205,6 +210,20 @@ func (s *SyslogScheduler) Deregister(deviceIP net.IP) {
 // wait until its nextFire, Wait() for a limiter token, pop, requeue, fire
 // outside the lock.
 func (s *SyslogScheduler) Run(ctx context.Context) {
+	// Derive a context that also cancels when Stop closes stopCh. Without
+	// this, `limiter.Wait(ctx)` cannot observe Stop — callers would see
+	// Run stay blocked for up to 1/rate seconds after Stop when a global
+	// cap is configured.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		select {
+		case <-s.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("syslog scheduler: Run panicked: %v", r)

--- a/go/simulator/syslog_scheduler.go
+++ b/go/simulator/syslog_scheduler.go
@@ -1,0 +1,325 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Central syslog scheduler. A single goroutine owns a min-heap of
+// (nextFire, deviceIP) entries. On each iteration it waits until the earliest
+// due entry, consumes one token from the global rate limiter, and fires the
+// device's SyslogExporter. Firing is a Poisson process per device: after each
+// fire the device is requeued with an exponential-distributed next-fire offset
+// (mean = -syslog-interval), naturally avoiding thundering-herd tick-boundary
+// bursts (design.md §D1, §D2).
+//
+// This is intentionally the same shape as trap_scheduler.go — one min-heap
+// goroutine keeps total timer count O(1) regardless of the 30k device fleet.
+// Per design.md §D1 we copy rather than share: the trap and syslog subsystems
+// carry independent rate caps and intervals, and a shared scheduler would
+// require an abstract event interface that we'd rather defer until a third
+// push-based capability appears.
+
+package main
+
+import (
+	"container/heap"
+	"context"
+	"log"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// syslogFirer is the behaviour the scheduler needs from each registered
+// device's SyslogExporter. Narrow interface to keep the scheduler decoupled
+// from SyslogExporter internals and to let tests substitute mocks.
+type syslogFirer interface {
+	// Fire emits one message from the given catalog entry. Implementations
+	// MUST be safe to call concurrently with Close; a fire on a closed
+	// exporter SHOULD be a silent no-op so the scheduler can never deadlock
+	// on a racing Deregister. The return value is the error from the encode
+	// or UDP write if any — the scheduler logs and continues.
+	Fire(entry *SyslogCatalogEntry, overrides map[string]string) error
+}
+
+// syslogHeapEntry is one queued device.
+type syslogHeapEntry struct {
+	nextFire time.Time
+	deviceIP net.IP
+	index    int
+}
+
+// syslogHeap implements heap.Interface. Earliest nextFire is popped first.
+type syslogHeap []*syslogHeapEntry
+
+func (h syslogHeap) Len() int           { return len(h) }
+func (h syslogHeap) Less(i, j int) bool { return h[i].nextFire.Before(h[j].nextFire) }
+func (h syslogHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
+func (h *syslogHeap) Push(x interface{}) {
+	e := x.(*syslogHeapEntry)
+	e.index = len(*h)
+	*h = append(*h, e)
+}
+func (h *syslogHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	e := old[n-1]
+	old[n-1] = nil
+	e.index = -1
+	*h = old[:n-1]
+	return e
+}
+
+// SyslogScheduler coordinates per-device syslog firing with a single
+// goroutine and a global token-bucket rate limiter. All fields are private;
+// callers interact via Register / Deregister / Run / Stop.
+type SyslogScheduler struct {
+	mu      sync.Mutex
+	heap    syslogHeap
+	byIP    map[string]*syslogHeapEntry // lookup for Deregister
+	devices map[string]syslogFirer      // exporter by device IP
+
+	catalog      *SyslogCatalog
+	meanInterval time.Duration
+	limiter      *rate.Limiter // nil → no global cap
+
+	// Injectable time/rand for deterministic tests. Production: now =
+	// time.Now, rnd seeded from crypto/rand-derived time.
+	now func() time.Time
+	rnd *rand.Rand
+
+	wake     chan struct{} // signalled by Register/Deregister/Stop to nudge Run
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// SyslogSchedulerOptions groups the tunables NewSyslogScheduler accepts. The
+// zero value is not valid — a Catalog and a non-zero MeanInterval are
+// required.
+type SyslogSchedulerOptions struct {
+	Catalog      *SyslogCatalog
+	MeanInterval time.Duration
+	// GlobalCapPerSecond is the maximum number of fires per second. Zero
+	// means unlimited (the limiter is elided).
+	GlobalCapPerSecond int
+	// Seed, when non-zero, pins the RNG used for catalog picks and the
+	// exponential inter-arrival draw. Primarily for tests.
+	Seed int64
+	// Now, when non-nil, overrides time.Now. Primarily for tests.
+	Now func() time.Time
+}
+
+// NewSyslogScheduler constructs a scheduler but does not start it. Call Run
+// to begin firing.
+func NewSyslogScheduler(opts SyslogSchedulerOptions) *SyslogScheduler {
+	if opts.Catalog == nil {
+		panic("NewSyslogScheduler: Catalog required")
+	}
+	if opts.MeanInterval <= 0 {
+		panic("NewSyslogScheduler: MeanInterval must be positive")
+	}
+	s := &SyslogScheduler{
+		byIP:         make(map[string]*syslogHeapEntry),
+		devices:      make(map[string]syslogFirer),
+		catalog:      opts.Catalog,
+		meanInterval: opts.MeanInterval,
+		wake:         make(chan struct{}, 1),
+		stopCh:       make(chan struct{}),
+	}
+	if opts.GlobalCapPerSecond > 0 {
+		// Burst = cap so short-term excursions fit within one second of
+		// steady-state tokens. Matches trap_scheduler.go reasoning.
+		s.limiter = rate.NewLimiter(rate.Limit(opts.GlobalCapPerSecond), opts.GlobalCapPerSecond)
+	}
+	if opts.Now != nil {
+		s.now = opts.Now
+	} else {
+		s.now = time.Now
+	}
+	seed := opts.Seed
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	s.rnd = rand.New(rand.NewSource(seed))
+	return s
+}
+
+// Register wires a device into the scheduler. If the device is already
+// registered (same IP), its exporter is replaced but the next-fire time is
+// preserved so re-registration doesn't double-fire.
+func (s *SyslogScheduler) Register(deviceIP net.IP, firer syslogFirer) {
+	if firer == nil {
+		return
+	}
+	key := deviceIP.String()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.devices[key] = firer
+	if _, already := s.byIP[key]; already {
+		return
+	}
+	// Initial fire: draw a Poisson offset from now. First-fire jitter
+	// prevents every device firing immediately at startup.
+	offset := time.Duration(s.rnd.ExpFloat64() * float64(s.meanInterval))
+	entry := &syslogHeapEntry{
+		nextFire: s.now().Add(offset),
+		deviceIP: append(net.IP(nil), deviceIP...), // defensive copy
+	}
+	heap.Push(&s.heap, entry)
+	s.byIP[key] = entry
+	s.nudge()
+}
+
+// Deregister removes a device from the scheduler. Safe to call for devices
+// that were never registered (no-op).
+func (s *SyslogScheduler) Deregister(deviceIP net.IP) {
+	key := deviceIP.String()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.byIP[key]
+	if !ok {
+		delete(s.devices, key)
+		return
+	}
+	if entry.index >= 0 && entry.index < s.heap.Len() {
+		heap.Remove(&s.heap, entry.index)
+	}
+	delete(s.byIP, key)
+	delete(s.devices, key)
+	s.nudge()
+}
+
+// Run blocks until ctx is cancelled or Stop is called. Loop: peek earliest,
+// wait until its nextFire, Wait() for a limiter token, pop, requeue, fire
+// outside the lock.
+func (s *SyslogScheduler) Run(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("syslog scheduler: Run panicked: %v", r)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		default:
+		}
+
+		s.mu.Lock()
+		if s.heap.Len() == 0 {
+			s.mu.Unlock()
+			// Wait until someone registers or we're stopped.
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.stopCh:
+				return
+			case <-s.wake:
+				continue
+			}
+		}
+		nextFire := s.heap[0].nextFire
+		s.mu.Unlock()
+
+		delay := nextFire.Sub(s.now())
+		if delay > 0 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-s.stopCh:
+				timer.Stop()
+				return
+			case <-s.wake:
+				// Heap changed while waiting (Register/Deregister). Re-peek.
+				timer.Stop()
+				continue
+			case <-timer.C:
+			}
+		}
+
+		if s.limiter != nil {
+			if err := s.limiter.Wait(ctx); err != nil {
+				return
+			}
+		}
+
+		s.mu.Lock()
+		if s.heap.Len() == 0 {
+			s.mu.Unlock()
+			continue
+		}
+		entry := heap.Pop(&s.heap).(*syslogHeapEntry)
+		key := entry.deviceIP.String()
+		firer, firerExists := s.devices[key]
+
+		if !firerExists {
+			// Deregistered while we waited; drop the entry.
+			delete(s.byIP, key)
+			s.mu.Unlock()
+			continue
+		}
+
+		// Requeue with an exponential-distributed offset.
+		offset := time.Duration(s.rnd.ExpFloat64() * float64(s.meanInterval))
+		entry.nextFire = s.now().Add(offset)
+		heap.Push(&s.heap, entry)
+		s.byIP[key] = entry
+
+		// Pick a catalog entry under the lock (rnd is not concurrent-safe).
+		catEntry := s.catalog.Pick(s.rnd)
+		s.mu.Unlock()
+
+		if catEntry != nil {
+			s.fireWithRecover(firer, entry.deviceIP, catEntry)
+		}
+	}
+}
+
+// fireWithRecover wraps Fire with panic recovery so a misbehaving exporter
+// can never take out the whole scheduler.
+func (s *SyslogScheduler) fireWithRecover(firer syslogFirer, deviceIP net.IP, entry *SyslogCatalogEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("syslog scheduler: Fire panicked for %s (entry=%s): %v",
+				deviceIP, entry.Name, r)
+		}
+	}()
+	if err := firer.Fire(entry, nil); err != nil {
+		// Non-fatal: log and continue. Exporter-level stats track send
+		// failures; the scheduler keeps firing for other devices.
+		log.Printf("syslog scheduler: fire %s for %s: %v", entry.Name, deviceIP, err)
+	}
+}
+
+// Stop signals Run to exit. Safe to call multiple times and from any goroutine.
+func (s *SyslogScheduler) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+	})
+}
+
+// nudge signals the Run goroutine that the heap has changed. Non-blocking:
+// a pending nudge collapses with this one.
+func (s *SyslogScheduler) nudge() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}

--- a/go/simulator/syslog_scheduler_test.go
+++ b/go/simulator/syslog_scheduler_test.go
@@ -1,0 +1,275 @@
+/*
+ * © 2025 Labmonkeys Space
+ * Apache-2.0 — see LICENSE.
+ */
+
+package main
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingSyslogFirer is a mock syslogFirer that records fire count per
+// device. Safe for concurrent use.
+type countingSyslogFirer struct {
+	deviceIP net.IP
+	count    atomic.Uint64
+	mu       sync.Mutex
+	firedAt  []time.Time
+	nextErr  error
+}
+
+func (f *countingSyslogFirer) Fire(entry *SyslogCatalogEntry, overrides map[string]string) error {
+	f.count.Add(1)
+	f.mu.Lock()
+	f.firedAt = append(f.firedAt, time.Now())
+	err := f.nextErr
+	f.mu.Unlock()
+	return err
+}
+
+func testSyslogCatalog(t *testing.T) *SyslogCatalog {
+	t.Helper()
+	cat, err := LoadEmbeddedSyslogCatalog()
+	if err != nil {
+		t.Fatalf("test catalog: %v", err)
+	}
+	return cat
+}
+
+// TestSyslogScheduler_FiresRegisteredDevices — each registered device
+// must get at least one fire within a reasonable window.
+func TestSyslogScheduler_FiresRegisteredDevices(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: 10 * time.Millisecond,
+		Seed:         1,
+	})
+
+	const N = 5
+	firers := make([]*countingSyslogFirer, N)
+	for i := 0; i < N; i++ {
+		firers[i] = &countingSyslogFirer{deviceIP: net.IPv4(10, 0, 0, byte(i+1))}
+		s.Register(firers[i].deviceIP, firers[i])
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		allFired := true
+		for _, f := range firers {
+			if f.count.Load() == 0 {
+				allFired = false
+				break
+			}
+		}
+		if allFired {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s.Stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not stop within 1s")
+	}
+	for i, f := range firers {
+		if f.count.Load() == 0 {
+			t.Errorf("device %d never fired", i)
+		}
+	}
+}
+
+// TestSyslogScheduler_GlobalCapEnforced — with a low cap and many devices
+// at a short interval, total fires-per-second must be bounded by the cap.
+func TestSyslogScheduler_GlobalCapEnforced(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	const cap = 20
+	const devices = 200
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:            cat,
+		MeanInterval:       time.Millisecond,
+		GlobalCapPerSecond: cap,
+		Seed:               42,
+	})
+	firers := make([]*countingSyslogFirer, devices)
+	for i := 0; i < devices; i++ {
+		firers[i] = &countingSyslogFirer{deviceIP: net.IPv4(10, 0, byte(i/256), byte(i%256))}
+		s.Register(firers[i].deviceIP, firers[i])
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	start := time.Now()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	<-ctx.Done()
+	s.Stop()
+	<-done
+	elapsed := time.Since(start)
+
+	var total uint64
+	for _, f := range firers {
+		total += f.count.Load()
+	}
+	// Allow full burst + one period of refill. cap=20 with burst=20 yields
+	// up to 40 in the first second, but we give 1.5× headroom for scheduler
+	// wake-up latency on slow CI.
+	maxAllowed := uint64(float64(cap)*elapsed.Seconds()*1.5 + float64(cap))
+	if total > maxAllowed {
+		t.Errorf("global cap violated: %d fires in %v (max allowed ~%d)", total, elapsed, maxAllowed)
+	}
+	if total == 0 {
+		t.Error("no fires recorded under cap")
+	}
+}
+
+// TestSyslogScheduler_RegisterDeregisterThreadSafety — mixed ops from many
+// goroutines must not race or panic.
+func TestSyslogScheduler_RegisterDeregisterThreadSafety(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: time.Millisecond,
+		Seed:         7,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+
+	const goroutines = 100
+	const ops = 50
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < ops; i++ {
+				ip := net.IPv4(10, 0, byte(id), byte(i))
+				f := &countingSyslogFirer{deviceIP: ip}
+				s.Register(ip, f)
+				s.Deregister(ip)
+			}
+		}(g)
+	}
+	wg.Wait()
+	s.Stop()
+	cancel()
+	<-done
+}
+
+// TestSyslogScheduler_DeregisterRemovesDevice — a deregistered device
+// stops receiving fires.
+func TestSyslogScheduler_DeregisterRemovesDevice(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: 10 * time.Millisecond,
+		Seed:         3,
+	})
+	ip := net.IPv4(10, 42, 0, 1)
+	f := &countingSyslogFirer{deviceIP: ip}
+	s.Register(ip, f)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+
+	// Wait for first fire, then deregister and verify count stabilises.
+	for time.Now().Before(time.Now().Add(time.Second)) {
+		if f.count.Load() > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	s.Deregister(ip)
+	at := f.count.Load()
+	time.Sleep(100 * time.Millisecond)
+	s.Stop()
+	cancel()
+	<-done
+	if after := f.count.Load(); after > at {
+		t.Errorf("deregistered device still firing: before=%d, after=%d", at, after)
+	}
+}
+
+// TestSyslogScheduler_StopIdempotent — repeated Stop calls and Stop after
+// Run completion must not panic.
+func TestSyslogScheduler_StopIdempotent(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: time.Second,
+		Seed:         11,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	s.Stop()
+	s.Stop()
+	cancel()
+	<-done
+	s.Stop()
+}
+
+// TestSyslogScheduler_FireErrorDoesNotStopLoop — a firer that returns an
+// error must not prevent subsequent fires.
+func TestSyslogScheduler_FireErrorDoesNotStopLoop(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: 5 * time.Millisecond,
+		Seed:         2,
+	})
+	ip := net.IPv4(10, 1, 1, 1)
+	f := &countingSyslogFirer{deviceIP: ip}
+	f.mu.Lock()
+	f.nextErr = context.DeadlineExceeded
+	f.mu.Unlock()
+	s.Register(ip, f)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	<-ctx.Done()
+	s.Stop()
+	<-done
+	if f.count.Load() < 2 {
+		t.Errorf("expected multiple fires despite errors, got %d", f.count.Load())
+	}
+}
+
+// TestSyslogScheduler_EmptyHeapDoesNotBusyLoop — running with zero
+// registered devices must idle cheaply, not spin.
+func TestSyslogScheduler_EmptyHeapDoesNotBusyLoop(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: time.Millisecond,
+		Seed:         4,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	<-ctx.Done()
+	s.Stop()
+	<-done
+	// If we got here without hang or panic, the loop idled correctly.
+}

--- a/go/simulator/syslog_scheduler_test.go
+++ b/go/simulator/syslog_scheduler_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"math"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -127,10 +128,12 @@ func TestSyslogScheduler_GlobalCapEnforced(t *testing.T) {
 	for _, f := range firers {
 		total += f.count.Load()
 	}
-	// Allow full burst + one period of refill. cap=20 with burst=20 yields
-	// up to 40 in the first second, but we give 1.5× headroom for scheduler
-	// wake-up latency on slow CI.
-	maxAllowed := uint64(float64(cap)*elapsed.Seconds()*1.5 + float64(cap))
+	// Theoretical max: full burst (cap) + steady-state (cap × elapsed seconds).
+	// With cap=20, burst=20, elapsed≈1s: ~40 fires. We allow 10% timing slack
+	// for scheduler wake-up latency on slow CI. Threshold ~44 catches
+	// regressions of ≥10% over the theoretical cap, vs the old 50 which
+	// silently tolerated ~25%.
+	maxAllowed := uint64(float64(cap)*(elapsed.Seconds()+1.0)*1.1) + 1
 	if total > maxAllowed {
 		t.Errorf("global cap violated: %d fires in %v (max allowed ~%d)", total, elapsed, maxAllowed)
 	}
@@ -192,7 +195,10 @@ func TestSyslogScheduler_DeregisterRemovesDevice(t *testing.T) {
 	go func() { s.Run(ctx); close(done) }()
 
 	// Wait for first fire, then deregister and verify count stabilises.
-	for time.Now().Before(time.Now().Add(time.Second)) {
+	// Capture the deadline once; `time.Now().Before(time.Now().Add(X))` is
+	// always true because both operands re-evaluate each iteration.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
 		if f.count.Load() > 0 {
 			break
 		}
@@ -204,8 +210,11 @@ func TestSyslogScheduler_DeregisterRemovesDevice(t *testing.T) {
 	s.Stop()
 	cancel()
 	<-done
-	if after := f.count.Load(); after > at {
-		t.Errorf("deregistered device still firing: before=%d, after=%d", at, after)
+	// One post-Deregister fire is a legitimate race: the scheduler may have
+	// captured the firer reference under the lock before Deregister acquired
+	// it, then released the lock and called Fire outside. Tolerate +1.
+	if after := f.count.Load(); after > at+1 {
+		t.Errorf("deregistered device still firing: before=%d, after=%d (tolerance +1)", at, after)
 	}
 }
 
@@ -252,6 +261,138 @@ func TestSyslogScheduler_FireErrorDoesNotStopLoop(t *testing.T) {
 	<-done
 	if f.count.Load() < 2 {
 		t.Errorf("expected multiple fires despite errors, got %d", f.count.Load())
+	}
+}
+
+// TestSyslogScheduler_ExponentialInterArrival — spec Requirement "Poisson
+// scheduling and global rate cap" Scenario "Fire intervals follow
+// exponential distribution". We use a single device at 10ms mean and
+// collect ~500 samples (~5s runtime). For an Exp(λ=100/s) distribution:
+//
+//   mean = 1/λ = 10ms
+//   variance = 1/λ² = 100ms²
+//   coefficient of variation (stddev/mean) = 1
+//
+// A periodic scheduler would have CV ≈ 0; a uniform-jittered one ≈ 0.58.
+// Asserting mean within 40% and CV > 0.7 distinguishes exponential from
+// both alternatives while tolerating wall-clock sampling noise.
+func TestSyslogScheduler_ExponentialInterArrival(t *testing.T) {
+	const meanInterval = 10 * time.Millisecond
+	const targetSamples = 500
+	cat := testSyslogCatalog(t)
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: meanInterval,
+		Seed:         12345,
+	})
+	ip := net.IPv4(10, 0, 0, 99)
+	f := &countingSyslogFirer{deviceIP: ip}
+	s.Register(ip, f)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if f.count.Load() >= targetSamples {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	s.Stop()
+	cancel()
+	<-done
+
+	f.mu.Lock()
+	times := make([]time.Time, len(f.firedAt))
+	copy(times, f.firedAt)
+	f.mu.Unlock()
+	if len(times) < targetSamples {
+		t.Fatalf("not enough samples: got %d, want %d", len(times), targetSamples)
+	}
+	// Drop the first sample's "warmup" interval (from Register to first fire).
+	intervals := make([]float64, 0, len(times)-1)
+	for i := 1; i < len(times); i++ {
+		intervals = append(intervals, times[i].Sub(times[i-1]).Seconds())
+	}
+	var sum float64
+	for _, d := range intervals {
+		sum += d
+	}
+	mean := sum / float64(len(intervals))
+	var sqsum float64
+	for _, d := range intervals {
+		diff := d - mean
+		sqsum += diff * diff
+	}
+	variance := sqsum / float64(len(intervals))
+	stddev := math.Sqrt(variance)
+	cv := stddev / mean
+
+	expected := meanInterval.Seconds()
+	if mean < expected*0.6 || mean > expected*1.4 {
+		t.Errorf("mean inter-arrival: got %.4fs, want within ±40%% of %.4fs", mean, expected)
+	}
+	// Exponential has CV = 1. Periodic = 0. Uniform jitter ≈ 0.58.
+	// We require CV > 0.7 to rule out the non-exponential alternatives
+	// while allowing for wall-clock sampling noise at small intervals.
+	if cv < 0.7 {
+		t.Errorf("coefficient of variation %.2f suggests non-exponential distribution (want ≈1)", cv)
+	}
+	t.Logf("inter-arrival: mean=%.4fs (target %.4f), CV=%.2f (target 1.0), n=%d",
+		mean, expected, cv, len(intervals))
+}
+
+// TestSyslogScheduler_RejectsSubMillisecondInterval — MeanInterval below
+// 1ms would busy-loop the scheduler when no global cap is set.
+func TestSyslogScheduler_RejectsSubMillisecondInterval(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewSyslogScheduler with sub-1ms interval should panic")
+		}
+	}()
+	_ = NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:      cat,
+		MeanInterval: 500 * time.Microsecond,
+	})
+}
+
+// TestSyslogScheduler_StopWithLimiterCap — Stop() must be able to
+// interrupt Run even when it is blocked in limiter.Wait() (which, before
+// the ctx-derivation fix, could hold Run blocked for up to 1/rate seconds).
+func TestSyslogScheduler_StopWithLimiterCap(t *testing.T) {
+	cat := testSyslogCatalog(t)
+	// Very low cap with a bucket already drained by Register's initial
+	// exponential draws — any subsequent limiter.Wait blocks for ≥1s.
+	s := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:            cat,
+		MeanInterval:       time.Millisecond,
+		GlobalCapPerSecond: 1,
+		Seed:               42,
+	})
+	for i := 0; i < 50; i++ {
+		ip := net.IPv4(10, 0, 0, byte(i+1))
+		s.Register(ip, &countingSyslogFirer{deviceIP: ip})
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+
+	// Give the scheduler time to drain the burst and block on limiter.Wait.
+	time.Sleep(50 * time.Millisecond)
+	stopAt := time.Now()
+	s.Stop()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("Stop() did not unblock Run within 500ms while limiter was held")
+	}
+	if elapsed := time.Since(stopAt); elapsed > 500*time.Millisecond {
+		t.Errorf("Stop() took %v (want <500ms even under cap)", elapsed)
 	}
 }
 


### PR DESCRIPTION
Second of three PRs implementing the add-syslog-udp OpenSpec change — epic #76. Builds on merged PR #89 (catalog + wire encoders).

## Closes

- Sub-issue #80 — Rate limiter and scheduler (tasks 4.1-4.6)
- Sub-issue #81 — Per-device SyslogExporter (tasks 5.1-5.5)
- Resolves pre-flight 1.2 from #77 (sysName reachable at fire time without SNMP coupling)

## What's in it

| File | Lines | Purpose |
|---|---|---|
| \`syslog_scheduler.go\` | 325 | Single-goroutine min-heap + Poisson + token-bucket limiter |
| \`syslog_scheduler_test.go\` | 275 | 7 tests (fires, global cap, thread-safety, Deregister, Stop, error paths, empty heap) |
| \`syslog_exporter.go\` | 273 | Per-device UDP emitter — Fire(), hostname fallback, openSyslogConnForDevice |
| \`syslog_exporter_test.go\` | 275 | 7 tests against a local UDP collector (5424, 3164, fallback, Close, failures, overrides, contract check) |
| **Total** | **1,148** | |

## Design conformance

- **D1** — scheduler copied (not shared) from trap; trap and syslog have independent intervals and caps.
- **D2** — Poisson per-device with exponential inter-arrival; global token-bucket cap.
- **D5** — hostname fallback priority: catalog template → sysName → DeviceIP.
- **D7** — per-device UDP via \`openSyslogConnForDevice\`, shared-socket fallback (non-fatal for syslog unlike INFORM).
- **D8** — \`SyslogEncoder\` interface from PR1 consumed; 5424 and 3164 both exercised in tests.
- **D9** — \`*rate.Limiter\` instance is local to this scheduler; not shared with trap.

## Pre-flight 1.2 resolution

\`sysName\` is accepted as a plain string in \`SyslogExporterOptions\` at construction time. Keeps the hot Fire() path free of SNMP-stack lookups. The upstream question — who populates the string from the device profile — moves to PR3's section 7 (device lifecycle wiring).

## Verified

- \`cd go && go test ./...\` clean on darwin (38 syslog tests pass; all prior tests still pass).
- \`go test -race -run TestSyslog ./simulator\` clean — no data races under scheduler lock + exporter atomic contention.
- \`openspec validate add-syslog-udp --strict\` passes.

## Out of scope for this PR (PR3 will add)

- \`SimulatorManager.StartSyslogExport\` / \`StopSyslogExport\` (section 6)
- Per-device lifecycle hook-up in \`device.go\` (section 7)
- Six \`-syslog-*\` CLI flags (section 8)
- \`POST /api/v1/devices/{ip}/syslog\` + \`GET /api/v1/syslog/status\` (section 9)
- CLAUDE.md \"Syslog export\" section + README feature bullet (section 10)

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, progress on epic #76: PR1 (#89 merged), PR2 (this), PR3 (integration — next)