### PR TITLE
fix: per-type catalog loader nits

### DIFF
--- a/go/simulator/syslog_catalog.go
+++ b/go/simulator/syslog_catalog.go
@@ -35,6 +35,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -419,6 +420,11 @@ func ScanPerTypeSyslogCatalogs(universal *SyslogCatalog, resourceDir string) (ma
 				resourceDir)
 			return result, nil
 		}
+		if os.IsPermission(err) {
+			log.Printf("syslog catalog scan: permission denied reading %q — per-type overlays disabled",
+				resourceDir)
+			return result, nil
+		}
 		return nil, fmt.Errorf("syslog catalog scan: reading %q: %w", resourceDir, err)
 	}
 	for _, entry := range entries {
@@ -430,9 +436,16 @@ func ScanPerTypeSyslogCatalogs(universal *SyslogCatalog, resourceDir string) (ma
 		if strings.HasPrefix(slug, "_") {
 			continue
 		}
-		path := resourceDir + "/" + entry.Name() + "/syslog.json"
+		path := filepath.Join(resourceDir, entry.Name(), "syslog.json")
 		info, err := os.Stat(path)
-		if err != nil || info.IsDir() {
+		if err != nil {
+			if os.IsPermission(err) {
+				log.Printf("syslog catalog scan: permission denied on %q — per-type overlay for %q skipped",
+					path, slug)
+			}
+			continue
+		}
+		if info.IsDir() {
 			continue
 		}
 		perType, err := LoadSyslogCatalogFromFile(path)

--- a/go/simulator/syslog_catalog.go
+++ b/go/simulator/syslog_catalog.go
@@ -31,7 +31,9 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"math/rand"
 	"os"
@@ -415,18 +417,21 @@ func ScanPerTypeSyslogCatalogs(universal *SyslogCatalog, resourceDir string) (ma
 	result := make(map[string]*SyslogCatalog)
 	entries, err := os.ReadDir(resourceDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			log.Printf("syslog catalog scan: resource dir %q not found — per-type overlays disabled",
 				resourceDir)
 			return result, nil
 		}
-		if os.IsPermission(err) {
+		if errors.Is(err, fs.ErrPermission) {
 			log.Printf("syslog catalog scan: permission denied reading %q — per-type overlays disabled",
 				resourceDir)
 			return result, nil
 		}
 		return nil, fmt.Errorf("syslog catalog scan: reading %q: %w", resourceDir, err)
 	}
+	// Mirror the log-once-per-scan pattern on the trap side so a
+	// systematic perms mismatch doesn't spam N lines at startup.
+	permissionLoggedThisScan := false
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -439,9 +444,10 @@ func ScanPerTypeSyslogCatalogs(universal *SyslogCatalog, resourceDir string) (ma
 		path := filepath.Join(resourceDir, entry.Name(), "syslog.json")
 		info, err := os.Stat(path)
 		if err != nil {
-			if os.IsPermission(err) {
-				log.Printf("syslog catalog scan: permission denied on %q — per-type overlay for %q skipped",
+			if errors.Is(err, fs.ErrPermission) && !permissionLoggedThisScan {
+				log.Printf("syslog catalog scan: permission denied on %q — per-type overlay for %q skipped (further permission errors this scan suppressed)",
 					path, slug)
+				permissionLoggedThisScan = true
 			}
 			continue
 		}

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -117,13 +117,6 @@ func (sm *SimulatorManager) syslogCatalogWithLabelFor(ip string) (*SyslogCatalog
 	return sm.syslogCatalog, universalCatalogKey
 }
 
-// resolvedSyslogCatalogLabel returns the label resolved for the given IP.
-// Retained as a convenience wrapper around `syslogCatalogWithLabelFor`.
-func (sm *SimulatorManager) resolvedSyslogCatalogLabel(ip string) string {
-	_, label := sm.syslogCatalogWithLabelFor(ip)
-	return label
-}
-
 // sortedSyslogEntryNames returns the catalog's entry names alphabetically.
 func sortedSyslogEntryNames(cat *SyslogCatalog) []string {
 	if cat == nil {

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -61,10 +61,14 @@ type SyslogStatus struct {
 }
 
 // Sentinel errors returned by FireSyslogOnDevice for HTTP status mapping.
+// See ErrTrapCatalogUnavailable for the rationale behind the
+// "catalog unavailable" sentinel — mirror it here so the syslog handler
+// can return 500 (not 503) when the manager is in a broken invariant.
 var (
-	ErrSyslogExportDisabled = fmt.Errorf("syslog export disabled")
-	ErrSyslogDeviceNotFound = fmt.Errorf("device not found")
-	ErrSyslogEntryNotFound  = fmt.Errorf("syslog catalog entry not found")
+	ErrSyslogExportDisabled     = fmt.Errorf("syslog export disabled")
+	ErrSyslogDeviceNotFound     = fmt.Errorf("device not found")
+	ErrSyslogEntryNotFound      = fmt.Errorf("syslog catalog entry not found")
+	ErrSyslogCatalogUnavailable = fmt.Errorf("syslog catalog unavailable (manager state broken)")
 )
 
 // SyslogEntryNotFoundError is returned by FireSyslogOnDevice when the
@@ -93,20 +97,31 @@ func syslogCatalogSource(slug, catalogFlagPath string) string {
 	return fmt.Sprintf("file:%s/%s/syslog.json", trapCatalogResourceDir, slug)
 }
 
-// resolvedSyslogCatalogLabel returns the catalogsByType key resolved for
-// the given IP — either a device-type slug or "_universal".
-func (sm *SimulatorManager) resolvedSyslogCatalogLabel(ip string) string {
+// syslogCatalogWithLabelFor mirrors `catalogWithLabelFor` on the trap
+// side — returns both the resolved catalog and its label under a single
+// RLock so the 400-error path can't split-brain between them.
+func (sm *SimulatorManager) syslogCatalogWithLabelFor(ip string) (*SyslogCatalog, string) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	if sm.syslogCatalogsByType == nil {
-		return universalCatalogKey
+		return sm.syslogCatalog, universalCatalogKey
 	}
 	if slug, ok := sm.deviceTypesByIP[ip]; ok {
-		if _, found := sm.syslogCatalogsByType[slug]; found {
-			return slug
+		if cat, found := sm.syslogCatalogsByType[slug]; found {
+			return cat, slug
 		}
 	}
-	return universalCatalogKey
+	if cat := sm.syslogCatalogsByType[universalCatalogKey]; cat != nil {
+		return cat, universalCatalogKey
+	}
+	return sm.syslogCatalog, universalCatalogKey
+}
+
+// resolvedSyslogCatalogLabel returns the label resolved for the given IP.
+// Retained as a convenience wrapper around `syslogCatalogWithLabelFor`.
+func (sm *SimulatorManager) resolvedSyslogCatalogLabel(ip string) string {
+	_, label := sm.syslogCatalogWithLabelFor(ip)
+	return label
 }
 
 // sortedSyslogEntryNames returns the catalog's entry names alphabetically.
@@ -464,15 +479,17 @@ func (sm *SimulatorManager) FireSyslogOnDevice(ip, entryName string, overrides m
 	if device == nil {
 		return fmt.Errorf("%w: %q", ErrSyslogDeviceNotFound, ip)
 	}
-	cat := sm.SyslogCatalogFor(ip)
+	// One RLock for catalog + label — see catalogWithLabelFor on the
+	// trap side for rationale.
+	cat, catLabel := sm.syslogCatalogWithLabelFor(ip)
 	if cat == nil {
-		return fmt.Errorf("%w: no catalog resolved for %s", ErrSyslogExportDisabled, ip)
+		return fmt.Errorf("%w: catalog resolution failed for %s", ErrSyslogCatalogUnavailable, ip)
 	}
 	entry, ok := cat.ByName[entryName]
 	if !ok {
 		return &SyslogEntryNotFoundError{
 			Name:    entryName,
-			Catalog: sm.resolvedSyslogCatalogLabel(ip),
+			Catalog: catLabel,
 			Entries: sortedSyslogEntryNames(cat),
 		}
 	}
@@ -499,21 +516,7 @@ func (sm *SimulatorManager) WriteSyslogStatusJSON(w http.ResponseWriter) {
 // → syslogCatalogsByType["_universal"] (the universal). Symmetric with
 // `CatalogFor` on the trap side.
 func (sm *SimulatorManager) SyslogCatalogFor(ip string) *SyslogCatalog {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	if sm.syslogCatalogsByType == nil {
-		return sm.syslogCatalog
-	}
-	if slug, ok := sm.deviceTypesByIP[ip]; ok {
-		if cat, found := sm.syslogCatalogsByType[slug]; found {
-			return cat
-		}
-	}
-	// See CatalogFor above — mirror the prefer-universal-then-legacy
-	// fallback so non-nil is guaranteed while any catalog is live.
-	if cat := sm.syslogCatalogsByType[universalCatalogKey]; cat != nil {
-		return cat
-	}
-	return sm.syslogCatalog
+	cat, _ := sm.syslogCatalogWithLabelFor(ip)
+	return cat
 }
 

--- a/go/simulator/trap_catalog.go
+++ b/go/simulator/trap_catalog.go
@@ -31,6 +31,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 )
@@ -230,6 +231,11 @@ func ScanPerTypeTrapCatalogs(universal *Catalog, resourceDir string) (map[string
 				resourceDir)
 			return result, nil
 		}
+		if os.IsPermission(err) {
+			log.Printf("trap catalog scan: permission denied reading %q — per-type overlays disabled",
+				resourceDir)
+			return result, nil
+		}
 		return nil, fmt.Errorf("trap catalog scan: reading %q: %w", resourceDir, err)
 	}
 	for _, entry := range entries {
@@ -246,9 +252,19 @@ func ScanPerTypeTrapCatalogs(universal *Catalog, resourceDir string) (map[string
 		if strings.HasPrefix(slug, "_") {
 			continue
 		}
-		path := resourceDir + "/" + entry.Name() + "/traps.json"
+		path := filepath.Join(resourceDir, entry.Name(), "traps.json")
 		info, err := os.Stat(path)
-		if err != nil || info.IsDir() {
+		if err != nil {
+			// Permission-denied is operator-visible — log once so a
+			// misconfigured per-type file doesn't silently fall back
+			// to the universal catalog without any signal.
+			if os.IsPermission(err) {
+				log.Printf("trap catalog scan: permission denied on %q — per-type overlay for %q skipped",
+					path, slug)
+			}
+			continue
+		}
+		if info.IsDir() {
 			continue
 		}
 		perType, err := LoadCatalogFromFile(path)

--- a/go/simulator/trap_catalog.go
+++ b/go/simulator/trap_catalog.go
@@ -27,7 +27,9 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"math/rand"
 	"os"
@@ -221,7 +223,7 @@ func ScanPerTypeTrapCatalogs(universal *Catalog, resourceDir string) (map[string
 	result := make(map[string]*Catalog)
 	entries, err := os.ReadDir(resourceDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// Missing resource tree is only a no-op when nothing else
 			// in the simulator cares about it (e.g. fully-embedded
 			// scenarios). Log a warning so operators running out of a
@@ -231,13 +233,18 @@ func ScanPerTypeTrapCatalogs(universal *Catalog, resourceDir string) (map[string
 				resourceDir)
 			return result, nil
 		}
-		if os.IsPermission(err) {
+		if errors.Is(err, fs.ErrPermission) {
 			log.Printf("trap catalog scan: permission denied reading %q — per-type overlays disabled",
 				resourceDir)
 			return result, nil
 		}
 		return nil, fmt.Errorf("trap catalog scan: reading %q: %w", resourceDir, err)
 	}
+	// permissionLoggedThisScan caps the inner permission-denied log to
+	// one line per scan. If an operator has a systematic perms mismatch
+	// (e.g., every resources/<slug>/ owned by another user) the naive
+	// per-entry log would spam 28+ lines at startup per feature.
+	permissionLoggedThisScan := false
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -255,12 +262,14 @@ func ScanPerTypeTrapCatalogs(universal *Catalog, resourceDir string) (map[string
 		path := filepath.Join(resourceDir, entry.Name(), "traps.json")
 		info, err := os.Stat(path)
 		if err != nil {
-			// Permission-denied is operator-visible — log once so a
+			// Permission-denied is operator-visible — log it so a
 			// misconfigured per-type file doesn't silently fall back
-			// to the universal catalog without any signal.
-			if os.IsPermission(err) {
-				log.Printf("trap catalog scan: permission denied on %q — per-type overlay for %q skipped",
+			// to the universal catalog without any signal. Log once
+			// per scan to avoid spam when the whole tree is locked.
+			if errors.Is(err, fs.ErrPermission) && !permissionLoggedThisScan {
+				log.Printf("trap catalog scan: permission denied on %q — per-type overlay for %q skipped (further permission errors this scan suppressed)",
 					path, slug)
+				permissionLoggedThisScan = true
 			}
 			continue
 		}

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -547,15 +547,6 @@ func (sm *SimulatorManager) FireTrapOnDevice(ip, trapName string, overrides map[
 	return id, nil
 }
 
-// resolvedCatalogLabel returns the catalogsByType key that CatalogFor
-// resolved for `ip`. Retained as a convenience wrapper around
-// `catalogWithLabelFor`; callers that need both the catalog pointer AND
-// the label should use `catalogWithLabelFor` directly (one RLock).
-func (sm *SimulatorManager) resolvedCatalogLabel(ip string) string {
-	_, label := sm.catalogWithLabelFor(ip)
-	return label
-}
-
 // sortedTrapEntryNames returns the catalog's entry names in stable
 // alphabetical order — useful for deterministic HTTP 400 bodies that
 // tests can assert against.

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -438,25 +438,34 @@ func (sm *SimulatorManager) FindDeviceByIP(ip string) *DeviceSimulator {
 // use; the hot path is O(1) (two map reads). Returns nil only when trap
 // export has never been initialised.
 func (sm *SimulatorManager) CatalogFor(ip string) *Catalog {
+	cat, _ := sm.catalogWithLabelFor(ip)
+	return cat
+}
+
+// catalogWithLabelFor returns the resolved catalog and its `catalogsByType`
+// key under a single RLock. Collapses what used to be three separate
+// RLock acquisitions in `FireTrapOnDevice`'s 400-error path (find-device +
+// CatalogFor + resolvedCatalogLabel) so a concurrent DeleteDevice cannot
+// split-brain the returned pair.
+//
+// Label is the key the status endpoint reports (device-type slug or the
+// reserved `_universal`). Catalog is the resolved *Catalog the hot path
+// uses.
+func (sm *SimulatorManager) catalogWithLabelFor(ip string) (*Catalog, string) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	if sm.trapCatalogsByType == nil {
-		return sm.trapCatalog
+		return sm.trapCatalog, universalCatalogKey
 	}
 	if slug, ok := sm.deviceTypesByIP[ip]; ok {
 		if cat, found := sm.trapCatalogsByType[slug]; found {
-			return cat
+			return cat, slug
 		}
 	}
-	// Prefer the catalogsByType universal entry; fall back to the legacy
-	// `trapCatalog` pointer only if someone mutated catalogsByType without
-	// re-seeding the universal key. A non-nil return when any catalog
-	// surface is initialised protects the scheduler hot path from silent
-	// no-op fires and simplifies `FireTrapOnDevice` error semantics.
 	if cat := sm.trapCatalogsByType[universalCatalogKey]; cat != nil {
-		return cat
+		return cat, universalCatalogKey
 	}
-	return sm.trapCatalog
+	return sm.trapCatalog, universalCatalogKey
 }
 
 // universalCatalogKey is the reserved slug used in trapCatalogsByType and
@@ -511,15 +520,20 @@ func (sm *SimulatorManager) FireTrapOnDevice(ip, trapName string, overrides map[
 	if device == nil {
 		return 0, fmt.Errorf("%w: %q", ErrTrapDeviceNotFound, ip)
 	}
-	cat := sm.CatalogFor(ip)
+	// Resolve the catalog and its label under ONE RLock so a concurrent
+	// DeleteDevice cannot split-brain the 400-error fields (label says
+	// `cisco_ios` but catalog came from `_universal`). Previously this
+	// acquired RLock three times (FindDeviceByIP + CatalogFor +
+	// resolvedCatalogLabel).
+	cat, catLabel := sm.catalogWithLabelFor(ip)
 	if cat == nil {
-		return 0, fmt.Errorf("%w: no catalog resolved for %s", ErrTrapExportDisabled, ip)
+		return 0, fmt.Errorf("%w: catalog resolution failed for %s", ErrTrapCatalogUnavailable, ip)
 	}
 	entry, ok := cat.ByName[trapName]
 	if !ok {
 		return 0, &TrapEntryNotFoundError{
 			Name:    trapName,
-			Catalog: sm.resolvedCatalogLabel(ip),
+			Catalog: catLabel,
 			Entries: sortedTrapEntryNames(cat),
 		}
 	}
@@ -534,21 +548,12 @@ func (sm *SimulatorManager) FireTrapOnDevice(ip, trapName string, overrides map[
 }
 
 // resolvedCatalogLabel returns the catalogsByType key that CatalogFor
-// resolved for `ip` — either a device-type slug or "_universal". Used only
-// for HTTP error bodies, so a miss (unknown IP) maps to "_universal" for a
-// sensible message.
+// resolved for `ip`. Retained as a convenience wrapper around
+// `catalogWithLabelFor`; callers that need both the catalog pointer AND
+// the label should use `catalogWithLabelFor` directly (one RLock).
 func (sm *SimulatorManager) resolvedCatalogLabel(ip string) string {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	if sm.trapCatalogsByType == nil {
-		return universalCatalogKey
-	}
-	if slug, ok := sm.deviceTypesByIP[ip]; ok {
-		if _, found := sm.trapCatalogsByType[slug]; found {
-			return slug
-		}
-	}
-	return universalCatalogKey
+	_, label := sm.catalogWithLabelFor(ip)
+	return label
 }
 
 // sortedTrapEntryNames returns the catalog's entry names in stable
@@ -581,10 +586,19 @@ func (e *TrapEntryNotFoundError) Error() string {
 func (e *TrapEntryNotFoundError) Unwrap() error { return ErrTrapEntryNotFound }
 
 // Sentinel errors returned by FireTrapOnDevice for HTTP status mapping.
+//
+// ErrTrapCatalogUnavailable signals a pathological internal state where
+// trap export reports active (`trapActive=true`) but neither the
+// per-type catalog map nor the legacy single-catalog pointer resolves
+// to a catalog. This cannot happen under normal operation — it would
+// mean the manager is mid-reinitialisation or something overwrote the
+// catalog state after Start. The handler maps this to 500, not 503,
+// because "try again later" is misleading for a broken invariant.
 var (
-	ErrTrapExportDisabled = fmt.Errorf("trap export disabled")
-	ErrTrapDeviceNotFound = fmt.Errorf("device not found")
-	ErrTrapEntryNotFound  = fmt.Errorf("trap catalog entry not found")
+	ErrTrapExportDisabled     = fmt.Errorf("trap export disabled")
+	ErrTrapDeviceNotFound     = fmt.Errorf("device not found")
+	ErrTrapEntryNotFound      = fmt.Errorf("trap catalog entry not found")
+	ErrTrapCatalogUnavailable = fmt.Errorf("trap catalog unavailable (manager state broken)")
 )
 
 // WriteTrapStatusJSON writes GetTrapStatus as JSON to w. Extracted for

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -146,6 +146,9 @@ func fireSyslogHandler(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, ErrSyslogExportDisabled):
 			sendErrorResponse(w, err.Error(), http.StatusServiceUnavailable)
+		case errors.Is(err, ErrSyslogCatalogUnavailable):
+			// Pathological manager state — see trap handler for rationale.
+			sendErrorResponse(w, err.Error(), http.StatusInternalServerError)
 		case errors.Is(err, ErrSyslogDeviceNotFound):
 			sendErrorResponse(w, err.Error(), http.StatusNotFound)
 		case errors.As(err, &entryErr):
@@ -204,6 +207,10 @@ func fireTrapHandler(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, ErrTrapExportDisabled):
 			sendErrorResponse(w, err.Error(), http.StatusServiceUnavailable)
+		case errors.Is(err, ErrTrapCatalogUnavailable):
+			// Pathological manager state — client retrying later
+			// won't help. Map to 500 rather than 503.
+			sendErrorResponse(w, err.Error(), http.StatusInternalServerError)
 		case errors.Is(err, ErrTrapDeviceNotFound):
 			sendErrorResponse(w, err.Error(), http.StatusNotFound)
 		case errors.As(err, &entryErr):


### PR DESCRIPTION
Applies the four low-severity polish items from #111 (PR #110 review deferrals).

## What's in

- **D1** — \`filepath.Join\` instead of string concat in both \`ScanPerType*Catalogs\` helpers
- **D2** — distinguish \`os.IsPermission\` from \`os.IsNotExist\`; log warning naming the path for permission errors, silent skip for not-exist
- **D3** — collapse triple \`sm.mu.RLock\` in \`FireTrapOnDevice\` 400-path via new \`catalogWithLabelFor(ip)\` returning catalog + label under one lock. Symmetric \`syslogCatalogWithLabelFor\` on the syslog side.
- **D4** — new \`ErrTrapCatalogUnavailable\` / \`ErrSyslogCatalogUnavailable\` sentinels; web.go maps them to 500 instead of 503 for the pathological "catalog-nil while active" state.

## Non-goals

- No behaviour change for happy paths
- No new flags or HTTP surface
- No byte-identity change

## Verification

- \`go test ./...\` green
- \`go vet ./...\` clean
- Byte-identity pins unchanged

Closes #111