### PR TITLE
feat: live ifDescr lookup for {{.IfName}}

### DIFF
--- a/go/simulator/field_resolver.go
+++ b/go/simulator/field_resolver.go
@@ -214,9 +214,32 @@ func (sm *SimulatorManager) ChassisID(deviceIP string) string {
 	return synthChassisID(ip)
 }
 
-// IfName — see FieldResolver. PR 2 returns the synthesised name
-// verbatim; PR 3 will insert a live lookup against the device's SNMP
-// OID table at `1.3.6.1.2.1.2.2.1.2.<IfIndex>`.
+// IfName — see FieldResolver. Live-lookup path: resolves the device by
+// IP, reads `ifDescr.<ifIndex>` (OID `1.3.6.1.2.1.2.2.1.2.N`) from the
+// device's SNMP OID table, and falls back to `synthIfName` when the
+// OID is absent. The exporter hot path uses `deviceIfNameFn` directly
+// (which also wraps `lookupIfDescr`); this method exists mostly for
+// test injection and future callers that want a single resolver
+// surface.
+//
+// Lookup is O(N) in the device map because `sm.devices` is keyed by
+// device ID, not IP — this is not the exporter hot path, so the cost is
+// acceptable here (see deviceIfNameFn for the hot-path companion).
 func (sm *SimulatorManager) IfName(deviceIP string, ifIndex int) string {
+	if ifIndex <= 0 {
+		return ""
+	}
+	sm.mu.RLock()
+	var device *DeviceSimulator
+	for _, d := range sm.devices {
+		if d.IP.String() == deviceIP {
+			device = d
+			break
+		}
+	}
+	sm.mu.RUnlock()
+	if name := lookupIfDescr(device, ifIndex); name != "" {
+		return name
+	}
 	return synthIfName(ifIndex)
 }

--- a/go/simulator/ifdescr_lookup_test.go
+++ b/go/simulator/ifdescr_lookup_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"net"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -131,6 +132,50 @@ func TestDeviceIfNameFn_ByteIdentity_Unchanged_OnMiss(t *testing.T) {
 		if got != want {
 			t.Errorf("ifIndex=%d: got %q, want %q", ifIndex, got, want)
 		}
+	}
+}
+
+// TestLookupIfDescr_AgainstRealLoadedResources is the integration test
+// that exercises the FULL chain: real `LoadSpecificResources` call →
+// `buildResourceIndexes` produces the `oidIndex` with its canonical key
+// format → `lookupIfDescr` reads from that map using the format the
+// helper assumes. The other tests in this file self-consistently
+// Store dot-prefixed keys that the helper then reads — they would all
+// pass even if the loader used a different convention. This one fails
+// loudly if the loader's key normalisation ever drifts from
+// `.1.3.6.1.2.1.2.2.1.2.<N>`, protecting PR 3 from a silent regression.
+func TestLookupIfDescr_AgainstRealLoadedResources(t *testing.T) {
+	sm := &SimulatorManager{resourcesCache: make(map[string]*DeviceResources)}
+	resources, err := sm.LoadSpecificResources("cisco_ios.json")
+	if err != nil {
+		t.Fatalf("LoadSpecificResources cisco_ios: %v", err)
+	}
+	if resources == nil || resources.oidIndex == nil {
+		t.Fatal("loaded resources missing oidIndex — buildResourceIndexes did not run")
+	}
+	device := &DeviceSimulator{
+		IP:        net.IPv4(10, 42, 0, 1),
+		resources: resources,
+	}
+	// Spot-check ifIndex 1. The shipped cisco_ios JSON fixture seeds
+	// ifDescr.1 = GigabitEthernet0/0 in resources/cisco_ios/cisco_ios_snmp_1.json.
+	// If the loader's key format ever diverges from the helper's, the
+	// Load misses → synth kicks in → "GigabitEthernet0/1" (note the
+	// different suffix). Asserting the exact vendor-shipped string
+	// catches both format drift AND a loader that silently fails to
+	// populate the map.
+	got := lookupIfDescr(device, 1)
+	if got == "" {
+		t.Fatal("lookupIfDescr returned empty — key format drift between loader and helper")
+	}
+	if got == "GigabitEthernet0/1" {
+		t.Fatal("lookupIfDescr returned the synth fallback, not the vendor value — loader key format drift")
+	}
+	// Sanity: the real value contains "Ethernet" (every Cisco ifDescr
+	// does). Not asserting the exact string so future fixture updates
+	// to cisco_ios don't require hand-editing this test.
+	if !strings.Contains(got, "Ethernet") {
+		t.Errorf("lookupIfDescr for cisco_ios ifIndex 1: got %q, want a string containing 'Ethernet'", got)
 	}
 }
 

--- a/go/simulator/ifdescr_lookup_test.go
+++ b/go/simulator/ifdescr_lookup_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -128,7 +129,7 @@ func TestDeviceIfNameFn_ByteIdentity_Unchanged_OnMiss(t *testing.T) {
 	fn := deviceIfNameFn(device)
 	for _, ifIndex := range []int{1, 2, 3, 10, 100, 65535} {
 		got := fn(ifIndex)
-		want := "GigabitEthernet0/" + itoaSimple(ifIndex)
+		want := "GigabitEthernet0/" + strconv.Itoa(ifIndex)
 		if got != want {
 			t.Errorf("ifIndex=%d: got %q, want %q", ifIndex, got, want)
 		}
@@ -179,26 +180,3 @@ func TestLookupIfDescr_AgainstRealLoadedResources(t *testing.T) {
 	}
 }
 
-// itoaSimple avoids pulling strconv in a test that otherwise only
-// needs a toy conversion.
-func itoaSimple(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}

--- a/go/simulator/ifdescr_lookup_test.go
+++ b/go/simulator/ifdescr_lookup_test.go
@@ -1,0 +1,159 @@
+/*
+ * © 2025 Labmonkeys Space
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ */
+
+package main
+
+import (
+	"net"
+	"sync"
+	"testing"
+)
+
+// TestLookupIfDescr_HitFromOIDTable confirms the live-lookup path: a
+// device whose SNMP OID table contains `ifDescr.5 = "TenGigE0/0/0/5"`
+// returns that vendor-flavoured string verbatim. This is the core of
+// PR 3's realism contract — Cisco IOS-XR catalogs reference
+// `TenGigE...` while Juniper reference `ge-0/0/5` etc., and those
+// strings must reach the template `{{.IfName}}` unchanged.
+func TestLookupIfDescr_HitFromOIDTable(t *testing.T) {
+	device := &DeviceSimulator{
+		IP:        net.IPv4(10, 42, 0, 1),
+		resources: &DeviceResources{oidIndex: &sync.Map{}},
+	}
+	device.resources.oidIndex.Store(".1.3.6.1.2.1.2.2.1.2.5", "TenGigE0/0/0/5")
+	if got := lookupIfDescr(device, 5); got != "TenGigE0/0/0/5" {
+		t.Errorf("lookupIfDescr(ifIndex=5): got %q, want TenGigE0/0/0/5", got)
+	}
+}
+
+// TestLookupIfDescr_MissReturnsEmpty confirms the miss path returns "",
+// letting callers decide on a fallback. This is the behaviour
+// `deviceIfNameFn` relies on when routing to `synthIfName`.
+func TestLookupIfDescr_MissReturnsEmpty(t *testing.T) {
+	device := &DeviceSimulator{
+		IP:        net.IPv4(10, 42, 0, 1),
+		resources: &DeviceResources{oidIndex: &sync.Map{}},
+	}
+	if got := lookupIfDescr(device, 99); got != "" {
+		t.Errorf("lookupIfDescr(missing ifIndex): got %q, want empty", got)
+	}
+}
+
+// TestLookupIfDescr_NilGuards confirms the helper tolerates nil device,
+// nil resources, and nil oidIndex without panicking. These states are
+// reachable in tests that construct bare DeviceSimulator structs.
+func TestLookupIfDescr_NilGuards(t *testing.T) {
+	if got := lookupIfDescr(nil, 1); got != "" {
+		t.Errorf("nil device: got %q, want empty", got)
+	}
+	if got := lookupIfDescr(&DeviceSimulator{}, 1); got != "" {
+		t.Errorf("nil resources: got %q, want empty", got)
+	}
+	if got := lookupIfDescr(&DeviceSimulator{resources: &DeviceResources{}}, 1); got != "" {
+		t.Errorf("nil oidIndex: got %q, want empty", got)
+	}
+}
+
+// TestDeviceIfNameFn_LiveLookupOverridesSynthesis exercises the full
+// `deviceIfNameFn` composition: with a real ifDescr in the table, the
+// synthesized fallback must NOT appear in the output.
+func TestDeviceIfNameFn_LiveLookupOverridesSynthesis(t *testing.T) {
+	device := &DeviceSimulator{
+		IP:        net.IPv4(10, 42, 0, 1),
+		resources: &DeviceResources{oidIndex: &sync.Map{}},
+	}
+	device.resources.oidIndex.Store(".1.3.6.1.2.1.2.2.1.2.1", "FastEthernet1/0/1")
+	fn := deviceIfNameFn(device)
+	if got := fn(1); got != "FastEthernet1/0/1" {
+		t.Errorf("deviceIfNameFn(1): got %q, want FastEthernet1/0/1", got)
+	}
+	// Fallback: ifIndex 99 has no entry; synthesis kicks in.
+	if got := fn(99); got != "GigabitEthernet0/99" {
+		t.Errorf("deviceIfNameFn(99): got %q, want GigabitEthernet0/99 (synth fallback)", got)
+	}
+	// Zero and negative still return empty (preserved guard).
+	if got := fn(0); got != "" {
+		t.Errorf("deviceIfNameFn(0): got %q, want empty", got)
+	}
+	if got := fn(-1); got != "" {
+		t.Errorf("deviceIfNameFn(-1): got %q, want empty", got)
+	}
+}
+
+// TestFieldResolver_IfName_LiveLookupFromManager exercises the
+// `(*SimulatorManager).IfName` path through the full resolver contract.
+// This is what PR 3 promises at the API level: the FieldResolver
+// interface returns vendor-flavoured ifDescr when the device has one.
+func TestFieldResolver_IfName_LiveLookupFromManager(t *testing.T) {
+	device := &DeviceSimulator{
+		ID:        "cisco-ios-0",
+		IP:        net.IPv4(10, 42, 0, 1),
+		resources: &DeviceResources{oidIndex: &sync.Map{}},
+	}
+	device.resources.oidIndex.Store(".1.3.6.1.2.1.2.2.1.2.7", "GigabitEthernet7")
+
+	sm := &SimulatorManager{
+		devices:         map[string]*DeviceSimulator{"cisco-ios-0": device},
+		deviceTypesByIP: map[string]string{"10.42.0.1": "cisco_ios"},
+	}
+
+	if got := sm.IfName("10.42.0.1", 7); got != "GigabitEthernet7" {
+		t.Errorf("live lookup: got %q, want GigabitEthernet7", got)
+	}
+	// Miss falls back to synth.
+	if got := sm.IfName("10.42.0.1", 42); got != "GigabitEthernet0/42" {
+		t.Errorf("miss fallback: got %q, want GigabitEthernet0/42", got)
+	}
+	// Unknown device also falls back.
+	if got := sm.IfName("10.99.99.99", 3); got != "GigabitEthernet0/3" {
+		t.Errorf("unknown device fallback: got %q, want GigabitEthernet0/3", got)
+	}
+}
+
+// TestDeviceIfNameFn_ByteIdentity_Unchanged_OnMiss pins that an ifIndex
+// not in the SNMP OID table produces the same string as pre-PR-3
+// (`GigabitEthernet0/N`). Protects existing catalog fixtures and the
+// byte-identity pins on the wire encoders — resolved template values
+// feed into BER / RFC-5424 layout only through string substitution.
+func TestDeviceIfNameFn_ByteIdentity_Unchanged_OnMiss(t *testing.T) {
+	// No oidIndex → every ifIndex misses → synth every time.
+	device := &DeviceSimulator{
+		IP:        net.IPv4(10, 42, 0, 1),
+		resources: &DeviceResources{oidIndex: &sync.Map{}},
+	}
+	fn := deviceIfNameFn(device)
+	for _, ifIndex := range []int{1, 2, 3, 10, 100, 65535} {
+		got := fn(ifIndex)
+		want := "GigabitEthernet0/" + itoaSimple(ifIndex)
+		if got != want {
+			t.Errorf("ifIndex=%d: got %q, want %q", ifIndex, got, want)
+		}
+	}
+}
+
+// itoaSimple avoids pulling strconv in a test that otherwise only
+// needs a toy conversion.
+func itoaSimple(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -348,19 +348,47 @@ func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) {
 
 // deviceIfNameFn returns the ifName for a given ifIndex on the device.
 //
-// For PR3 scope we synthesise a generic Cisco-style name (`GigabitEthernet0/N`)
-// rather than looking up the real ifDescr from the device's SNMP OID table.
-// A follow-up PR can replace this with a real lookup against the device's
-// response cache when per-device-type catalog realism becomes in scope; for
-// the v1 generic catalog the synthesised name is adequate and keeps this
-// change decoupled from the device-simulation internals.
-func deviceIfNameFn(_ *DeviceSimulator) func(int) string {
+// Live-lookup path: reads `ifDescr.<ifIndex>` (OID `1.3.6.1.2.1.2.2.1.2.N`)
+// from the device's SNMP OID table. When present, this yields vendor-
+// flavoured interface names like `TenGigE0/0/0/5` for Cisco IOS-XR or
+// `ge-0/0/5` for Juniper — exactly what vendor catalog realism needs
+// (design.md §D4, closes epic #103 task 3.2). When the OID is absent
+// (e.g. for a device type that doesn't ship an ifTable, or for an
+// ifIndex outside the loaded resource set) the fallback is the pre-PR-3
+// synthesised `GigabitEthernet0/<N>` so old fixtures continue to render.
+//
+// Zero or negative ifIndex returns "" — matches the pre-existing guard
+// and keeps the exporter's default safe for devices with no interfaces.
+func deviceIfNameFn(device *DeviceSimulator) func(int) string {
 	return func(ifIndex int) string {
 		if ifIndex <= 0 {
 			return ""
 		}
-		return fmt.Sprintf("GigabitEthernet0/%d", ifIndex)
+		if name := lookupIfDescr(device, ifIndex); name != "" {
+			return name
+		}
+		return synthIfName(ifIndex)
 	}
+}
+
+// lookupIfDescr returns the device's `ifDescr.<ifIndex>` value from the
+// SNMP OID table, or "" when the OID is absent. Factored out so the
+// `FieldResolver.IfName` path and `deviceIfNameFn` share one lookup.
+//
+// The OID key format is dot-prefixed (e.g. `.1.3.6.1.2.1.2.2.1.2.5`) to
+// match `resources.go` normalisation (all OID keys get a leading dot
+// when loaded). sync.Map read is lock-free and constant-time.
+func lookupIfDescr(device *DeviceSimulator, ifIndex int) string {
+	if device == nil || device.resources == nil || device.resources.oidIndex == nil {
+		return ""
+	}
+	key := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.2.%d", ifIndex)
+	v, ok := device.resources.oidIndex.Load(key)
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
 }
 
 // GetSyslogStatus returns a JSON-serializable snapshot of the syslog export


### PR DESCRIPTION
Third PR in the **per-device-type catalogs** epic (#103). Closes #106.

Swap \`{{.IfName}}\` from synthesis to a live lookup against the device's SNMP OID table at \`1.3.6.1.2.1.2.2.1.2.<ifIndex>\` (ifDescr). Falls back to \`GigabitEthernet0/<N>\` synthesis when the OID is absent.

## What's in

- \`lookupIfDescr(device, ifIndex)\` helper: one sync.Map read, nil-safe
- \`deviceIfNameFn\` now composes live lookup + synth fallback
- \`(*SimulatorManager).IfName\` routes through the same lookup

## Why it matters for vendor realism

Cisco IOS-XR: \`TenGigE0/0/0/5\` · Juniper MX: \`ge-0/0/5\` · Arista: \`Ethernet12/1\` — all now reach \`{{.IfName}}\` templates unchanged. This is the prerequisite for vendor catalog content in PRs 4 and 5.

## Tests (6 new)

- Hit / miss / nil-guards on the lookup helper
- Composition: live wins, synth fills gap, zero/negative guarded
- End-to-end through FieldResolver
- Byte-identity: ifDescr=missing path produces the exact pre-PR-3 string for a 6-ifIndex sweep

## Verification

- \`go test ./...\` green
- Byte-identity pins unchanged (string substitution doesn't affect BER / RFC 5424 layout)
- \`openspec validate add-per-type-catalogs --strict\` passes

Parent: #103
Depends on: #110 (merged), #112 (merged)