### PR TITLE
feat(simulator): emit optional snmpTrapEnterprise.0 varbind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,8 @@ The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-s
 - Override with `-trap-catalog <path>` (complete replacement, not merge).
 - Universal catalog ships 5 entries: `coldStart`, `warmStart`, `linkDown`, `linkUp`, `authenticationFailure` (RFC 3418). Weights: linkDown=40, linkUp=40, authenticationFailure=10, coldStart=5, warmStart=5.
 - Template vocabulary is restricted to `{{.IfIndex}}`, `{{.Uptime}}`, `{{.Now}}`, `{{.DeviceIP}}`. Unknown fields are rejected at catalog load.
-- The two mandatory SNMPv2-Trap varbinds (`sysUpTime.0`, `snmpTrapOID.0`) are prepended automatically by the encoder — catalog authors supply only body varbinds; entries that list either reserved OID explicitly are rejected.
+- The two mandatory SNMPv2-Trap varbinds (`sysUpTime.0`, `snmpTrapOID.0`) are prepended automatically by the encoder — catalog authors supply only body varbinds; entries that list either reserved OID (or `snmpTrapEnterprise.0`) as a body varbind are rejected.
+- Optional top-level `snmpTrapEnterprise` field (string, dotted OID) per entry. When set, the encoder emits an additional `snmpTrapEnterprise.0` varbind (OID `1.3.6.1.6.3.1.1.4.3.0`) after the two mandatory ones — useful for v1↔v2c cross-compatibility on collectors that expect the enterprise OID per SNMPv2-MIB §10. Catalog-loader rejects reserved OIDs (`sysUpTime.0`, `snmpTrapOID.0`, `snmpTrapEnterprise.0`) as enterprise values. Omit the field to keep the backward-compatible 2-varbind prefix.
 
 **Trap operational notes:**
 - INFORM mode (`-trap-mode inform`) requires `-trap-source-per-device=true` (the default) so the per-device UDP socket can demux acks without a global request-id table. Startup fails with a clear error if the operator explicitly sets the flag false.

--- a/go/simulator/trap_catalog.go
+++ b/go/simulator/trap_catalog.go
@@ -236,17 +236,21 @@ func compileEntry(raw catalogEntryJSON, source string, idx int) (*CatalogEntry, 
 	}
 
 	entry := &CatalogEntry{
-		Name:               raw.Name,
-		SnmpTrapOID:        strings.TrimPrefix(raw.SnmpTrapOID, "."),
-		SnmpTrapEnterprise: strings.TrimPrefix(raw.SnmpTrapEnterprise, "."),
-		Weight:             weight,
-		Varbinds:           make([]VarbindTemplate, 0, len(raw.Varbinds)),
+		Name:        raw.Name,
+		SnmpTrapOID: strings.TrimPrefix(raw.SnmpTrapOID, "."),
+		Weight:      weight,
+		Varbinds:    make([]VarbindTemplate, 0, len(raw.Varbinds)),
 	}
-	// The optional snmpTrapEnterprise.0 value must not collide with OIDs
-	// the encoder auto-prepends. snmpTrapOID.0 / sysUpTime.0 as an
-	// enterprise value would be nonsensical; snmpTrapEnterprise.0 itself
-	// is the OID of the varbind, not its value.
-	if entry.SnmpTrapEnterprise != "" {
+	// The optional snmpTrapEnterprise.0 value must be a well-formed dotted-
+	// decimal OID and must not collide with OIDs the encoder auto-prepends.
+	// Format check runs first so the operator sees a specific message about
+	// the format gap (".", whitespace, single-arc, trailing-dot, etc.) rather
+	// than a reserved-OID error that never fires for malformed input.
+	if raw.SnmpTrapEnterprise != "" {
+		entry.SnmpTrapEnterprise = strings.TrimPrefix(raw.SnmpTrapEnterprise, ".")
+		if err := validateDottedOID(entry.SnmpTrapEnterprise, raw.Name, "snmpTrapEnterprise"); err != nil {
+			return nil, fmt.Errorf("trap catalog: %s %w", source, err)
+		}
 		switch entry.SnmpTrapEnterprise {
 		case oidSysUpTime0, oidSnmpTrapOID0, oidSnmpTrapEnterprise0:
 			return nil, fmt.Errorf("trap catalog: %s entry %q: snmpTrapEnterprise value %s "+
@@ -321,6 +325,47 @@ func validateVarbindOID(raw, entryName string, idx int) error {
 		return fmt.Errorf("trap catalog: entry %q varbind %d: OID %s is reserved — "+
 			"use the entry-level `snmpTrapEnterprise` field instead of a body varbind",
 			entryName, idx, raw)
+	}
+	return nil
+}
+
+// maxDottedOIDLen caps the length of top-level literal OID fields (currently
+// only snmpTrapEnterprise). Well under the UDP MTU budget and comfortably
+// larger than any real enterprise OID.
+const maxDottedOIDLen = 256
+
+// validateDottedOID rejects malformed literal dotted-decimal OIDs:
+// empty strings, strings over maxDottedOIDLen, single-arc, trailing dot,
+// empty arcs (consecutive dots), and non-numeric characters. Used on
+// literal-OID fields (snmpTrapEnterprise); body varbinds use a template
+// grammar and go through validateVarbindOID instead.
+func validateDottedOID(oid, entryName, field string) error {
+	if oid == "" {
+		return fmt.Errorf("entry %q %s: OID is empty", entryName, field)
+	}
+	if len(oid) > maxDottedOIDLen {
+		return fmt.Errorf("entry %q %s: OID length %d exceeds max %d",
+			entryName, field, len(oid), maxDottedOIDLen)
+	}
+	if strings.HasSuffix(oid, ".") {
+		return fmt.Errorf("entry %q %s: OID %q has trailing dot", entryName, field, oid)
+	}
+	arcs := strings.Split(oid, ".")
+	if len(arcs) < 2 {
+		return fmt.Errorf("entry %q %s: OID %q must have at least two arcs",
+			entryName, field, oid)
+	}
+	for _, arc := range arcs {
+		if arc == "" {
+			return fmt.Errorf("entry %q %s: OID %q has an empty arc",
+				entryName, field, oid)
+		}
+		for _, r := range arc {
+			if r < '0' || r > '9' {
+				return fmt.Errorf("entry %q %s: OID %q contains non-numeric character %q",
+					entryName, field, oid, r)
+			}
+		}
 	}
 	return nil
 }

--- a/go/simulator/trap_catalog.go
+++ b/go/simulator/trap_catalog.go
@@ -40,10 +40,14 @@ var embeddedCatalogFS embed.FS
 const embeddedCatalogPath = "resources/_common/traps.json"
 
 // Reserved OIDs that the encoder prepends automatically to every trap.
-// Catalog authors MUST NOT include them in body varbinds (design.md §D10).
+// Catalog authors MUST NOT include them in body varbinds.
+// - `sysUpTime.0` and `snmpTrapOID.0` are prepended unconditionally (design.md §D10).
+// - `snmpTrapEnterprise.0` is prepended when the catalog entry sets the
+//   optional `snmpTrapEnterprise` field (follow-up issue #100).
 const (
-	oidSysUpTime0    = "1.3.6.1.2.1.1.3.0"
-	oidSnmpTrapOID0  = "1.3.6.1.6.3.1.1.4.1.0"
+	oidSysUpTime0          = "1.3.6.1.2.1.1.3.0"
+	oidSnmpTrapOID0        = "1.3.6.1.6.3.1.1.4.1.0"
+	oidSnmpTrapEnterprise0 = "1.3.6.1.6.3.1.1.4.3.0"
 )
 
 // allowedTemplateFields enumerates the four template fields the catalog
@@ -81,10 +85,11 @@ type trapVarbindJSON struct {
 
 // catalogEntryJSON is the on-disk shape of one trap catalog entry.
 type catalogEntryJSON struct {
-	Name        string            `json:"name"`
-	SnmpTrapOID string            `json:"snmpTrapOID"`
-	Weight      int               `json:"weight"`
-	Varbinds    []trapVarbindJSON `json:"varbinds"`
+	Name               string            `json:"name"`
+	SnmpTrapOID        string            `json:"snmpTrapOID"`
+	SnmpTrapEnterprise string            `json:"snmpTrapEnterprise,omitempty"`
+	Weight             int               `json:"weight"`
+	Varbinds           []trapVarbindJSON `json:"varbinds"`
 }
 
 // trapCatalogJSON is the on-disk shape of the whole catalog file.
@@ -107,11 +112,19 @@ type VarbindTemplate struct {
 
 // CatalogEntry is one parsed trap in the catalog. Weight defaults to 1 when
 // omitted from JSON; Pick is weight-biased random selection.
+//
+// SnmpTrapEnterprise is the OPTIONAL value for the `snmpTrapEnterprise.0`
+// varbind (OID 1.3.6.1.6.3.1.1.4.3.0) from SNMPv2-MIB §10. When non-empty,
+// the encoder auto-prepends this varbind after the two mandatory
+// (`sysUpTime.0`, `snmpTrapOID.0`) and before the body varbinds. Empty
+// means the varbind is not emitted — backward-compatible with catalogs
+// authored before this field existed.
 type CatalogEntry struct {
-	Name        string
-	SnmpTrapOID string
-	Weight      int
-	Varbinds    []VarbindTemplate
+	Name               string
+	SnmpTrapOID        string
+	SnmpTrapEnterprise string
+	Weight             int
+	Varbinds           []VarbindTemplate
 }
 
 // Catalog is the whole parsed trap catalog plus cached weight metadata for Pick.
@@ -223,10 +236,24 @@ func compileEntry(raw catalogEntryJSON, source string, idx int) (*CatalogEntry, 
 	}
 
 	entry := &CatalogEntry{
-		Name:        raw.Name,
-		SnmpTrapOID: strings.TrimPrefix(raw.SnmpTrapOID, "."),
-		Weight:      weight,
-		Varbinds:    make([]VarbindTemplate, 0, len(raw.Varbinds)),
+		Name:               raw.Name,
+		SnmpTrapOID:        strings.TrimPrefix(raw.SnmpTrapOID, "."),
+		SnmpTrapEnterprise: strings.TrimPrefix(raw.SnmpTrapEnterprise, "."),
+		Weight:             weight,
+		Varbinds:           make([]VarbindTemplate, 0, len(raw.Varbinds)),
+	}
+	// The optional snmpTrapEnterprise.0 value must not collide with OIDs
+	// the encoder auto-prepends. snmpTrapOID.0 / sysUpTime.0 as an
+	// enterprise value would be nonsensical; snmpTrapEnterprise.0 itself
+	// is the OID of the varbind, not its value.
+	if entry.SnmpTrapEnterprise != "" {
+		switch entry.SnmpTrapEnterprise {
+		case oidSysUpTime0, oidSnmpTrapOID0, oidSnmpTrapEnterprise0:
+			return nil, fmt.Errorf("trap catalog: %s entry %q: snmpTrapEnterprise value %s "+
+				"is a reserved OID — the field should hold an enterprise OID reflecting "+
+				"the notification type, typically the parent of snmpTrapOID",
+				source, raw.Name, raw.SnmpTrapEnterprise)
+		}
 	}
 	for j, vb := range raw.Varbinds {
 		if err := validateVarbindOID(vb.OID, raw.Name, j); err != nil {
@@ -273,17 +300,26 @@ func compileEntry(raw catalogEntryJSON, source string, idx int) (*CatalogEntry, 
 	return entry, nil
 }
 
-// validateVarbindOID rejects the two reserved OIDs that the encoder prepends
+// validateVarbindOID rejects the reserved OIDs that the encoder prepends
 // automatically. Accepts templates (anything containing "{{") as a pass — the
 // reserved OIDs are literal strings, so a template'd OID cannot collide.
+//
+// snmpTrapEnterprise.0 is rejected in body varbinds because it has its own
+// top-level catalog field (`snmpTrapEnterprise`); including it in body
+// varbinds would produce a duplicate on the wire.
 func validateVarbindOID(raw, entryName string, idx int) error {
 	if strings.Contains(raw, "{{") {
 		return nil
 	}
 	norm := strings.TrimPrefix(raw, ".")
-	if norm == oidSysUpTime0 || norm == oidSnmpTrapOID0 {
+	switch norm {
+	case oidSysUpTime0, oidSnmpTrapOID0:
 		return fmt.Errorf("trap catalog: entry %q varbind %d: OID %s is reserved "+
 			"(sysUpTime.0 and snmpTrapOID.0 are prepended automatically by the encoder)",
+			entryName, idx, raw)
+	case oidSnmpTrapEnterprise0:
+		return fmt.Errorf("trap catalog: entry %q varbind %d: OID %s is reserved — "+
+			"use the entry-level `snmpTrapEnterprise` field instead of a body varbind",
 			entryName, idx, raw)
 	}
 	return nil

--- a/go/simulator/trap_catalog_test.go
+++ b/go/simulator/trap_catalog_test.go
@@ -61,6 +61,8 @@ func TestLoadCatalogFromFile_ReservedOIDRejected(t *testing.T) {
 		{"sysUpTime no prefix", "1.3.6.1.2.1.1.3.0"},
 		{"snmpTrapOID with dot prefix", ".1.3.6.1.6.3.1.1.4.1.0"},
 		{"snmpTrapOID no prefix", "1.3.6.1.6.3.1.1.4.1.0"},
+		{"snmpTrapEnterprise with dot prefix", ".1.3.6.1.6.3.1.1.4.3.0"},
+		{"snmpTrapEnterprise no prefix", "1.3.6.1.6.3.1.1.4.3.0"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -78,6 +80,88 @@ func TestLoadCatalogFromFile_ReservedOIDRejected(t *testing.T) {
 				t.Errorf("error should mention 'reserved': %v", err)
 			}
 		})
+	}
+}
+
+// TestLoadCatalogFromFile_EnterpriseField_Valid confirms an entry with a
+// legitimate snmpTrapEnterprise OID loads correctly and stores it on the
+// parsed CatalogEntry.
+func TestLoadCatalogFromFile_EnterpriseField_Valid(t *testing.T) {
+	body := `{"traps":[{"name":"x","snmpTrapOID":"1.3.6.1.6.3.1.1.5.3","snmpTrapEnterprise":"1.3.6.1.4.1.9.1","varbinds":[]}]}`
+	path := filepath.Join(t.TempDir(), "c.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := LoadCatalogFromFile(path)
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	if got := cat.Entries[0].SnmpTrapEnterprise; got != "1.3.6.1.4.1.9.1" {
+		t.Errorf("SnmpTrapEnterprise: got %q, want %q", got, "1.3.6.1.4.1.9.1")
+	}
+}
+
+// TestLoadCatalogFromFile_EnterpriseField_StripsLeadingDot exercises the
+// same TrimPrefix normalisation used for snmpTrapOID.
+func TestLoadCatalogFromFile_EnterpriseField_StripsLeadingDot(t *testing.T) {
+	body := `{"traps":[{"name":"x","snmpTrapOID":"1.3.6.1.6.3.1.1.5.3","snmpTrapEnterprise":".1.3.6.1.4.1.9.1","varbinds":[]}]}`
+	path := filepath.Join(t.TempDir(), "c.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := LoadCatalogFromFile(path)
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	if got := cat.Entries[0].SnmpTrapEnterprise; got != "1.3.6.1.4.1.9.1" {
+		t.Errorf("SnmpTrapEnterprise not dot-stripped: got %q, want %q", got, "1.3.6.1.4.1.9.1")
+	}
+}
+
+// TestLoadCatalogFromFile_EnterpriseField_RejectsReserved makes sure the
+// entry-level snmpTrapEnterprise field itself cannot hold one of the three
+// reserved OIDs (sysUpTime.0, snmpTrapOID.0, snmpTrapEnterprise.0).
+func TestLoadCatalogFromFile_EnterpriseField_RejectsReserved(t *testing.T) {
+	cases := []string{
+		"1.3.6.1.2.1.1.3.0",
+		"1.3.6.1.6.3.1.1.4.1.0",
+		"1.3.6.1.6.3.1.1.4.3.0",
+	}
+	for _, oid := range cases {
+		t.Run(oid, func(t *testing.T) {
+			body := `{"traps":[{"name":"x","snmpTrapOID":"1.2.3","snmpTrapEnterprise":"` +
+				oid + `","varbinds":[]}]}`
+			path := filepath.Join(t.TempDir(), "c.json")
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadCatalogFromFile(path)
+			if err == nil {
+				t.Fatal("expected reserved-OID rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), "reserved") {
+				t.Errorf("error should mention 'reserved': %v", err)
+			}
+		})
+	}
+}
+
+// TestLoadCatalogFromFile_EnterpriseField_DefaultEmpty confirms that an
+// entry without the snmpTrapEnterprise field produces an empty string on
+// the parsed entry — backward-compatibility anchor for pre-issue-#100
+// catalogs.
+func TestLoadCatalogFromFile_EnterpriseField_DefaultEmpty(t *testing.T) {
+	body := `{"traps":[{"name":"x","snmpTrapOID":"1.3.6.1.6.3.1.1.5.3","varbinds":[]}]}`
+	path := filepath.Join(t.TempDir(), "c.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := LoadCatalogFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cat.Entries[0].SnmpTrapEnterprise; got != "" {
+		t.Errorf("SnmpTrapEnterprise: got %q, want empty (field absent in JSON)", got)
 	}
 }
 

--- a/go/simulator/trap_catalog_test.go
+++ b/go/simulator/trap_catalog_test.go
@@ -120,12 +120,17 @@ func TestLoadCatalogFromFile_EnterpriseField_StripsLeadingDot(t *testing.T) {
 
 // TestLoadCatalogFromFile_EnterpriseField_RejectsReserved makes sure the
 // entry-level snmpTrapEnterprise field itself cannot hold one of the three
-// reserved OIDs (sysUpTime.0, snmpTrapOID.0, snmpTrapEnterprise.0).
+// reserved OIDs (sysUpTime.0, snmpTrapOID.0, snmpTrapEnterprise.0), in both
+// no-prefix and leading-dot forms — the leading-dot variant is the evasion
+// path (TrimPrefix happens before the reserved-OID comparison).
 func TestLoadCatalogFromFile_EnterpriseField_RejectsReserved(t *testing.T) {
 	cases := []string{
 		"1.3.6.1.2.1.1.3.0",
 		"1.3.6.1.6.3.1.1.4.1.0",
 		"1.3.6.1.6.3.1.1.4.3.0",
+		".1.3.6.1.2.1.1.3.0",
+		".1.3.6.1.6.3.1.1.4.1.0",
+		".1.3.6.1.6.3.1.1.4.3.0",
 	}
 	for _, oid := range cases {
 		t.Run(oid, func(t *testing.T) {
@@ -143,6 +148,66 @@ func TestLoadCatalogFromFile_EnterpriseField_RejectsReserved(t *testing.T) {
 				t.Errorf("error should mention 'reserved': %v", err)
 			}
 		})
+	}
+}
+
+// TestLoadCatalogFromFile_EnterpriseField_RejectsMalformed exercises the
+// dotted-OID format validator: single-dot / single-arc / trailing-dot /
+// embedded empty arc / non-numeric / whitespace-only inputs must all be
+// rejected at catalog load rather than silently producing broken wire bytes.
+func TestLoadCatalogFromFile_EnterpriseField_RejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		oid  string
+	}{
+		{"single_dot", "."},
+		{"whitespace_only", "   "},
+		{"single_arc", "12345"},
+		{"trailing_dot", "1.3.6.1.4.1.9.1."},
+		{"empty_arc_middle", "1.3..6"},
+		{"non_numeric_character", "1.3.6.1.4.1.abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"traps":[{"name":"x","snmpTrapOID":"1.2.3","snmpTrapEnterprise":"` +
+				tc.oid + `","varbinds":[]}]}`
+			path := filepath.Join(t.TempDir(), "c.json")
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadCatalogFromFile(path)
+			if err == nil {
+				t.Fatalf("expected malformed-OID rejection for %q, got nil", tc.oid)
+			}
+			if !strings.Contains(err.Error(), "snmpTrapEnterprise") {
+				t.Errorf("error should name the field: %v", err)
+			}
+		})
+	}
+}
+
+// TestLoadCatalogFromFile_EnterpriseField_RejectsOverLength pins the
+// maxDottedOIDLen cap. A 257-char OID must be rejected even though it's
+// otherwise well-formed digits-and-dots — bounds the enterprise varbind's
+// contribution to the UDP MTU budget.
+func TestLoadCatalogFromFile_EnterpriseField_RejectsOverLength(t *testing.T) {
+	// Build an OID of length 257: "1" + (".1" * 128) = 1 + 256 = 257 chars.
+	oid := "1" + strings.Repeat(".1", 128)
+	if len(oid) != 257 {
+		t.Fatalf("setup: want len 257, got %d", len(oid))
+	}
+	body := `{"traps":[{"name":"x","snmpTrapOID":"1.2.3","snmpTrapEnterprise":"` +
+		oid + `","varbinds":[]}]}`
+	path := filepath.Join(t.TempDir(), "c.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadCatalogFromFile(path)
+	if err == nil {
+		t.Fatal("expected over-length rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds max") {
+		t.Errorf("error should mention the length cap: %v", err)
 	}
 }
 
@@ -317,5 +382,73 @@ func TestCatalogEntry_Resolve_Fast(t *testing.T) {
 		if _, err := entry.Resolve(ctx, nil); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestCatalog_To_Wire_IntegrationWithEnterprise exercises the full pipeline:
+// catalog JSON with snmpTrapEnterprise + body varbinds → LoadCatalogFromFile
+// → Resolve → EncodeTrap → BER decode. Confirms the enterprise OID survives
+// from catalog source to the wire in the correct position (slot 2, after
+// sysUpTime.0 and snmpTrapOID.0) alongside a template-resolved body varbind.
+func TestCatalog_To_Wire_IntegrationWithEnterprise(t *testing.T) {
+	body := `{"traps":[{
+		"name": "enterpriseLink",
+		"snmpTrapOID": "1.3.6.1.6.3.1.1.5.3",
+		"snmpTrapEnterprise": "1.3.6.1.4.1.9.1",
+		"varbinds": [
+			{"oid":"1.3.6.1.2.1.2.2.1.1.{{.IfIndex}}","type":"integer","value":"{{.IfIndex}}"}
+		]
+	}]}`
+	path := filepath.Join(t.TempDir(), "c.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := LoadCatalogFromFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	entry := cat.ByName["enterpriseLink"]
+	if entry == nil {
+		t.Fatal("enterpriseLink entry missing after load")
+	}
+	ctx := TemplateCtx{IfIndex: 5, Uptime: 100, Now: 1700000000, DeviceIP: "10.42.0.1"}
+	vbs, err := entry.Resolve(ctx, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	enc := SNMPv2cEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodeTrap("public", 7, entry.SnmpTrapOID, entry.SnmpTrapEnterprise, 100, vbs, buf)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	dec := decodeV2cNotification(t, buf[:n])
+	if len(dec.Varbinds) != 4 {
+		t.Fatalf("varbind count: got %d, want 4 (sysUpTime + snmpTrapOID + enterprise + body)",
+			len(dec.Varbinds))
+	}
+	// Slot 0: sysUpTime.0
+	if dec.Varbinds[0].OID != "."+oidSysUpTime0 {
+		t.Errorf("vb[0].OID: got %s, want .%s", dec.Varbinds[0].OID, oidSysUpTime0)
+	}
+	// Slot 1: snmpTrapOID.0 value = catalog's snmpTrapOID
+	if dec.Varbinds[1].OID != "."+oidSnmpTrapOID0 {
+		t.Errorf("vb[1].OID: got %s, want .%s", dec.Varbinds[1].OID, oidSnmpTrapOID0)
+	}
+	if got := decodeOID(dec.Varbinds[1].RawValue); got != ".1.3.6.1.6.3.1.1.5.3" {
+		t.Errorf("vb[1] snmpTrapOID value: got %s, want .1.3.6.1.6.3.1.1.5.3", got)
+	}
+	// Slot 2: snmpTrapEnterprise.0 value = catalog's snmpTrapEnterprise
+	if dec.Varbinds[2].OID != "."+oidSnmpTrapEnterprise0 {
+		t.Errorf("vb[2].OID: got %s, want .%s", dec.Varbinds[2].OID, oidSnmpTrapEnterprise0)
+	}
+	if got := decodeOID(dec.Varbinds[2].RawValue); got != ".1.3.6.1.4.1.9.1" {
+		t.Errorf("vb[2] enterprise OID value: got %s, want .1.3.6.1.4.1.9.1", got)
+	}
+	// Slot 3: body varbind with IfIndex=5 resolved into both OID and value
+	if dec.Varbinds[3].OID != ".1.3.6.1.2.1.2.2.1.1.5" {
+		t.Errorf("vb[3].OID: got %s, want .1.3.6.1.2.1.2.2.1.1.5 (IfIndex=5)", dec.Varbinds[3].OID)
 	}
 }

--- a/go/simulator/trap_exporter.go
+++ b/go/simulator/trap_exporter.go
@@ -252,9 +252,9 @@ func (e *TrapExporter) Fire(entry *CatalogEntry, overrides map[string]string) ui
 
 	var n int
 	if e.mode == TrapModeInform {
-		n, err = e.encoder.EncodeInform(e.community, reqID, entry.SnmpTrapOID, ctx.Uptime, varbinds, buf)
+		n, err = e.encoder.EncodeInform(e.community, reqID, entry.SnmpTrapOID, entry.SnmpTrapEnterprise, ctx.Uptime, varbinds, buf)
 	} else {
-		n, err = e.encoder.EncodeTrap(e.community, reqID, entry.SnmpTrapOID, ctx.Uptime, varbinds, buf)
+		n, err = e.encoder.EncodeTrap(e.community, reqID, entry.SnmpTrapOID, entry.SnmpTrapEnterprise, ctx.Uptime, varbinds, buf)
 	}
 	if err != nil {
 		log.Printf("trap: encode %s for %s: %v", entry.Name, e.deviceIP, err)

--- a/go/simulator/trap_v2c.go
+++ b/go/simulator/trap_v2c.go
@@ -116,9 +116,12 @@ func encodeV2cNotification(pduTag byte, community string, reqID uint32, trapOID,
 	//   1. sysUpTime.0 (TimeTicks)
 	//   2. snmpTrapOID.0 (OID = trapOID)
 	//   3. snmpTrapEnterprise.0 (OID = enterpriseOID) — only when non-empty.
-	//      SNMPv2-MIB §10 places this additional-info varbind after the two
-	//      mandatory ones and before catalog body varbinds; convention
-	//      across net-snmp / pysnmp / SNMP4J matches.
+	//      RFC 3584 §4.1 (the SNMPv1↔v2c proxy translation spec) places
+	//      snmpTrapEnterprise.0 as the third element of variable-bindings,
+	//      after sysUpTime.0 and snmpTrapOID.0 and before any additional
+	//      varbinds. SNMPv2-MIB §10 makes this additional-info varbind
+	//      optional on native v2c notifications; when catalog authors set it
+	//      we emit it in the same position RFC 3584 pins.
 	//   N. body varbinds
 	vbContents := make([]byte, 0, 64+len(varbinds)*32)
 	vbContents = append(vbContents, encodeVarbindTimeTicks(oidSysUpTime0, uptimeHundredths)...)

--- a/go/simulator/trap_v2c.go
+++ b/go/simulator/trap_v2c.go
@@ -58,15 +58,19 @@ import (
 type TrapEncoder interface {
 	// EncodeTrap writes an SNMPv2-Trap-PDU wrapped in an SNMPv2c message into
 	// buf and returns the byte length written. trapOID is the dotted-decimal
-	// OID that becomes snmpTrapOID.0 in the PDU. varbinds are the body
-	// varbinds; the encoder prepends sysUpTime.0 and snmpTrapOID.0 itself.
-	EncodeTrap(community string, reqID uint32, trapOID string,
+	// OID that becomes snmpTrapOID.0 in the PDU. enterpriseOID, when non-
+	// empty, causes the encoder to emit an additional `snmpTrapEnterprise.0`
+	// varbind (OID 1.3.6.1.6.3.1.1.4.3.0) with that OID as its value — per
+	// SNMPv2-MIB §10 this OPTIONAL varbind aids v1↔v2c cross-compatibility
+	// handling on the receiving side. varbinds are the catalog-body varbinds;
+	// the encoder prepends sysUpTime.0 and snmpTrapOID.0 unconditionally.
+	EncodeTrap(community string, reqID uint32, trapOID, enterpriseOID string,
 		uptimeHundredths uint32, varbinds []Varbind, buf []byte) (int, error)
 
 	// EncodeInform is identical to EncodeTrap but uses the InformRequest-PDU
 	// tag (0xA6). The receiving collector replies with a GetResponse-PDU
 	// (0xA2) that ParseAck decodes.
-	EncodeInform(community string, reqID uint32, trapOID string,
+	EncodeInform(community string, reqID uint32, trapOID, enterpriseOID string,
 		uptimeHundredths uint32, varbinds []Varbind, buf []byte) (int, error)
 
 	// ParseAck decodes a collector-side acknowledgement datagram. Returns the
@@ -81,15 +85,15 @@ type TrapEncoder interface {
 type SNMPv2cEncoder struct{}
 
 // EncodeTrap — see TrapEncoder.
-func (SNMPv2cEncoder) EncodeTrap(community string, reqID uint32, trapOID string,
+func (SNMPv2cEncoder) EncodeTrap(community string, reqID uint32, trapOID, enterpriseOID string,
 	uptimeHundredths uint32, varbinds []Varbind, buf []byte) (int, error) {
-	return encodeV2cNotification(ASN1_TRAP_V2C, community, reqID, trapOID, uptimeHundredths, varbinds, buf)
+	return encodeV2cNotification(ASN1_TRAP_V2C, community, reqID, trapOID, enterpriseOID, uptimeHundredths, varbinds, buf)
 }
 
 // EncodeInform — see TrapEncoder.
-func (SNMPv2cEncoder) EncodeInform(community string, reqID uint32, trapOID string,
+func (SNMPv2cEncoder) EncodeInform(community string, reqID uint32, trapOID, enterpriseOID string,
 	uptimeHundredths uint32, varbinds []Varbind, buf []byte) (int, error) {
-	return encodeV2cNotification(ASN1_INFORM_REQUEST, community, reqID, trapOID, uptimeHundredths, varbinds, buf)
+	return encodeV2cNotification(ASN1_INFORM_REQUEST, community, reqID, trapOID, enterpriseOID, uptimeHundredths, varbinds, buf)
 }
 
 // ParseAck — see TrapEncoder.
@@ -99,7 +103,7 @@ func (SNMPv2cEncoder) ParseAck(pkt []byte) (uint32, bool, error) {
 
 // encodeV2cNotification is the shared body of EncodeTrap and EncodeInform; the
 // only difference between TRAP and INFORM on the wire is the PDU tag byte.
-func encodeV2cNotification(pduTag byte, community string, reqID uint32, trapOID string,
+func encodeV2cNotification(pduTag byte, community string, reqID uint32, trapOID, enterpriseOID string,
 	uptimeHundredths uint32, varbinds []Varbind, buf []byte) (int, error) {
 	// Build the PDU inner SEQUENCE contents:
 	//   request-id / error-status / error-index / variable-bindings
@@ -111,10 +115,17 @@ func encodeV2cNotification(pduTag byte, community string, reqID uint32, trapOID 
 	// variable-bindings SEQUENCE:
 	//   1. sysUpTime.0 (TimeTicks)
 	//   2. snmpTrapOID.0 (OID = trapOID)
-	//   3..N. body varbinds
+	//   3. snmpTrapEnterprise.0 (OID = enterpriseOID) — only when non-empty.
+	//      SNMPv2-MIB §10 places this additional-info varbind after the two
+	//      mandatory ones and before catalog body varbinds; convention
+	//      across net-snmp / pysnmp / SNMP4J matches.
+	//   N. body varbinds
 	vbContents := make([]byte, 0, 64+len(varbinds)*32)
 	vbContents = append(vbContents, encodeVarbindTimeTicks(oidSysUpTime0, uptimeHundredths)...)
 	vbContents = append(vbContents, encodeVarbindOID(oidSnmpTrapOID0, trapOID)...)
+	if enterpriseOID != "" {
+		vbContents = append(vbContents, encodeVarbindOID(oidSnmpTrapEnterprise0, enterpriseOID)...)
+	}
 	for i, vb := range varbinds {
 		enc, err := encodeVarbindTyped(vb)
 		if err != nil {

--- a/go/simulator/trap_v2c_test.go
+++ b/go/simulator/trap_v2c_test.go
@@ -156,7 +156,7 @@ func TestSNMPv2cEncoder_EncodeTrap_RoundTrip(t *testing.T) {
 		{OID: "1.3.6.1.2.1.2.2.1.7.7", Type: TrapVTInteger, Value: "2"},
 		{OID: "1.3.6.1.2.1.2.2.1.8.7", Type: TrapVTInteger, Value: "2"},
 	}
-	n, err := enc.EncodeTrap("public", 12345, "1.3.6.1.6.3.1.1.5.3", 1234567, varbinds, buf)
+	n, err := enc.EncodeTrap("public", 12345, "1.3.6.1.6.3.1.1.5.3", "", 1234567, varbinds, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func TestSNMPv2cEncoder_EncodeTrap_RoundTrip(t *testing.T) {
 func TestSNMPv2cEncoder_EncodeInform_HasInformTag(t *testing.T) {
 	enc := SNMPv2cEncoder{}
 	buf := make([]byte, 1500)
-	n, err := enc.EncodeInform("public", 42, "1.3.6.1.6.3.1.1.5.4", 100, nil, buf)
+	n, err := enc.EncodeInform("public", 42, "1.3.6.1.6.3.1.1.5.4", "", 100, nil, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func TestSNMPv2cEncoder_ParseAck_RejectsNonGetResponse(t *testing.T) {
 	// Build a TRAP instead of GetResponse and feed it to ParseAck.
 	enc := SNMPv2cEncoder{}
 	buf := make([]byte, 1500)
-	n, _ := enc.EncodeTrap("public", 1, "1.2.3", 100, nil, buf)
+	n, _ := enc.EncodeTrap("public", 1, "1.2.3", "", 100, nil, buf)
 	_, _, err := enc.ParseAck(buf[:n])
 	if err == nil {
 		t.Fatal("ParseAck should reject a TRAP-tagged packet")
@@ -300,7 +300,7 @@ func TestSNMPv2cEncoder_RequestIDDistinct_10k(t *testing.T) {
 	buf := make([]byte, 1500)
 	seen := make(map[uint32]struct{}, 10000)
 	for i := uint32(1); i <= 10000; i++ {
-		n, err := enc.EncodeTrap("c", i, "1.2.3", 0, nil, buf)
+		n, err := enc.EncodeTrap("c", i, "1.2.3", "", 0, nil, buf)
 		if err != nil {
 			t.Fatalf("encode %d: %v", i, err)
 		}
@@ -330,7 +330,7 @@ func TestSNMPv2cEncoder_AllVarbindTypes(t *testing.T) {
 	buf := make([]byte, 1500)
 	for _, tc := range cases {
 		t.Run(string(tc.Type), func(t *testing.T) {
-			n, err := enc.EncodeTrap("public", 1, "1.2.3", 0, []Varbind{tc}, buf)
+			n, err := enc.EncodeTrap("public", 1, "1.2.3", "", 0, []Varbind{tc}, buf)
 			if err != nil {
 				t.Fatalf("encode %s: %v", tc.Type, err)
 			}
@@ -353,7 +353,7 @@ func TestSNMPv2cEncoder_RejectsInvalidVarbindValues(t *testing.T) {
 	}
 	for _, vb := range bad {
 		t.Run(string(vb.Type)+"_"+vb.Value, func(t *testing.T) {
-			_, err := enc.EncodeTrap("c", 1, "1.2.3", 0, []Varbind{vb}, buf)
+			_, err := enc.EncodeTrap("c", 1, "1.2.3", "", 0, []Varbind{vb}, buf)
 			if err == nil {
 				t.Fatalf("want error for bad %s value %q, got nil", vb.Type, vb.Value)
 			}
@@ -373,7 +373,7 @@ func TestSNMPv2cEncoder_ByteIdentity(t *testing.T) {
 		{OID: "1.3.6.1.2.1.2.2.1.7.3", Type: TrapVTInteger, Value: "2"},
 		{OID: "1.3.6.1.2.1.2.2.1.8.3", Type: TrapVTInteger, Value: "2"},
 	}
-	n, err := enc.EncodeTrap("public", 42, "1.3.6.1.6.3.1.1.5.3", 12345678, varbinds, buf)
+	n, err := enc.EncodeTrap("public", 42, "1.3.6.1.6.3.1.1.5.3", "", 12345678, varbinds, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,6 +410,80 @@ var testPinRegistry = map[string]string{
 	// varbinds will trip this. If the change is intentional, update the
 	// pin — otherwise investigate the regression.
 	"trap_v2c_byte_identity": "c8cebe20015fc9060e33997c31c74899",
+	// Pinned on first-run of TestSNMPv2cEncoder_EnterpriseVarbind_ByteIdentity.
+	// Covers the wire layout when snmpTrapEnterprise is set on the catalog
+	// entry and the encoder emits the optional third mandatory-prepended
+	// varbind. The empty-enterprise path is already pinned above.
+	"trap_v2c_byte_identity_with_enterprise": "fd35e3de4511176b54845a00d226059a",
+}
+
+// TestSNMPv2cEncoder_EnterpriseVarbind_Emitted confirms that a non-empty
+// enterpriseOID causes the encoder to emit an additional snmpTrapEnterprise.0
+// varbind (OID 1.3.6.1.6.3.1.1.4.3.0) after the two mandatory varbinds.
+func TestSNMPv2cEncoder_EnterpriseVarbind_Emitted(t *testing.T) {
+	enc := SNMPv2cEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodeTrap("public", 1, "1.3.6.1.6.3.1.1.5.3", "1.3.6.1.4.1.9.1", 0, nil, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded := decodeV2cNotification(t, buf[:n])
+	if got := len(decoded.Varbinds); got != 3 {
+		t.Fatalf("varbind count: got %d, want 3 (sysUpTime + snmpTrapOID + snmpTrapEnterprise)", got)
+	}
+	// decodeOID in the test harness prepends a literal "." — match the
+	// convention used by the other decoder-oracle assertions in this file.
+	if decoded.Varbinds[2].OID != "."+oidSnmpTrapEnterprise0 {
+		t.Errorf("varbind[2].OID: got %s, want .%s", decoded.Varbinds[2].OID, oidSnmpTrapEnterprise0)
+	}
+	if decoded.Varbinds[2].TypeTag != ASN1_OBJECT_ID {
+		t.Errorf("varbind[2].TypeTag: got 0x%02x, want 0x%02x (OID)", decoded.Varbinds[2].TypeTag, ASN1_OBJECT_ID)
+	}
+	if got := decodeOID(decoded.Varbinds[2].RawValue); got != ".1.3.6.1.4.1.9.1" {
+		t.Errorf("varbind[2] enterprise OID value: got %s, want .1.3.6.1.4.1.9.1", got)
+	}
+}
+
+// TestSNMPv2cEncoder_EnterpriseVarbind_Skipped confirms that an empty
+// enterpriseOID produces exactly 2 varbinds (sysUpTime + snmpTrapOID) — the
+// backward-compatible behaviour for catalogs authored before the field existed.
+func TestSNMPv2cEncoder_EnterpriseVarbind_Skipped(t *testing.T) {
+	enc := SNMPv2cEncoder{}
+	buf := make([]byte, 1500)
+	n, err := enc.EncodeTrap("public", 1, "1.3.6.1.6.3.1.1.5.3", "", 0, nil, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded := decodeV2cNotification(t, buf[:n])
+	if got := len(decoded.Varbinds); got != 2 {
+		t.Fatalf("varbind count with empty enterpriseOID: got %d, want 2", got)
+	}
+}
+
+// TestSNMPv2cEncoder_EnterpriseVarbind_ByteIdentity pins the MD5 of a canonical
+// TRAP encode WITH snmpTrapEnterprise.0 set. This is a second byte-identity
+// test (the first, TestSNMPv2cEncoder_ByteIdentity, covers the no-enterprise
+// path). Any change to the enterprise emission layout (position, encoding)
+// trips this hash.
+func TestSNMPv2cEncoder_EnterpriseVarbind_ByteIdentity(t *testing.T) {
+	enc := SNMPv2cEncoder{}
+	buf := make([]byte, 1500)
+	varbinds := []Varbind{
+		{OID: "1.3.6.1.2.1.2.2.1.1.3", Type: TrapVTInteger, Value: "3"},
+		{OID: "1.3.6.1.2.1.2.2.1.7.3", Type: TrapVTInteger, Value: "2"},
+		{OID: "1.3.6.1.2.1.2.2.1.8.3", Type: TrapVTInteger, Value: "2"},
+	}
+	n, err := enc.EncodeTrap("public", 42, "1.3.6.1.6.3.1.1.5.3", "1.3.6.1.4.1.9.1", 12345678, varbinds, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := md5.Sum(buf[:n])
+	got := hex.EncodeToString(sum[:])
+	want := firstRunPin(t, "trap_v2c_byte_identity_with_enterprise", got)
+	if got != want {
+		t.Errorf("TRAP byte identity (with enterprise) changed:\n got  %s\n want %s\n"+
+			"If intentional, update the pin in testPinRegistry.", got, want)
+	}
 }
 
 // buildAckDatagram constructs a minimal SNMPv2c GetResponse-PDU with the
@@ -441,7 +515,7 @@ func buildAckDatagram(t *testing.T, community string, reqID uint32, errorStatus 
 func TestDecodeV2cNotification_ValidShape(t *testing.T) {
 	enc := SNMPv2cEncoder{}
 	buf := make([]byte, 1500)
-	n, _ := enc.EncodeTrap("x", 1, "1.2", 0, nil, buf)
+	n, _ := enc.EncodeTrap("x", 1, "1.2", "", 0, nil, buf)
 	dec := decodeV2cNotification(t, buf[:n])
 	if fmt.Sprintf("%d/%d", dec.Version, dec.RequestID) != "1/1" {
 		t.Fatal("decoder sanity failed")

--- a/go/simulator/trap_v2c_test.go
+++ b/go/simulator/trap_v2c_test.go
@@ -419,11 +419,13 @@ var testPinRegistry = map[string]string{
 
 // TestSNMPv2cEncoder_EnterpriseVarbind_Emitted confirms that a non-empty
 // enterpriseOID causes the encoder to emit an additional snmpTrapEnterprise.0
-// varbind (OID 1.3.6.1.6.3.1.1.4.3.0) after the two mandatory varbinds.
+// varbind (OID 1.3.6.1.6.3.1.1.4.3.0) after the two mandatory varbinds and
+// pins the positional contract: slot 0 = sysUpTime.0, slot 1 = snmpTrapOID.0,
+// slot 2 = snmpTrapEnterprise.0.
 func TestSNMPv2cEncoder_EnterpriseVarbind_Emitted(t *testing.T) {
 	enc := SNMPv2cEncoder{}
 	buf := make([]byte, 1500)
-	n, err := enc.EncodeTrap("public", 1, "1.3.6.1.6.3.1.1.5.3", "1.3.6.1.4.1.9.1", 0, nil, buf)
+	n, err := enc.EncodeTrap("public", 1, "1.3.6.1.6.3.1.1.5.3", "1.3.6.1.4.1.9.1", 4242, nil, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -431,8 +433,26 @@ func TestSNMPv2cEncoder_EnterpriseVarbind_Emitted(t *testing.T) {
 	if got := len(decoded.Varbinds); got != 3 {
 		t.Fatalf("varbind count: got %d, want 3 (sysUpTime + snmpTrapOID + snmpTrapEnterprise)", got)
 	}
-	// decodeOID in the test harness prepends a literal "." — match the
-	// convention used by the other decoder-oracle assertions in this file.
+	// Slot 0: sysUpTime.0 TimeTicks = 4242 — pin position, not just presence.
+	if decoded.Varbinds[0].OID != "."+oidSysUpTime0 {
+		t.Errorf("varbind[0].OID: got %s, want .%s", decoded.Varbinds[0].OID, oidSysUpTime0)
+	}
+	if decoded.Varbinds[0].TypeTag != ASN1_TIMETICKS {
+		t.Errorf("varbind[0].TypeTag: got 0x%02x, want 0x%02x (TimeTicks)",
+			decoded.Varbinds[0].TypeTag, ASN1_TIMETICKS)
+	}
+	if got := parseUintBE(decoded.Varbinds[0].RawValue); got != 4242 {
+		t.Errorf("varbind[0] value: got %d, want 4242", got)
+	}
+	// Slot 1: snmpTrapOID.0 value = trapOID argument.
+	if decoded.Varbinds[1].OID != "."+oidSnmpTrapOID0 {
+		t.Errorf("varbind[1].OID: got %s, want .%s", decoded.Varbinds[1].OID, oidSnmpTrapOID0)
+	}
+	if got := decodeOID(decoded.Varbinds[1].RawValue); got != ".1.3.6.1.6.3.1.1.5.3" {
+		t.Errorf("varbind[1] snmpTrapOID value: got %s, want .1.3.6.1.6.3.1.1.5.3", got)
+	}
+	// Slot 2: snmpTrapEnterprise.0. decodeOID prepends a literal "." — match
+	// the convention used by the other decoder-oracle assertions in this file.
 	if decoded.Varbinds[2].OID != "."+oidSnmpTrapEnterprise0 {
 		t.Errorf("varbind[2].OID: got %s, want .%s", decoded.Varbinds[2].OID, oidSnmpTrapEnterprise0)
 	}
@@ -441,6 +461,39 @@ func TestSNMPv2cEncoder_EnterpriseVarbind_Emitted(t *testing.T) {
 	}
 	if got := decodeOID(decoded.Varbinds[2].RawValue); got != ".1.3.6.1.4.1.9.1" {
 		t.Errorf("varbind[2] enterprise OID value: got %s, want .1.3.6.1.4.1.9.1", got)
+	}
+}
+
+// TestSNMPv2cEncoder_EnterpriseVarbind_WithBodyVarbinds covers the composition
+// case: enterprise prepended varbind PLUS catalog body varbinds. Asserts the
+// body varbinds land at positions 3..N+2 (not clobbered by or commingled with
+// the enterprise slot).
+func TestSNMPv2cEncoder_EnterpriseVarbind_WithBodyVarbinds(t *testing.T) {
+	enc := SNMPv2cEncoder{}
+	buf := make([]byte, 1500)
+	body := []Varbind{
+		{OID: "1.3.6.1.2.1.2.2.1.1.3", Type: TrapVTInteger, Value: "3"},
+		{OID: "1.3.6.1.2.1.2.2.1.7.3", Type: TrapVTInteger, Value: "2"},
+	}
+	n, err := enc.EncodeTrap("public", 1, "1.3.6.1.6.3.1.1.5.3", "1.3.6.1.4.1.9.1", 0, body, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded := decodeV2cNotification(t, buf[:n])
+	if got := len(decoded.Varbinds); got != 5 {
+		t.Fatalf("varbind count: got %d, want 5 (sysUpTime + snmpTrapOID + enterprise + 2 body)", got)
+	}
+	if decoded.Varbinds[2].OID != "."+oidSnmpTrapEnterprise0 {
+		t.Errorf("varbind[2].OID: got %s, want .%s (enterprise must stay at slot 2 when body varbinds follow)",
+			decoded.Varbinds[2].OID, oidSnmpTrapEnterprise0)
+	}
+	if decoded.Varbinds[3].OID != ".1.3.6.1.2.1.2.2.1.1.3" {
+		t.Errorf("varbind[3].OID: got %s, want .1.3.6.1.2.1.2.2.1.1.3 (first body varbind)",
+			decoded.Varbinds[3].OID)
+	}
+	if decoded.Varbinds[4].OID != ".1.3.6.1.2.1.2.2.1.7.3" {
+		t.Errorf("varbind[4].OID: got %s, want .1.3.6.1.2.1.2.2.1.7.3 (second body varbind)",
+			decoded.Varbinds[4].OID)
 	}
 }
 


### PR DESCRIPTION
Closes #100 — a follow-up from the archived `add-snmp-trap-v2c` change, where `snmpTrapEnterprise.0` emission was flagged as design Open Question #5.

## Why

SNMPv2-MIB §10 defines `snmpTrapEnterprise.0` (OID `1.3.6.1.6.3.1.1.4.3.0`) as an OPTIONAL varbind that SNMPv2c traps MAY include for v1↔v2c cross-compatibility. OpenNMS `trapd` and some older SNMP managers expect it for notifications that also have a v1 counterpart. Until this PR the simulator auto-prepended only `sysUpTime.0` + `snmpTrapOID.0`; the enterprise varbind was not emitted.

## What changes

**Opt-in per catalog entry** via a new optional top-level string field:

```json
{
  "name": "linkDown",
  "snmpTrapOID": "1.3.6.1.6.3.1.1.5.3",
  "snmpTrapEnterprise": "1.3.6.1.4.1.9.1",   ← NEW, optional
  "varbinds": [...]
}
```

- **Present + non-empty** → encoder emits a third prepended varbind (OID `1.3.6.1.6.3.1.1.4.3.0`, value = the operator-supplied OID) between `snmpTrapOID.0` and the catalog body varbinds.
- **Absent or empty** → wire format is byte-identical to pre-#100 output. **Backward-compatible** with existing catalogs.

Catalog loader rejects reserved values (`sysUpTime.0`, `snmpTrapOID.0`, `snmpTrapEnterprise.0` itself) as enterprise OIDs. Body varbind validator also rejects `1.3.6.1.6.3.1.1.4.3.0` to prevent duplicate emission.

## Stats

| File | Change |
|---|---|
| `go/simulator/trap_catalog.go` | +29/-6 — schema field, loader normalise + validate, reserved-OID rejection |
| `go/simulator/trap_catalog_test.go` | +82 — 4 new tests (valid field, leading-dot strip, reserved rejection parametric, default empty) |
| `go/simulator/trap_v2c.go` | +20/-11 — `enterpriseOID` param on encoder interface, conditional emission in `encodeV2cNotification` |
| `go/simulator/trap_v2c_test.go` | +86/-4 — signature backfill on 8 existing call sites + 3 new tests (emitted, skipped, byte-identity) |
| `go/simulator/trap_exporter.go` | +2/-2 — passes `entry.SnmpTrapEnterprise` through |
| `CLAUDE.md` | +2/-1 — documents the new catalog field |
| **Total** | **244+/38-** |

## Verified

- `cd go && go test ./...` clean on darwin
- `go test -race ./simulator` clean
- `openspec validate --specs snmp-trap --strict` passes (spec gained a "Optional `snmpTrapEnterprise.0` varbind" Requirement with 4 scenarios; openspec is gitignored, so that part is a machine-local update)
- Existing byte-identity pin for the no-enterprise path unchanged — proves backward compatibility at the wire level

## Explicitly not in scope

**Auto-derivation** (computing an enterprise OID from the trap OID's parent). The issue flagged this as an open question. The coldStart / warmStart cases don't have a literal-parent enterprise OID, so an auto-derivation policy would need a lookup table — larger design call than this PR. The opt-in field lets operators specify exactly what they want today; an `-trap-auto-enterprise` flag could be layered on later without breaking this contract.

## Test plan

- [ ] CI passes
- [ ] Operators who set `snmpTrapEnterprise` in their custom catalog verify via Wireshark / snmptrapd that the third varbind arrives as expected