### PR TITLE
feat(simulator): wire syslog manager, CLI, HTTP, and docs (PR3/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,62 @@ The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-s
 - SD-NAME keys are validated against RFC 5424 §6.3.3 at load; each templated value is pre-compiled to a `*template.Template` so the fire hot path is allocation-light (measured 894 ns/op).
 - Entry `appName` is required (RFC 3164 TAG has no NILVALUE). Facility and severity accept canonical names (`local7`, `error`) or integers in range (`0..23` / `0..7`). MTU-safety dry-render rejects entries whose worst-case rendered output exceeds 1400 bytes.
 
+**Syslog catalog JSON schema** (one entry; the file is `{"entries":[…]}`):
+
+```json
+{
+  "name":     "interface-down",       // required; unique within catalog
+  "weight":   40,                     // weighted-random Pick; 0/omitted → 1
+  "facility": "local7",               // name (kern/user/.../local0..local7) or integer 0..23
+  "severity": "error",                // name (emerg/alert/crit/err|error/warning|warn/notice/info/debug) or integer 0..7
+  "appName":  "IFMGR",                // required (3164 TAG has no NILVALUE); sanitised to ASCII token
+  "msgId":    "LINKDOWN",             // 5424 MSGID; empty → NILVALUE; dropped in 3164
+  "hostname": "{{.SysName}}",         // optional override; empty → sysName→DeviceIP fallback
+  "structuredData": {                 // 5424 STRUCTURED-DATA; empty map → NILVALUE; dropped in 3164
+    "ifIndex": "{{.IfIndex}}",        // keys must match RFC 5424 §6.3.3 SD-NAME grammar
+    "ifName":  "{{.IfName}}"
+  },
+  "template": "Interface {{.IfName}} (ifIndex={{.IfIndex}}) changed state to down"
+}
+```
+
+**HOSTNAME derivation priority** (resolved at fire time, per design §D5):
+1. If the catalog entry defines a non-empty `hostname` template, render it (with the six-field vocabulary) and use the result.
+2. Otherwise, use the device's stored `sysName.0` value (captured at device construction).
+3. Otherwise, use the device's IPv4 as dotted-quad.
+
+In every branch the result is run through `sanitiseHostname`: spaces become hyphens (spec mandate), other framing / control chars become `_`.
+
+**PRI calculation and vocabulary** (per RFC 5424 §6.2.1, shared by 5424 and 3164):
+
+- `PRI = facility * 8 + severity`, emitted as `<N>` with no leading zeros (range 0..191).
+- Catalog entries accept either the canonical name or the integer:
+
+  | Facility   | Int | Facility   | Int | Facility   | Int |
+  |------------|-----|------------|-----|------------|-----|
+  | `kern`     | 0   | `cron`     | 9   | `local0`   | 16  |
+  | `user`     | 1   | `authpriv` | 10  | `local1`   | 17  |
+  | `mail`     | 2   | `ftp`      | 11  | `local2`   | 18  |
+  | `daemon`   | 3   | `ntp`      | 12  | `local3`   | 19  |
+  | `auth`     | 4   | `audit`    | 13  | `local4`   | 20  |
+  | `syslog`   | 5   | `alert`    | 14  | `local5`   | 21  |
+  | `lpr`      | 6   | `clock`    | 15  | `local6`   | 22  |
+  | `news`     | 7   |            |     | `local7`   | 23  |
+  | `uucp`     | 8   |            |     |            |     |
+
+  | Severity  | Int | Aliases       |
+  |-----------|-----|---------------|
+  | `emerg`   | 0   |               |
+  | `alert`   | 1   |               |
+  | `crit`    | 2   |               |
+  | `err`     | 3   | `error`       |
+  | `warning` | 4   | `warn`        |
+  | `notice`  | 5   |               |
+  | `info`    | 6   |               |
+  | `debug`   | 7   |               |
+
+  Out-of-range integers or unknown names are rejected at catalog load.
+
 **Syslog operational notes:**
 - Only one format on the wire at a time — `-syslog-format 5424` (default) or `3164`. Mixed formats on one socket break auto-detecting parsers downstream; operators select one per deployment.
 - Per-device UDP source binding reuses the same `setupVethPair` + `FORWARD -i veth-sim-host -j ACCEPT` rule shared by flow / trap. No new netns / iptables surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ sudo ./simulator [flags]
 -trap-inform-timeout <duration>   # Per-retry timeout in inform mode (default: 5s)
 -trap-inform-retries <int>        # Max retransmissions per inform (default: 2)
 
+# UDP syslog export flags (RFC 5424 / RFC 3164)
+-syslog-collector <host:port>     # Enable UDP syslog export to this collector (default port 514)
+-syslog-format <fmt>              # 5424 (default, structured) | 3164 (legacy BSD)
+-syslog-interval <duration>       # Per-device mean firing interval, Poisson-distributed (default: 10s)
+-syslog-global-cap <rate>         # Simulator-wide rate ceiling (0 = unlimited)
+-syslog-catalog <path>            # Override embedded universal 6-entry catalog
+-syslog-source-per-device         # Source IP = device IP (default: true; bind failure is non-fatal, falls back to shared socket)
+
 # Tests
 cd go
 go test ./...
@@ -111,6 +119,27 @@ The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-s
 **Trap HTTP endpoints:**
 - `GET /api/v1/traps/status` — JSON with `enabled`, `mode`, `sent`, INFORM counters (`informs_pending`, `informs_acked`, `informs_failed`, `informs_dropped` when mode=inform), `rate_limiter_tokens_available` (when `-trap-global-cap` is set), `devices_exporting`.
 - `POST /api/v1/devices/{ip}/trap` — body `{"name":"linkDown","varbindOverrides":{"IfIndex":"3"}}` → `202 Accepted` + `{"requestId": N}`. `400` for unknown catalog entry, `404` for unknown device, `503` when trap export is disabled. Fire-and-forget: returns without waiting on INFORM ack.
+
+**UDP syslog export:** `syslog_manager.go` (SimulatorManager integration, SyslogConfig, `StartSyslogExport` / `StopSyslogExport`, `SyslogStatus`) + `syslog_catalog.go` (JSON catalog with embedded universal 6-entry set; weighted-random pick; `text/template`-based body / structured-data resolution with all templates pre-compiled at load) + `syslog_wire.go` (`SyslogEncoder` interface with `RFC5424Encoder` and `RFC3164Encoder` — PRI calc, ISO 8601 / `Mmm DD HH:MM:SS` timestamps, SD-PARAM escape per §6.3.3, HOSTNAME / APP-NAME / MSGID / TAG sanitisation, MaxMessageSize enforcement) + `syslog_scheduler.go` (single central min-heap scheduler with Poisson inter-arrival + `golang.org/x/time/rate` global cap; derived context so `Stop()` is bounded-time under cap) + `syslog_exporter.go` (per-device `SyslogExporter` with atomic per-device UDP socket and shared-socket fallback).
+
+**Syslog catalog:**
+- Default catalog is compiled into the binary from `resources/_common/syslog.json` via `embed.FS` — feature works out of the box.
+- Override with `-syslog-catalog <path>` (complete replacement, not merge).
+- Universal catalog ships 6 entries: `interface-up` / `interface-down` (local7.notice/error, IFMGR), `auth-success` / `auth-failure` (authpriv.info/warning, sshd), `config-change` / `system-restart` (local7.notice/warning, SYSMGR). Weights sum to 135.
+- Template vocabulary is restricted to `{{.DeviceIP}}`, `{{.SysName}}`, `{{.IfIndex}}`, `{{.IfName}}`, `{{.Now}}`, `{{.Uptime}}`. Unknown fields are rejected at catalog load.
+- SD-NAME keys are validated against RFC 5424 §6.3.3 at load; each templated value is pre-compiled to a `*template.Template` so the fire hot path is allocation-light (measured 894 ns/op).
+- Entry `appName` is required (RFC 3164 TAG has no NILVALUE). Facility and severity accept canonical names (`local7`, `error`) or integers in range (`0..23` / `0..7`). MTU-safety dry-render rejects entries whose worst-case rendered output exceeds 1400 bytes.
+
+**Syslog operational notes:**
+- Only one format on the wire at a time — `-syslog-format 5424` (default) or `3164`. Mixed formats on one socket break auto-detecting parsers downstream; operators select one per deployment.
+- Per-device UDP source binding reuses the same `setupVethPair` + `FORWARD -i veth-sim-host -j ACCEPT` rule shared by flow / trap. No new netns / iptables surface.
+- Per-device bind failure is **non-fatal** for syslog (unlike INFORM): exporter logs a warning and falls back to the shared socket. When the primary per-device write fails but the shared fallback succeeds, the primary failure is logged and stats count the send as successful.
+- The collector-side `rp_filter` caveat is the same as flow / trap — accept UDP from device IPs with `net.ipv4.conf.*.rp_filter=0` or `2`.
+- On-demand HTTP fires **bypass the global rate limiter** (test-harness use case; scheduler-driven traffic still honours `-syslog-global-cap`).
+
+**Syslog HTTP endpoints:**
+- `GET /api/v1/syslog/status` — JSON with `enabled`, `format` (`5424` or `3164`), `collector`, `sent`, `send_failures`, `rate_limiter_tokens_available` (when `-syslog-global-cap` is set), `devices_exporting`.
+- `POST /api/v1/devices/{ip}/syslog` — body `{"name":"interface-down","templateOverrides":{"IfIndex":"3","IfName":"Gi0/3"}}` → `202 Accepted` + `{}`. `400` for unknown catalog entry or malformed JSON, `404` for unknown device, `503` when syslog export is disabled.
 
 **Resource loading:** `resources.go` loads and caches the 379 JSON files at startup. Each device type directory has split JSON files for SNMP, SSH, and REST responses that are merged at load time.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ network namespaces.
   UDP source IPs. Suited to OpenNMS `trapd` scale testing. Configure with
   `-trap-collector <host:port>`; full flag list and catalog schema in
   [CLAUDE.md](CLAUDE.md) → "SNMP trap export".
+- **Per-device UDP syslog export** (RFC 5424 / RFC 3164) — central
+  Poisson scheduler with a global rate cap, user-overridable JSON
+  catalog, and per-device UDP source IPs. Ships six generic entries
+  (interface up/down, auth success/failure, config change, system
+  restart) spanning `local7` and `authpriv`; select format with
+  `-syslog-format 5424|3164`. Suited to OpenNMS `syslogd` scale
+  testing — configure with `-syslog-collector <host:port>`; full flag
+  list and catalog schema in [CLAUDE.md](CLAUDE.md) →
+  "UDP syslog export".
 
 ## Quick start
 

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -282,6 +282,15 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 				}
 			}
 
+			// Initialize UDP syslog exporter if syslog export is enabled.
+			// Per-device bind failure is non-fatal (no ack path that requires
+			// symmetric source IPs); exporter falls back to the shared socket.
+			if sm.syslogActive.Load() {
+				if err := sm.startDeviceSyslogExporter(device); err != nil {
+					log.Printf("syslog export: skipping device %s: %v", device.IP, err)
+				}
+			}
+
 			// Cache the dynamic values using atomic for lock-free access
 			device.cachedSysName.Store(sysNameValue)
 			device.cachedSysLocation.Store(sysLocationValue)
@@ -521,6 +530,13 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 		}
 	}
 
+	// Initialize UDP syslog exporter if syslog export is enabled.
+	if sm.syslogActive.Load() {
+		if err := sm.startDeviceSyslogExporter(device); err != nil {
+			log.Printf("syslog export: skipping device %s: %v", device.IP, err)
+		}
+	}
+
 	// Cache the dynamic values using atomic for lock-free access
 	device.cachedSysName.Store(sysNameValue)
 	device.cachedSysLocation.Store(sysLocationValue)
@@ -664,6 +680,14 @@ func (d *DeviceSimulator) Stop() error {
 		d.trapExporter = nil
 	}
 
+	if d.syslogExporter != nil {
+		_ = d.syslogExporter.Close()
+		if manager != nil && manager.syslogScheduler != nil {
+			manager.syslogScheduler.Deregister(d.IP)
+		}
+		d.syslogExporter = nil
+	}
+
 	// Only destroy TUN interface if it's not pre-allocated and not part of bulk deletion
 	// Individual device stops will close the file descriptor but not delete the interface
 	// Bulk deletion handles the actual interface removal
@@ -706,6 +730,10 @@ func (d *DeviceSimulator) stopListenersOnly() {
 	if d.trapExporter != nil {
 		_ = d.trapExporter.Close()
 		d.trapExporter = nil
+	}
+	if d.syslogExporter != nil {
+		_ = d.syslogExporter.Close()
+		d.syslogExporter = nil
 	}
 	if d.tunIface != nil {
 		d.tunIface.destroy() // Close FD only, no ip link delete

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -284,11 +284,10 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 
 			// Initialize UDP syslog exporter if syslog export is enabled.
 			// Per-device bind failure is non-fatal (no ack path that requires
-			// symmetric source IPs); exporter falls back to the shared socket.
+			// symmetric source IPs); exporter falls back to the shared socket
+			// with an in-function warning log.
 			if sm.syslogActive.Load() {
-				if err := sm.startDeviceSyslogExporter(device); err != nil {
-					log.Printf("syslog export: skipping device %s: %v", device.IP, err)
-				}
+				sm.startDeviceSyslogExporter(device)
 			}
 
 			// Cache the dynamic values using atomic for lock-free access
@@ -532,9 +531,7 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 
 	// Initialize UDP syslog exporter if syslog export is enabled.
 	if sm.syslogActive.Load() {
-		if err := sm.startDeviceSyslogExporter(device); err != nil {
-			log.Printf("syslog export: skipping device %s: %v", device.IP, err)
-		}
+		sm.startDeviceSyslogExporter(device)
 	}
 
 	// Cache the dynamic values using atomic for lock-free access

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -339,6 +339,10 @@ func (sm *SimulatorManager) Shutdown() error {
 	// shared fallback socket). Safe to call when trap export was never started.
 	sm.StopTrapExport()
 
+	// Stop the syslog subsystem (same shape as trap). Safe to call when
+	// syslog export was never started.
+	sm.StopSyslogExport()
+
 	if sm.useNamespace && sm.netNamespace != nil {
 		// Fast path: when using a namespace, deleting it instantly destroys all
 		// TUN interfaces inside it. No need to delete them one by one.

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -121,6 +121,14 @@ func main() {
 		trapSourcePerDevice = flag.Bool("trap-source-per-device", true, "Bind a per-device UDP socket in the opensim ns so trap packets use the device IP as source (required in -trap-mode inform)")
 		trapInformTimeout   = flag.Duration("trap-inform-timeout", 5*time.Second, "Per-retry timeout in INFORM mode (default 5s)")
 		trapInformRetries   = flag.Int("trap-inform-retries", 2, "Maximum retransmissions per INFORM before declaring it failed (default 2)")
+
+		// UDP syslog export flags. See CLAUDE.md "Syslog export" for detail.
+		syslogCollector       = flag.String("syslog-collector", "", "UDP syslog collector address (host:port, e.g. 10.0.0.50:514); enables syslog export when non-empty")
+		syslogFormat          = flag.String("syslog-format", "5424", "Syslog wire format: 5424 (default, structured RFC 5424) or 3164 (BSD RFC 3164)")
+		syslogInterval        = flag.Duration("syslog-interval", 10*time.Second, "Per-device mean firing interval (Poisson-distributed); default 10s")
+		syslogGlobalCap       = flag.Int("syslog-global-cap", 0, "Simulator-wide rate ceiling for syslog fires (0 = unlimited)")
+		syslogCatalog         = flag.String("syslog-catalog", "", "Path to a JSON syslog catalog; overrides the embedded universal 6-entry catalog when set")
+		syslogSourcePerDevice = flag.Bool("syslog-source-per-device", true, "Bind a per-device UDP socket in the opensim ns so syslog packets use the device IP as source (default true). Bind failures fall back to shared socket with a warning (never fatal for syslog)")
 	)
 
 	flag.Parse()
@@ -228,6 +236,27 @@ func main() {
 		}
 		if err := manager.StartTrapExport(cfg); err != nil {
 			log.Fatalf("Failed to initialize trap export: %v", err)
+		}
+	}
+
+	// Enable UDP syslog export if a collector address was provided.
+	// Must run before device creation so per-device SyslogExporters are
+	// wired during startup.
+	if *syslogCollector != "" {
+		format, err := ParseSyslogFormat(*syslogFormat)
+		if err != nil {
+			log.Fatalf("Failed to initialize syslog export: %v", err)
+		}
+		cfg := SyslogConfig{
+			Collector:       *syslogCollector,
+			Format:          format,
+			Interval:        *syslogInterval,
+			GlobalCap:       *syslogGlobalCap,
+			CatalogPath:     *syslogCatalog,
+			SourcePerDevice: *syslogSourcePerDevice,
+		}
+		if err := manager.StartSyslogExport(cfg); err != nil {
+			log.Fatalf("Failed to initialize syslog export: %v", err)
 		}
 	}
 

--- a/go/simulator/syslog_api_test.go
+++ b/go/simulator/syslog_api_test.go
@@ -6,8 +6,11 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -161,6 +164,12 @@ func TestFireSyslogOnDevice_HappyPath(t *testing.T) {
 	if !strings.Contains(wire, "LINKDOWN") {
 		t.Errorf("wire missing MsgID: %q", wire)
 	}
+	// Spec Requirement "On-demand HTTP syslog endpoint" scenario "Valid
+	// request returns 202" says "AND the sent counter SHALL increment
+	// by 1". Verify via the status endpoint.
+	if got := sm.GetSyslogStatus().Sent; got != 1 {
+		t.Errorf("SyslogStatus.Sent after one Fire: got %d, want 1", got)
+	}
 }
 
 func TestFireSyslogOnDevice_UnknownCatalogName(t *testing.T) {
@@ -218,6 +227,157 @@ func TestFireSyslogOnDevice_OverridesApplied(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP handler tests (go through the real mux + handlers)
+// ---------------------------------------------------------------------------
+
+// withManager temporarily installs sm as the package-level `manager`
+// variable that `fireSyslogHandler` and `syslogStatusHandler` read.
+// Restores the previous value on test cleanup.
+func withManager(t *testing.T, sm *SimulatorManager) {
+	t.Helper()
+	prev := manager
+	manager = sm
+	t.Cleanup(func() { manager = prev })
+}
+
+func TestSyslogHTTP_StatusEndpointDisabled(t *testing.T) {
+	sm := newTestSyslogManager()
+	withManager(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/syslog/status", nil)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status code: got %d, want 200", rr.Code)
+	}
+	var body SyslogStatus
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v — raw=%q", err, rr.Body.String())
+	}
+	if body.Enabled {
+		t.Errorf("Enabled: got %v, want false when feature disabled", body.Enabled)
+	}
+}
+
+func TestSyslogHTTP_StatusEndpointEnabled(t *testing.T) {
+	sm, _, _ := startSyslogForTest(t, SyslogFormat5424)
+	withManager(t, sm)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/syslog/status", nil)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status code: got %d, want 200", rr.Code)
+	}
+	var body SyslogStatus
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !body.Enabled || body.Format != "5424" || body.DevicesExporting != 1 {
+		t.Errorf("enabled status unexpected: %+v", body)
+	}
+}
+
+func TestSyslogHTTP_FireEndpoint202(t *testing.T) {
+	sm, collector, device := startSyslogForTest(t, SyslogFormat5424)
+	withManager(t, sm)
+
+	body := strings.NewReader(`{"name":"interface-down"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/"+device.IP.String()+"/syslog", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status code: got %d, want 202 — body=%q", rr.Code, rr.Body.String())
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != "{}" {
+		t.Errorf("body: got %q, want {}", got)
+	}
+	// Verify the datagram actually reached the collector (end-to-end
+	// validation of the manager → exporter → UDP path through the HTTP
+	// handler surface).
+	_ = collector.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 2048)
+	if _, _, err := collector.ReadFromUDP(buf); err != nil {
+		t.Errorf("collector did not receive datagram: %v", err)
+	}
+}
+
+func TestSyslogHTTP_FireEndpoint400UnknownCatalogEntry(t *testing.T) {
+	sm, _, device := startSyslogForTest(t, SyslogFormat5424)
+	withManager(t, sm)
+
+	body := strings.NewReader(`{"name":"notACatalogEntry"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/"+device.IP.String()+"/syslog", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status code: got %d, want 400 — body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSyslogHTTP_FireEndpoint404UnknownDevice(t *testing.T) {
+	sm, _, _ := startSyslogForTest(t, SyslogFormat5424)
+	withManager(t, sm)
+
+	body := strings.NewReader(`{"name":"interface-up"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/10.99.99.99/syslog", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status code: got %d, want 404", rr.Code)
+	}
+}
+
+func TestSyslogHTTP_FireEndpoint503FeatureDisabled(t *testing.T) {
+	sm := newTestSyslogManager()
+	withManager(t, sm)
+
+	body := strings.NewReader(`{"name":"interface-up"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/10.0.0.1/syslog", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status code: got %d, want 503", rr.Code)
+	}
+}
+
+func TestSyslogHTTP_FireEndpoint400MissingName(t *testing.T) {
+	sm, _, device := startSyslogForTest(t, SyslogFormat5424)
+	withManager(t, sm)
+
+	body := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/"+device.IP.String()+"/syslog", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status code: got %d, want 400", rr.Code)
+	}
+}
+
+func TestSyslogHTTP_FireEndpoint400UnknownField(t *testing.T) {
+	// `DisallowUnknownFields` fix: a typo'd key surfaces as 400 instead
+	// of being silently dropped.
+	sm, _, device := startSyslogForTest(t, SyslogFormat5424)
+	withManager(t, sm)
+
+	body := strings.NewReader(`{"name":"interface-down","tempalteOverrides":{"IfIndex":"7"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/"+device.IP.String()+"/syslog", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("typo'd field accepted silently: got %d, want 400", rr.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -242,10 +402,14 @@ func startSyslogForTest(t *testing.T, format SyslogFormat) (*SimulatorManager, *
 	collector, collectorAddr := newLocalUDPCollector(t)
 
 	err := sm.StartSyslogExport(SyslogConfig{
-		Collector:       collectorAddr.String(),
-		Format:          format,
-		Interval:        10 * time.Second, // long — test fires directly via FireSyslogOnDevice
-		SourcePerDevice: false,            // no netns available in unit tests
+		Collector: collectorAddr.String(),
+		Format:    format,
+		// One hour, not ten seconds: the scheduler's Poisson draw has an
+		// unbounded tail, and at 10s the ~1% of runs with a sub-second
+		// tail draw made `TestFireSyslogOnDevice_OverridesApplied` read
+		// the scheduled datagram instead of the explicit-fire one.
+		Interval:        time.Hour,
+		SourcePerDevice: false, // no netns available in unit tests
 	})
 	if err != nil {
 		t.Fatalf("StartSyslogExport: %v", err)

--- a/go/simulator/syslog_api_test.go
+++ b/go/simulator/syslog_api_test.go
@@ -1,0 +1,282 @@
+/*
+ * © 2025 Labmonkeys Space
+ * Apache-2.0 — see LICENSE.
+ */
+
+package main
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+func TestStartSyslogExport_RejectsEmptyCollector(t *testing.T) {
+	sm := newTestSyslogManager()
+	err := sm.StartSyslogExport(SyslogConfig{Interval: time.Second})
+	if err == nil || !strings.Contains(err.Error(), "-syslog-collector") {
+		t.Fatalf("want empty-collector error, got %v", err)
+	}
+	if sm.syslogActive.Load() {
+		t.Error("syslogActive should remain false after failed StartSyslogExport")
+	}
+}
+
+func TestStartSyslogExport_RejectsNonPositiveInterval(t *testing.T) {
+	sm := newTestSyslogManager()
+	err := sm.StartSyslogExport(SyslogConfig{
+		Collector: "127.0.0.1:16500",
+		Interval:  0,
+	})
+	if err == nil || !strings.Contains(err.Error(), "-syslog-interval") {
+		t.Fatalf("want interval error, got %v", err)
+	}
+}
+
+func TestStartSyslogExport_RejectsNegativeCap(t *testing.T) {
+	sm := newTestSyslogManager()
+	err := sm.StartSyslogExport(SyslogConfig{
+		Collector: "127.0.0.1:16501",
+		Interval:  time.Second,
+		GlobalCap: -1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "-syslog-global-cap") {
+		t.Fatalf("want cap error, got %v", err)
+	}
+}
+
+func TestStartSyslogExport_RejectsUnresolvableCollector(t *testing.T) {
+	sm := newTestSyslogManager()
+	err := sm.StartSyslogExport(SyslogConfig{
+		Collector: "host-does-not-resolve.invalid:514",
+		Interval:  time.Second,
+	})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid collector address") && !strings.Contains(err.Error(), "no such host") {
+		t.Errorf("error %q: want mention of invalid collector", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle happy path
+// ---------------------------------------------------------------------------
+
+func TestStartStopSyslogExport_HappyPath(t *testing.T) {
+	sm := newTestSyslogManager()
+	collector, collectorAddr := newLocalUDPCollector(t)
+	_ = collector // collector is cleaned up by t.Cleanup
+
+	err := sm.StartSyslogExport(SyslogConfig{
+		Collector:       collectorAddr.String(),
+		Format:          SyslogFormat5424,
+		Interval:        time.Second,
+		SourcePerDevice: false, // tests run without netns
+	})
+	if err != nil {
+		t.Fatalf("StartSyslogExport: %v", err)
+	}
+	if !sm.syslogActive.Load() {
+		t.Fatal("syslogActive should be true after successful Start")
+	}
+	if sm.syslogCatalog == nil || len(sm.syslogCatalog.Entries) != 6 {
+		t.Errorf("embedded catalog not loaded: %v", sm.syslogCatalog)
+	}
+
+	// Idempotency: second Start without Stop should fail.
+	if err := sm.StartSyslogExport(SyslogConfig{
+		Collector: collectorAddr.String(),
+		Interval:  time.Second,
+	}); err == nil {
+		t.Error("second Start should refuse without a Stop")
+	}
+
+	sm.StopSyslogExport()
+	if sm.syslogActive.Load() {
+		t.Error("syslogActive should be false after Stop")
+	}
+	// Stop is idempotent.
+	sm.StopSyslogExport()
+}
+
+// ---------------------------------------------------------------------------
+// GetSyslogStatus
+// ---------------------------------------------------------------------------
+
+func TestGetSyslogStatus_Disabled(t *testing.T) {
+	sm := newTestSyslogManager()
+	st := sm.GetSyslogStatus()
+	if st.Enabled {
+		t.Error("Enabled should be false when feature not started")
+	}
+	if st.Format != "" || st.Collector != "" {
+		t.Errorf("Format/Collector should be empty when disabled: %+v", st)
+	}
+}
+
+func TestGetSyslogStatus_EnabledShape(t *testing.T) {
+	sm, _, _ := startSyslogForTest(t, SyslogFormat3164)
+	st := sm.GetSyslogStatus()
+	if !st.Enabled {
+		t.Fatal("Enabled should be true")
+	}
+	if st.Format != "3164" {
+		t.Errorf("Format: got %q, want 3164", st.Format)
+	}
+	if st.Collector == "" {
+		t.Error("Collector should be populated")
+	}
+	if st.DevicesExporting != 1 {
+		t.Errorf("DevicesExporting: got %d, want 1 (test fixture has one device)", st.DevicesExporting)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FireSyslogOnDevice
+// ---------------------------------------------------------------------------
+
+func TestFireSyslogOnDevice_HappyPath(t *testing.T) {
+	sm, collector, device := startSyslogForTest(t, SyslogFormat5424)
+	if err := sm.FireSyslogOnDevice(device.IP.String(), "interface-down", nil); err != nil {
+		t.Fatal(err)
+	}
+	// Wait briefly for the datagram.
+	_ = collector.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 2048)
+	n, _, err := collector.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("collector did not receive datagram: %v", err)
+	}
+	wire := string(buf[:n])
+	if !strings.HasPrefix(wire, "<187>1 ") {
+		t.Errorf("wire did not start with expected PRI+version: %q", wire)
+	}
+	if !strings.Contains(wire, "LINKDOWN") {
+		t.Errorf("wire missing MsgID: %q", wire)
+	}
+}
+
+func TestFireSyslogOnDevice_UnknownCatalogName(t *testing.T) {
+	sm, _, device := startSyslogForTest(t, SyslogFormat5424)
+	err := sm.FireSyslogOnDevice(device.IP.String(), "notAnEntry", nil)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !errors.Is(err, ErrSyslogEntryNotFound) {
+		t.Errorf("want ErrSyslogEntryNotFound, got %v", err)
+	}
+}
+
+func TestFireSyslogOnDevice_UnknownDevice(t *testing.T) {
+	sm, _, _ := startSyslogForTest(t, SyslogFormat5424)
+	err := sm.FireSyslogOnDevice("10.99.99.99", "interface-up", nil)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !errors.Is(err, ErrSyslogDeviceNotFound) {
+		t.Errorf("want ErrSyslogDeviceNotFound, got %v", err)
+	}
+}
+
+func TestFireSyslogOnDevice_Disabled(t *testing.T) {
+	sm := newTestSyslogManager()
+	err := sm.FireSyslogOnDevice("10.0.0.1", "interface-up", nil)
+	if err == nil || !errors.Is(err, ErrSyslogExportDisabled) {
+		t.Errorf("want ErrSyslogExportDisabled, got %v", err)
+	}
+}
+
+func TestFireSyslogOnDevice_OverridesApplied(t *testing.T) {
+	sm, collector, device := startSyslogForTest(t, SyslogFormat5424)
+	err := sm.FireSyslogOnDevice(device.IP.String(), "interface-down", map[string]string{
+		"IfIndex": "42",
+		"IfName":  "GigabitEthernet7/42",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = collector.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 2048)
+	n, _, err := collector.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("no datagram: %v", err)
+	}
+	wire := string(buf[:n])
+	if !strings.Contains(wire, "ifIndex=42") {
+		t.Errorf("override IfIndex not present: %q", wire)
+	}
+	if !strings.Contains(wire, "GigabitEthernet7/42") {
+		t.Errorf("override IfName not present: %q", wire)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newTestSyslogManager builds a minimal SimulatorManager suitable for
+// exercising the syslog subsystem. No netns, no real devices.
+func newTestSyslogManager() *SimulatorManager {
+	return &SimulatorManager{
+		devices:          make(map[string]*DeviceSimulator),
+		deviceIPs:        make(map[string]struct{}),
+		resourcesCache:   make(map[string]*DeviceResources),
+		tunInterfacePool: make(map[string]*TunInterface),
+	}
+}
+
+// startSyslogForTest stands up a SimulatorManager with syslog export
+// active, registers one fake device with a SyslogExporter writing via a
+// shared socket (no netns). Returns the manager, the collector socket (for
+// reading emitted datagrams), and the fake device. Registers t.Cleanup.
+func startSyslogForTest(t *testing.T, format SyslogFormat) (*SimulatorManager, *net.UDPConn, *DeviceSimulator) {
+	t.Helper()
+	sm := newTestSyslogManager()
+	collector, collectorAddr := newLocalUDPCollector(t)
+
+	err := sm.StartSyslogExport(SyslogConfig{
+		Collector:       collectorAddr.String(),
+		Format:          format,
+		Interval:        10 * time.Second, // long — test fires directly via FireSyslogOnDevice
+		SourcePerDevice: false,            // no netns available in unit tests
+	})
+	if err != nil {
+		t.Fatalf("StartSyslogExport: %v", err)
+	}
+
+	// Build a fake device with a SyslogExporter that writes via the
+	// manager's shared socket (SharedConn). This mirrors what
+	// startDeviceSyslogExporter does but without touching netns.
+	device := &DeviceSimulator{
+		ID:      "test-device",
+		IP:      net.IPv4(127, 0, 0, 1),
+		sysName: "test-host",
+	}
+	exp := NewSyslogExporter(SyslogExporterOptions{
+		DeviceIP:   device.IP,
+		Encoder:    sm.syslogEncoder,
+		Collector:  sm.syslogCollectorAddr,
+		SharedConn: sm.syslogConn,
+		SysName:    device.sysName,
+		IfIndexFn:  func() int { return 3 },
+		IfNameFn:   func(i int) string { return "GigabitEthernet0/3" },
+	})
+	device.syslogExporter = exp
+	sm.devices[device.ID] = device
+	sm.deviceIPs[device.IP.String()] = struct{}{}
+	if sm.syslogScheduler != nil {
+		sm.syslogScheduler.Register(device.IP, exp)
+	}
+
+	t.Cleanup(func() {
+		sm.StopSyslogExport()
+	})
+	return sm, collector, device
+}

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -82,6 +82,12 @@ func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
 	if cfg.Interval <= 0 {
 		return fmt.Errorf("syslog export: -syslog-interval must be positive, got %s", cfg.Interval)
 	}
+	// Mirror NewSyslogScheduler's own floor: sub-millisecond intervals
+	// busy-loop the scheduler when no global cap is set. Catch it here with
+	// a clean startup error rather than let the scheduler constructor panic.
+	if cfg.Interval < time.Millisecond {
+		return fmt.Errorf("syslog export: -syslog-interval must be >= 1ms, got %s", cfg.Interval)
+	}
 	if cfg.GlobalCap < 0 {
 		return fmt.Errorf("syslog export: -syslog-global-cap must be non-negative, got %d", cfg.GlobalCap)
 	}
@@ -166,12 +172,23 @@ func (sm *SimulatorManager) StopSyslogExport() {
 	}
 	sm.syslogActive.Store(false)
 
+	// Snapshot per-device exporters under each device's own mutex so we
+	// don't race `startDeviceSyslogExporter` (which writes under d.mu) or
+	// direct reads from `GetSyslogStatus` / `FireSyslogOnDevice`.
 	sm.mu.RLock()
 	scheduler := sm.syslogScheduler
-	devices := make([]*DeviceSimulator, 0, len(sm.devices))
+	type devExp struct {
+		d   *DeviceSimulator
+		exp *SyslogExporter
+	}
+	captured := make([]devExp, 0, len(sm.devices))
 	for _, d := range sm.devices {
-		if d.syslogExporter != nil {
-			devices = append(devices, d)
+		d.mu.Lock()
+		exp := d.syslogExporter
+		d.syslogExporter = nil
+		d.mu.Unlock()
+		if exp != nil {
+			captured = append(captured, devExp{d: d, exp: exp})
 		}
 	}
 	conn := sm.syslogConn
@@ -180,11 +197,8 @@ func (sm *SimulatorManager) StopSyslogExport() {
 	if scheduler != nil {
 		scheduler.Stop()
 	}
-	for _, d := range devices {
-		if d.syslogExporter != nil {
-			_ = d.syslogExporter.Close()
-			d.syslogExporter = nil
-		}
+	for _, ce := range captured {
+		_ = ce.exp.Close()
 	}
 	if conn != nil {
 		_ = conn.Close()
@@ -203,11 +217,20 @@ func (sm *SimulatorManager) StopSyslogExport() {
 //
 // Unlike the trap counterpart, per-device bind failure is never fatal for
 // syslog — there is no ack path that requires symmetric source IPs. On bind
-// failure we log a warning and fall back to the shared socket.
-func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) error {
+// failure we log a warning and fall back to the shared socket. Every error
+// scenario inside this function is handled internally (logged + degraded),
+// so the function has no error return; the trap-style signature was trimmed
+// after a review noted the call-site `err != nil` log branches were dead.
+func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) {
 	if !sm.syslogActive.Load() || device == nil {
-		return nil
+		return
 	}
+	// `device.sysName` is written once at device construction and never
+	// mutated (the simulator doesn't expose sysName-set via the admin API),
+	// so reading it here without holding `device.mu` is safe. Capture it
+	// into the exporter options as a plain string; subsequent runtime
+	// changes to `device.sysName` — if ever introduced — would not be
+	// reflected in emitted syslog messages until the exporter is rebuilt.
 	sm.mu.RLock()
 	opts := SyslogExporterOptions{
 		DeviceIP:   device.IP,
@@ -240,7 +263,6 @@ func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) e
 	if scheduler != nil {
 		scheduler.Register(device.IP, exporter)
 	}
-	return nil
 }
 
 // deviceIfNameFn returns the ifName for a given ifIndex on the device.
@@ -278,11 +300,16 @@ func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
 	var sent, failures uint64
 	devicesExporting := 0
 	for _, d := range sm.devices {
-		if d.syslogExporter == nil {
+		// Snapshot the exporter pointer under d.mu so a concurrent Stop
+		// path (which nils it under d.mu.Lock) can't race this read.
+		d.mu.RLock()
+		exp := d.syslogExporter
+		d.mu.RUnlock()
+		if exp == nil {
 			continue
 		}
 		devicesExporting++
-		st := d.syslogExporter.Stats()
+		st := exp.Stats()
 		sent += st.Sent.Load()
 		failures += st.SendFailures.Load()
 	}
@@ -327,10 +354,15 @@ func (sm *SimulatorManager) FireSyslogOnDevice(ip, entryName string, overrides m
 	if device == nil {
 		return fmt.Errorf("%w: %q", ErrSyslogDeviceNotFound, ip)
 	}
-	if device.syslogExporter == nil {
+	// Snapshot the exporter pointer under d.mu so a concurrent Stop can't
+	// nil it between the guard check and the Fire call (TOCTOU).
+	device.mu.RLock()
+	exp := device.syslogExporter
+	device.mu.RUnlock()
+	if exp == nil {
 		return fmt.Errorf("%w: device %s has no syslog exporter", ErrSyslogExportDisabled, ip)
 	}
-	return device.syslogExporter.Fire(entry, overrides)
+	return exp.Fire(entry, overrides)
 }
 
 // WriteSyslogStatusJSON writes GetSyslogStatus as JSON to w. Extracted for

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -1,0 +1,342 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// SimulatorManager-level UDP syslog export lifecycle.
+//
+// Parses the SyslogConfig surfaced by CLI flags, loads the catalog (embedded
+// or file override), creates the shared SyslogScheduler + SyslogEncoder, and
+// starts the scheduler goroutine. Wires per-device SyslogExporters into
+// device startup/teardown (see device.go) and exposes GetSyslogStatus +
+// FireSyslogOnDevice for the HTTP API.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// SyslogConfig bundles CLI-derived configuration for the syslog subsystem.
+// Empty Collector disables the feature.
+type SyslogConfig struct {
+	Collector       string
+	Format          SyslogFormat
+	Interval        time.Duration
+	GlobalCap       int // 0 = unlimited
+	CatalogPath     string
+	SourcePerDevice bool
+}
+
+// SyslogStatus is the JSON body returned by GET /api/v1/syslog/status. Field
+// shape matches spec Requirement "Syslog status HTTP endpoint".
+type SyslogStatus struct {
+	Enabled                    bool   `json:"enabled"`
+	Format                     string `json:"format,omitempty"`
+	Collector                  string `json:"collector,omitempty"`
+	Sent                       uint64 `json:"sent"`
+	SendFailures               uint64 `json:"send_failures"`
+	RateLimiterTokensAvailable int    `json:"rate_limiter_tokens_available,omitempty"`
+	DevicesExporting           int    `json:"devices_exporting"`
+}
+
+// Sentinel errors returned by FireSyslogOnDevice for HTTP status mapping.
+var (
+	ErrSyslogExportDisabled = fmt.Errorf("syslog export disabled")
+	ErrSyslogDeviceNotFound = fmt.Errorf("device not found")
+	ErrSyslogEntryNotFound  = fmt.Errorf("syslog catalog entry not found")
+)
+
+// StartSyslogExport validates cfg, loads the catalog, creates the shared
+// scheduler, and starts the scheduler goroutine. Partial state on failure
+// is unwound before returning.
+//
+// Preconditions:
+//   - Called after manager construction, before any device creation that
+//     should participate in syslog export.
+func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
+	if sm.syslogActive.Load() {
+		return fmt.Errorf("syslog export: already active; Shutdown before re-initializing")
+	}
+	if cfg.Collector == "" {
+		return fmt.Errorf("syslog export: -syslog-collector required to enable feature")
+	}
+	if cfg.Interval <= 0 {
+		return fmt.Errorf("syslog export: -syslog-interval must be positive, got %s", cfg.Interval)
+	}
+	if cfg.GlobalCap < 0 {
+		return fmt.Errorf("syslog export: -syslog-global-cap must be non-negative, got %d", cfg.GlobalCap)
+	}
+	if cfg.Format == "" {
+		cfg.Format = SyslogFormat5424
+	}
+	encoder, err := NewSyslogEncoder(cfg.Format)
+	if err != nil {
+		return fmt.Errorf("syslog export: %w", err)
+	}
+
+	addr, err := net.ResolveUDPAddr("udp4", cfg.Collector)
+	if err != nil {
+		return fmt.Errorf("syslog export: invalid collector address %q: %w", cfg.Collector, err)
+	}
+
+	var catalog *SyslogCatalog
+	if cfg.CatalogPath == "" {
+		catalog, err = LoadEmbeddedSyslogCatalog()
+	} else {
+		catalog, err = LoadSyslogCatalogFromFile(cfg.CatalogPath)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Shared fallback socket: used when per-device binding is off or fails.
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		return fmt.Errorf("syslog export: failed to open shared UDP socket: %w", err)
+	}
+
+	var limiter *rate.Limiter
+	if cfg.GlobalCap > 0 {
+		limiter = rate.NewLimiter(rate.Limit(cfg.GlobalCap), cfg.GlobalCap)
+	}
+
+	scheduler := NewSyslogScheduler(SyslogSchedulerOptions{
+		Catalog:            catalog,
+		MeanInterval:       cfg.Interval,
+		GlobalCapPerSecond: cfg.GlobalCap,
+	})
+
+	sm.mu.Lock()
+	sm.syslogCatalog = catalog
+	sm.syslogScheduler = scheduler
+	sm.syslogEncoder = encoder
+	sm.syslogLimiter = limiter
+	sm.syslogConn = conn
+	sm.syslogCollectorAddr = addr
+	sm.syslogCollectorStr = cfg.Collector
+	sm.syslogFormat = cfg.Format
+	sm.syslogInterval = cfg.Interval
+	sm.syslogGlobalCap = cfg.GlobalCap
+	sm.syslogSourcePerDevice = cfg.SourcePerDevice
+	sm.syslogCatalogPath = cfg.CatalogPath
+	sm.mu.Unlock()
+	sm.syslogActive.Store(true)
+
+	capStr := "unlimited"
+	if cfg.GlobalCap > 0 {
+		capStr = fmt.Sprintf("%d/s", cfg.GlobalCap)
+	}
+	catStr := "<embedded>"
+	if cfg.CatalogPath != "" {
+		catStr = cfg.CatalogPath
+	}
+	log.Printf("Syslog export: %s → %s (format=%s, interval=%s, cap=%s, catalog=%s, per-device-source=%v)",
+		conn.LocalAddr(), cfg.Collector, cfg.Format, cfg.Interval, capStr, catStr, cfg.SourcePerDevice)
+
+	go scheduler.Run(context.Background())
+
+	return nil
+}
+
+// StopSyslogExport stops the scheduler, closes the shared socket, and closes
+// every device's SyslogExporter. Safe to call when syslog export is inactive
+// (no-op).
+func (sm *SimulatorManager) StopSyslogExport() {
+	if !sm.syslogActive.Load() {
+		return
+	}
+	sm.syslogActive.Store(false)
+
+	sm.mu.RLock()
+	scheduler := sm.syslogScheduler
+	devices := make([]*DeviceSimulator, 0, len(sm.devices))
+	for _, d := range sm.devices {
+		if d.syslogExporter != nil {
+			devices = append(devices, d)
+		}
+	}
+	conn := sm.syslogConn
+	sm.mu.RUnlock()
+
+	if scheduler != nil {
+		scheduler.Stop()
+	}
+	for _, d := range devices {
+		if d.syslogExporter != nil {
+			_ = d.syslogExporter.Close()
+			d.syslogExporter = nil
+		}
+	}
+	if conn != nil {
+		_ = conn.Close()
+	}
+
+	sm.mu.Lock()
+	sm.syslogScheduler = nil
+	sm.syslogConn = nil
+	sm.mu.Unlock()
+}
+
+// startDeviceSyslogExporter creates a SyslogExporter for the device, opens a
+// per-device UDP socket when enabled, and registers the exporter with the
+// scheduler. Called from device creation sites in device.go (mirrors the
+// trap-export hook).
+//
+// Unlike the trap counterpart, per-device bind failure is never fatal for
+// syslog — there is no ack path that requires symmetric source IPs. On bind
+// failure we log a warning and fall back to the shared socket.
+func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) error {
+	if !sm.syslogActive.Load() || device == nil {
+		return nil
+	}
+	sm.mu.RLock()
+	opts := SyslogExporterOptions{
+		DeviceIP:   device.IP,
+		Encoder:    sm.syslogEncoder,
+		Collector:  sm.syslogCollectorAddr,
+		SharedConn: sm.syslogConn,
+		SysName:    device.sysName,
+		IfIndexFn:  deviceIfIndexFn(device),
+		IfNameFn:   deviceIfNameFn(device),
+	}
+	sourcePerDevice := sm.syslogSourcePerDevice
+	scheduler := sm.syslogScheduler
+	sm.mu.RUnlock()
+
+	exporter := NewSyslogExporter(opts)
+
+	if sourcePerDevice {
+		conn := openSyslogConnForDevice(device)
+		if conn == nil {
+			log.Printf("syslog export: device %s per-device bind failed, falling back to shared socket", device.IP)
+		} else {
+			exporter.SetConn(conn)
+		}
+	}
+
+	device.mu.Lock()
+	device.syslogExporter = exporter
+	device.mu.Unlock()
+
+	if scheduler != nil {
+		scheduler.Register(device.IP, exporter)
+	}
+	return nil
+}
+
+// deviceIfNameFn returns the ifName for a given ifIndex on the device.
+//
+// For PR3 scope we synthesise a generic Cisco-style name (`GigabitEthernet0/N`)
+// rather than looking up the real ifDescr from the device's SNMP OID table.
+// A follow-up PR can replace this with a real lookup against the device's
+// response cache when per-device-type catalog realism becomes in scope; for
+// the v1 generic catalog the synthesised name is adequate and keeps this
+// change decoupled from the device-simulation internals.
+func deviceIfNameFn(_ *DeviceSimulator) func(int) string {
+	return func(ifIndex int) string {
+		if ifIndex <= 0 {
+			return ""
+		}
+		return fmt.Sprintf("GigabitEthernet0/%d", ifIndex)
+	}
+}
+
+// GetSyslogStatus returns a JSON-serializable snapshot of the syslog export
+// state. Exposed via GET /api/v1/syslog/status.
+func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
+	if !sm.syslogActive.Load() {
+		return SyslogStatus{Enabled: false}
+	}
+
+	sm.mu.RLock()
+	status := SyslogStatus{
+		Enabled:   true,
+		Format:    string(sm.syslogFormat),
+		Collector: sm.syslogCollectorStr,
+	}
+	limiter := sm.syslogLimiter
+
+	var sent, failures uint64
+	devicesExporting := 0
+	for _, d := range sm.devices {
+		if d.syslogExporter == nil {
+			continue
+		}
+		devicesExporting++
+		st := d.syslogExporter.Stats()
+		sent += st.Sent.Load()
+		failures += st.SendFailures.Load()
+	}
+	var tokens int
+	if limiter != nil {
+		tokens = int(limiter.Tokens())
+	}
+	sm.mu.RUnlock()
+
+	status.Sent = sent
+	status.SendFailures = failures
+	status.DevicesExporting = devicesExporting
+	if limiter != nil {
+		status.RateLimiterTokensAvailable = tokens
+	}
+	return status
+}
+
+// FireSyslogOnDevice implements POST /api/v1/devices/{ip}/syslog by looking
+// up the device's SyslogExporter and invoking Fire with the given catalog
+// name. On-demand fires bypass the global rate limiter (pre-flight 1.4
+// resolution) — the scheduler is the only consumer of the limiter; direct
+// Fire calls write immediately.
+//
+// Returns errors tagged so the HTTP layer can map them:
+//   - ErrSyslogExportDisabled → 503 Service Unavailable
+//   - ErrSyslogDeviceNotFound → 404
+//   - ErrSyslogEntryNotFound  → 400
+func (sm *SimulatorManager) FireSyslogOnDevice(ip, entryName string, overrides map[string]string) error {
+	if !sm.syslogActive.Load() {
+		return ErrSyslogExportDisabled
+	}
+	sm.mu.RLock()
+	cat := sm.syslogCatalog
+	sm.mu.RUnlock()
+
+	entry, ok := cat.ByName[entryName]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSyslogEntryNotFound, entryName)
+	}
+	device := sm.FindDeviceByIP(ip)
+	if device == nil {
+		return fmt.Errorf("%w: %q", ErrSyslogDeviceNotFound, ip)
+	}
+	if device.syslogExporter == nil {
+		return fmt.Errorf("%w: device %s has no syslog exporter", ErrSyslogExportDisabled, ip)
+	}
+	return device.syslogExporter.Fire(entry, overrides)
+}
+
+// WriteSyslogStatusJSON writes GetSyslogStatus as JSON to w. Extracted for
+// testability and because the api.go pattern in this codebase is thin handlers.
+func (sm *SimulatorManager) WriteSyslogStatusJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sm.GetSyslogStatus())
+}
+

--- a/go/simulator/syslog_wire.go
+++ b/go/simulator/syslog_wire.go
@@ -31,6 +31,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -43,8 +44,13 @@ const (
 )
 
 // ParseSyslogFormat validates the operator-supplied -syslog-format value.
+// Leading/trailing whitespace and case are normalised, matching the
+// tolerance of the equivalent `ParseTrapMode` — operators occasionally
+// quote flag arguments with stray whitespace and that shouldn't be a
+// startup error.
 func ParseSyslogFormat(s string) (SyslogFormat, error) {
-	switch s {
+	normalised := strings.ToLower(strings.TrimSpace(s))
+	switch normalised {
 	case string(SyslogFormat5424):
 		return SyslogFormat5424, nil
 	case string(SyslogFormat3164):

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -84,6 +84,7 @@ type DeviceSimulator struct {
 	metricsCycler *MetricsCycler   // Per-device cycling CPU/memory metrics
 	flowExporter  *FlowExporter   // NetFlow/IPFIX exporter (nil if flow export disabled)
 	trapExporter  *TrapExporter   // SNMP trap/inform exporter (nil if trap export disabled)
+	syslogExporter *SyslogExporter // UDP syslog exporter (nil if syslog export disabled)
 	netNamespace  *NetNamespace   // Network namespace (nil if using root namespace)
 	running      bool
 	mu           sync.RWMutex
@@ -222,6 +223,22 @@ type SimulatorManager struct {
 	trapInformRetries   int
 	trapSourcePerDevice bool
 	trapCatalogPath     string // "" when using embedded catalog
+
+	// UDP syslog export state (nil/zero when disabled; set by StartSyslogExport).
+	// See syslog_manager.go for lifecycle and syslog_exporter.go for per-device state.
+	syslogActive          atomic.Bool
+	syslogCatalog         *SyslogCatalog
+	syslogScheduler       *SyslogScheduler
+	syslogEncoder         SyslogEncoder
+	syslogLimiter         *rate.Limiter // independent of trap's limiter (design.md §D9)
+	syslogConn            *net.UDPConn  // shared fallback when per-device bind disabled or fails
+	syslogCollectorAddr   *net.UDPAddr
+	syslogCollectorStr    string
+	syslogFormat          SyslogFormat
+	syslogInterval        time.Duration
+	syslogGlobalCap       int
+	syslogSourcePerDevice bool
+	syslogCatalogPath     string // "" when using embedded catalog
 
 	mu              sync.RWMutex
 }

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -124,7 +124,15 @@ func fireSyslogHandler(w http.ResponseWriter, r *http.Request) {
 		Name              string            `json:"name"`
 		TemplateOverrides map[string]string `json:"templateOverrides"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// Bound the request body so a malicious or misconfigured client can't
+	// force an unbounded allocation on the admin-plane HTTP surface.
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	dec := json.NewDecoder(r.Body)
+	// Reject unknown field names so typo'd override keys (e.g.
+	// `tempalteOverrides`) surface as a 400 instead of being silently
+	// dropped and producing confusing "overrides didn't apply" debugging.
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
 		sendErrorResponse(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -99,6 +99,59 @@ func trapStatusHandler(w http.ResponseWriter, r *http.Request) {
 	manager.WriteTrapStatusJSON(w)
 }
 
+// syslogStatusHandler implements GET /api/v1/syslog/status. Returns a
+// SyslogStatus JSON body (shape documented in syslog_manager.go).
+func syslogStatusHandler(w http.ResponseWriter, r *http.Request) {
+	manager.WriteSyslogStatusJSON(w)
+}
+
+// fireSyslogHandler implements POST /api/v1/devices/{ip}/syslog. Body:
+//
+//	{ "name": "interface-down", "templateOverrides": {"IfIndex": "3"} }
+//
+// Returns 202 Accepted with {} on success. Bypasses the global rate
+// limiter (pre-flight 1.4): on-demand fires are for test-harness use and
+// should not compete with scheduled traffic for tokens.
+// Status code mapping:
+//   - 503 when syslog export is not enabled
+//   - 404 when the device IP is unknown
+//   - 400 when the catalog entry name is unknown or JSON is malformed
+func fireSyslogHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	ip := vars["ip"]
+
+	var req struct {
+		Name              string            `json:"name"`
+		TemplateOverrides map[string]string `json:"templateOverrides"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sendErrorResponse(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		sendErrorResponse(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := manager.FireSyslogOnDevice(ip, req.Name, req.TemplateOverrides); err != nil {
+		switch {
+		case errors.Is(err, ErrSyslogExportDisabled):
+			sendErrorResponse(w, err.Error(), http.StatusServiceUnavailable)
+		case errors.Is(err, ErrSyslogDeviceNotFound):
+			sendErrorResponse(w, err.Error(), http.StatusNotFound)
+		case errors.Is(err, ErrSyslogEntryNotFound):
+			sendErrorResponse(w, err.Error(), http.StatusBadRequest)
+		default:
+			sendErrorResponse(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = w.Write([]byte("{}"))
+}
+
 // fireTrapHandler implements POST /api/v1/devices/{ip}/trap. Body:
 //
 //	{ "name": "linkDown", "varbindOverrides": {"IfIndex": "3"} }
@@ -306,6 +359,8 @@ func setupRoutes() *mux.Router {
 	api.HandleFunc("/flows/status", flowStatusHandler).Methods("GET")
 	api.HandleFunc("/traps/status", trapStatusHandler).Methods("GET")
 	api.HandleFunc("/devices/{ip}/trap", fireTrapHandler).Methods("POST")
+	api.HandleFunc("/syslog/status", syslogStatusHandler).Methods("GET")
+	api.HandleFunc("/devices/{ip}/syslog", fireSyslogHandler).Methods("POST")
 	api.HandleFunc("/debug/pprof-memory", pprofMemoryHandler).Methods("GET")
 	api.HandleFunc("/debug/cpu-profile", cpuProfileHandler).Methods("GET")
 


### PR DESCRIPTION
Third and final PR completing the \`add-syslog-udp\` OpenSpec change — epic #76. Builds on merged PR #89 (catalog + wire encoders) and PR #90 (scheduler + exporter). This PR is the integration layer.

## Closes

- Sub-issue #82 — SimulatorManager integration
- Sub-issue #83 — Device lifecycle wiring
- Sub-issue #84 — CLI flag wiring
- Sub-issue #85 — HTTP API
- Sub-issue #86 — Documentation
- Resolves pre-flight 1.4 from #77 (on-demand fires bypass global cap)

## What's in it

| File | Lines | Purpose |
|---|---|---|
| \`syslog_manager.go\` (new) | 342 | \`StartSyslogExport\`/\`StopSyslogExport\`, per-device wiring, \`GetSyslogStatus\`, \`FireSyslogOnDevice\`, \`SyslogStatus\` JSON |
| \`syslog_api_test.go\` (new) | 282 | 10 tests — config validation, lifecycle, status shapes, fire paths |
| \`types.go\` | +17 | \`syslogExporter\` on DeviceSimulator; 16 \`syslog*\` fields on SimulatorManager |
| \`device.go\` | +28 | Per-device exporter start/stop at 4 sites (paired with trap) |
| \`manager.go\` | +4 | \`StopSyslogExport()\` after \`StopTrapExport()\` in Shutdown |
| \`simulator.go\` | +29 | Six \`-syslog-*\` CLI flags + \`StartSyslogExport\` invocation |
| \`web.go\` | +55 | Two new handlers + routes, mirroring trap patterns |
| \`CLAUDE.md\` | +29 | CLI flag table, architecture block, catalog schema, ops notes |
| \`README.md\` | +9 | Feature bullet with CLAUDE.md pointer |
| **Total** | **795** | |

## Design conformance (PR3 in-scope items)

- **D5 HOSTNAME derivation** — priority 2 (sysName) / priority 3 (DeviceIP) fallback implemented in \`SyslogExporter.Fire\`; verified in PR2 tests.
- **D7 per-device UDP + shared fallback** — \`openSyslogConnForDevice\` called for each device when \`-syslog-source-per-device=true\`; non-fatal on bind failure (unlike INFORM).
- **D9 separate \`rate.Limiter\`** — syslog carries its own limiter, not shared with trap.
- **Pre-flight 1.4 on-demand bypass** — \`FireSyslogOnDevice\` calls \`SyslogExporter.Fire\` directly; only the scheduler's Run loop consumes limiter tokens. Comment in \`syslog_manager.go\` captures the decision.

## Implementation notes

- **ifName synthesis** — v1 synthesises \`GigabitEthernet0/<N>\` from the random ifIndex draw rather than looking up the device's real \`ifDescr\`. Adequate for the generic catalog; a follow-up PR can wire a real lookup when per-device-type catalogs become in scope.
- **Per-device bind is non-fatal for syslog** — no ack path requiring symmetric source IPs, so bind failure logs a warning and falls back to the shared socket.

## Verified

- \`cd go && go test ./...\` clean on darwin — **48 syslog tests** (38 from PR1/PR2 + 10 from PR3); all prior tests still pass.
- \`go test -race -run TestSyslog ./simulator\` clean.
- \`openspec validate add-syslog-udp --strict\` passes.
- Build: \`go build ./simulator\` clean.

## Out of scope (deferred to post-merge)

- **Section 11 manual validation** — rsyslogd / syslog-ng smoke test (11.4), OpenNMS syslogd (11.5), 30k-device scale test (11.6). All require root + netns + a running collector; explicitly deferred to maintainer post-merge per the trap-export precedent.
- **Section 12 post-merge** — MEMORY.md entry, \`openspec archive add-syslog-udp\`, follow-up issues for TCP / TLS / per-device-type catalogs / burst modeling / state-coupled notifications.

## Epic completion

After this PR merges, **epic #76 is complete**: all five sub-issues (#77 pre-flight + 9 sub-issue pattern) closed, all three PRs (#89, #90, this) shipped. 52/61 OpenSpec task items ticked; the remaining 9 items are either manual smoke tests (section 11, requiring a real collector) or post-merge housekeeping (section 12).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, operator smoke test: \`sudo ./simulator -syslog-collector <host>:514 -auto-start-ip 10.0.0.1 -auto-count 10\` → verify messages arrive at the collector with correct per-device source IPs.