### PR TITLE
docs: syslog + per-type catalog pages

### DIFF
--- a/docs/ops/snmp-traps.md
+++ b/docs/ops/snmp-traps.md
@@ -129,6 +129,13 @@ device IP as the sender and an OID from the universal catalog
 (`linkDown` / `linkUp` dominate; `coldStart` / `warmStart` /
 `authenticationFailure` appear less often).
 
+For vendor-flavoured content (e.g., Cisco `ciscoConfigManEvent` or
+Juniper `jnxPowerSupplyFailure`), select a device type with a per-type
+overlay — see
+[SNMP trap reference → Per-type catalog overlays](../reference/snmp-traps.md#per-type-catalog-overlays).
+`cisco_ios` devices fire from 12 merged entries (universal 5 + 7 Cisco),
+`juniper_mx240` devices fire from a comparable 12-entry Juniper set.
+
 If you need it sooner on demand:
 
 ```bash
@@ -158,7 +165,8 @@ conflicts) see [Troubleshooting](troubleshooting.md).
 
 ## Related
 
-- [SNMP trap reference](../reference/snmp-traps.md) — wire format, catalog JSON, HTTP endpoints
+- [SNMP trap reference](../reference/snmp-traps.md) — wire format, catalog JSON, HTTP endpoints, per-type catalog overlays
 - [CLI flags → SNMP trap / INFORM export flags](../reference/cli-flags.md#snmp-trap--inform-export-flags)
+- [UDP syslog export (operator guide)](syslog-export.md) — sibling feature; shares overlay loader and template vocabulary
 - [Flow export (operator guide)](flow-export.md) — shared `opensim` namespace plumbing
 - [Web API → Fire a trap on demand](../reference/web-api.md#fire-a-trap-on-demand)

--- a/docs/ops/syslog-export.md
+++ b/docs/ops/syslog-export.md
@@ -1,0 +1,181 @@
+# UDP syslog export (operator guide)
+
+l8opensim can emit UDP syslog messages in either **RFC 5424** (the modern
+structured format with `[SD-PARAM]` blocks) or **RFC 3164** (the legacy
+BSD format most network gear still defaults to) from every simulated
+device to a single collector such as `rsyslog`, `syslog-ng`, or
+OpenNMS `syslogd`. Each device uses its own IP as the UDP source by
+default, so collectors that key on source-IP → node mapping attribute
+messages correctly without extra work.
+
+This page is the operator-facing setup guide. For the CLI flags see
+[CLI flags → UDP syslog export](../reference/cli-flags.md#udp-syslog-export-flags);
+for wire format, catalog JSON, and HTTP endpoints see
+[UDP syslog reference](../reference/syslog-export.md).
+
+## Enabling syslog export
+
+The feature is off by default. Pass `-syslog-collector <host:port>` to
+enable it; the other flags have sensible defaults for modern collectors.
+
+```bash
+# 100 devices, RFC 5424, one message every ~10s per device (Poisson-distributed)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -syslog-collector 192.168.1.10:514
+
+# Legacy BSD format (required by some older collectors + network gear that still
+# auto-detects based on leading '<PRI>Mmm DD' shape)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -syslog-collector 192.168.1.10:514 \
+  -syslog-format 3164
+
+# Tighter interval + global rate cap (≤ 500 messages/s across all devices)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 1000 \
+  -syslog-collector 192.168.1.10:514 \
+  -syslog-interval 1s -syslog-global-cap 500
+
+# Custom catalog (overrides universal + disables per-type overlays)
+sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -syslog-collector 192.168.1.10:514 \
+  -syslog-catalog /etc/opensim/my-syslog.json
+```
+
+## 5424 vs 3164
+
+Only **one format is active per simulator process** — the two coexist
+poorly on a single UDP socket because auto-detecting collectors can
+mis-parse the other form.
+
+| Aspect | RFC 5424 (`-syslog-format 5424`, default) | RFC 3164 (`-syslog-format 3164`) |
+|--------|-------------------------------------------|----------------------------------|
+| Timestamp | ISO 8601 with fractional seconds (`2026-04-21T13:30:45.123Z`) | BSD-style (`Apr 21 13:30:45`) |
+| HOSTNAME | Explicit field | Explicit field |
+| APP-NAME / TAG | `APP-NAME` required; `PROCID` and `MSGID` distinct | Single `TAG` only, no structured MSGID |
+| Structured data | `[key="value" ...]` SD-PARAM blocks | Not supported — `structuredData` in catalog entries is dropped |
+| Max message size | 1400 bytes (enforced at load time via dry-render) | Same |
+| Year in timestamp | Included | Absent (RFC 3164 omits the year) |
+
+Choose 5424 for new deployments and anything that consumes structured
+data. Choose 3164 for downstream testing against legacy collectors or
+when the message sink auto-detects format from the leading characters.
+
+## Per-device source IP binding
+
+`-syslog-source-per-device=true` (the default) binds a UDP socket per
+device inside the `opensim` network namespace so the UDP source address
+on the wire matches the simulated device's IP. Per-device bind failures
+are **non-fatal** — unlike trap export's INFORM mode, syslog has no ack
+path that depends on symmetric source IPs. When a bind fails:
+
+1. The simulator logs a warning naming the device IP and the bind error.
+2. That device's exporter falls back to the shared simulator-process
+   UDP socket.
+3. The collector sees the simulator host's IP as the source for that
+   device's messages (breaks source-IP → node mapping for the affected
+   device only).
+
+Setting `-syslog-source-per-device=false` skips per-device binding
+entirely — every device's messages arrive with the simulator host's IP
+as the source. Use this if the collector side doesn't care about source
+IP (e.g., it keys on `HOSTNAME` field or `structuredData` instead).
+
+## Rate cap and scheduling
+
+Per-device firing follows a **Poisson process** with mean
+`-syslog-interval` (default 10s) — the same design as trap export, for
+the same reason: naïve periodic scheduling causes synchronised-burst
+artefacts that don't reflect real-world syslog traffic shapes.
+
+`-syslog-global-cap <rate>` adds a hard ceiling across all devices.
+Sizing guidance:
+
+- **Steady-state estimate:** `devices / syslog_interval_seconds`.
+  30,000 devices at `-syslog-interval 10s` ≈ 3000 msg/s average.
+- **Under-cap deliberately** to leave headroom for on-demand HTTP-API
+  fires you inject for fault injection. On-demand fires **bypass the
+  global cap** (test-harness use case).
+- `-syslog-global-cap 0` (the default) means unlimited.
+
+## Prerequisites inherited from flow / trap export
+
+Per-device source IP binding reuses the same `opensim` network namespace
+plumbing as flow and trap export — no new `iptables` rules and no new
+netns setup. Three conditions apply:
+
+- **`iptables FORWARD` rule.** At startup the simulator inserts
+  `FORWARD -i veth-sim-host -j ACCEPT` so Docker-present hosts (which
+  default FORWARD to drop) allow per-device egress. Walkthrough:
+  [Flow export → Prerequisites](flow-export.md#prerequisites-for-per-device-source-ip).
+- **Route to the collector from inside the namespace.** Same default
+  route via `veth-sim-host` (`10.254.0.1`); if you've customised host
+  routing, verify with
+  `sudo ip netns exec opensim ip route get <collector-ip>`.
+- **Collector-side `rp_filter`.** Reverse-path filtering on the
+  collector host may drop UDP/514 packets whose source IP
+  (`10.0.0.x`, `10.42.0.x`, whatever subnet your devices live in)
+  isn't reachable back through the receiving interface. Loose mode
+  fixes it:
+  ```bash
+  sudo sysctl -w net.ipv4.conf.all.rp_filter=2
+  sudo sysctl -w net.ipv4.conf.<iface>.rp_filter=2
+  ```
+
+## Smoke test
+
+The simplest end-to-end check uses `netcat` (or `socat`) as a trivial
+UDP sink:
+
+```bash
+# In one terminal — dump every received datagram to stdout
+nc -ul 514 | sed -u 's/^/recv: /'
+
+# In another terminal — point the simulator at it
+sudo ./simulator -auto-start-ip 127.0.0.1 -auto-count 5 \
+  -syslog-collector 127.0.0.1:514 -syslog-interval 2s
+```
+
+You should see lines arriving every few seconds. The universal catalog
+dominates with `interface-up` / `interface-down` (together 60% of
+fires by weight); `auth-success` / `auth-failure` sit at 30%, and
+`config-change` / `system-restart` round out the remainder.
+
+For vendor-flavoured content (e.g., Cisco `%LINK-3-UPDOWN:` or Juniper
+`MIB2D_IFD_IFL_ENCAPS_MISMATCH:`), select a device type with a per-type
+overlay — see
+[Syslog reference → Per-type catalogs](../reference/syslog-export.md#per-type-catalog-overlays).
+
+If you need a specific message on demand:
+
+```bash
+# Fire a named catalog entry immediately via the HTTP API
+curl -X POST http://localhost:8080/api/v1/devices/127.0.0.1/syslog \
+  -H "Content-Type: application/json" \
+  -d '{"name":"interface-down","templateOverrides":{"IfIndex":"3"}}'
+```
+
+See [Web API → Fire a syslog message on demand](../reference/web-api.md#fire-a-syslog-message-on-demand)
+for the full request / response shape.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `enabled: false` in `/api/v1/syslog/status` | `-syslog-collector` not set | Pass the flag; verify port |
+| `enabled: true`, `sent` is 0 | Scheduler idle (no devices yet) | Wait for device creation to finish |
+| Messages sent but collector sees nothing | FORWARD rule missing or `rp_filter` blocking | See [Flow export → Flow troubleshooting](flow-export.md#flow-troubleshooting) — the netns diagnostic steps apply verbatim |
+| Source IP on the wire is the host, not the device | Per-device bind failed for that device (non-fatal) | Check simulator logs for `per-device bind failed`; expected when run without netns (`-no-namespace`) |
+| Collector parser chokes on the message format | Collector and simulator disagree on 5424 vs 3164 | Match `-syslog-format` to the collector's expected form |
+| `structuredData` missing from emitted messages | Running `-syslog-format 3164` — RFC 3164 doesn't support SD | Switch to 5424 or accept the loss |
+| `send_failures` climbing | Collector unreachable or firewalled | Verify collector listening on UDP/514; check firewall rules |
+| Catalog load fails at startup naming a `resources/<slug>/syslog.json` | Malformed per-type JSON or a reserved template field | See [Syslog reference → Per-type catalogs](../reference/syslog-export.md#per-type-catalog-overlays) for the schema and vocabulary |
+
+For generic bring-up failures (TUN module missing, `sudo` required,
+port conflicts) see [Troubleshooting](troubleshooting.md).
+
+## Related
+
+- [UDP syslog reference](../reference/syslog-export.md) — wire format, catalog JSON, HTTP endpoints, per-type catalog overlays
+- [CLI flags → UDP syslog export](../reference/cli-flags.md#udp-syslog-export-flags)
+- [SNMP trap export (operator guide)](snmp-traps.md) — sibling feature; shared overlay loader and template vocabulary
+- [Flow export (operator guide)](flow-export.md) — shared `opensim` namespace plumbing
+- [Web API → Fire a syslog message on demand](../reference/web-api.md#fire-a-syslog-message-on-demand)

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -87,11 +87,26 @@ prerequisites and `snmptrapd` smoke-test, and
 | `-trap-mode` | `trap` \| `inform` | `trap` | Notification mode. TRAP is fire-and-forget; INFORM is acknowledged and retried. |
 | `-trap-interval` | duration | `30s` | Per-device mean firing interval (Poisson-distributed, not periodic). |
 | `-trap-global-cap` | int (tps) | `0` | Simulator-wide rate ceiling across fires + INFORM retries. `0` is unlimited. |
-| `-trap-catalog` | string | — | Path to a JSON catalog; empty uses the embedded universal 5-trap catalog. |
+| `-trap-catalog` | string | — | Path to a JSON catalog; empty uses the embedded universal 5-trap catalog + per-type overlays from `resources/<slug>/traps.json`. Setting this flag **disables per-type overlays** — the file becomes the sole catalog for every device. |
 | `-trap-community` | string | `public` | SNMPv2c community string. |
 | `-trap-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. **Required** when `-trap-mode inform`. |
 | `-trap-inform-timeout` | duration | `5s` | Per-retry timeout in INFORM mode. |
 | `-trap-inform-retries` | int | `2` | Maximum retransmissions per INFORM before it's declared failed. |
+
+## UDP syslog export flags
+
+See [UDP syslog export (operator guide)](../ops/syslog-export.md) for
+prerequisites and `netcat` smoke-test, and
+[UDP syslog reference](syslog-export.md) for wire format and catalog JSON.
+
+| Flag | Type | Default | Purpose |
+|------|------|---------|---------|
+| `-syslog-collector` | string | — | Enable syslog export to this UDP collector (e.g. `192.168.1.10:514`). Empty disables the feature. |
+| `-syslog-format` | `5424` \| `3164` | `5424` | Wire format. RFC 5424 is structured (recommended); RFC 3164 is legacy BSD. One format per process — they don't mix on a single UDP socket. |
+| `-syslog-interval` | duration | `10s` | Per-device mean firing interval (Poisson-distributed, not periodic). |
+| `-syslog-global-cap` | int (rate) | `0` | Simulator-wide rate ceiling across scheduled fires. On-demand HTTP fires bypass the cap. `0` is unlimited. |
+| `-syslog-catalog` | string | — | Path to a JSON catalog; empty uses the embedded universal 6-entry catalog + per-type overlays from `resources/<slug>/syslog.json`. Setting this flag **disables per-type overlays** — the file becomes the sole catalog for every device. |
+| `-syslog-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. Per-device bind failures are non-fatal (unlike INFORM mode on the trap side) — the exporter falls back to the shared socket with a warning. |
 
 ## Examples
 

--- a/docs/reference/snmp-traps.md
+++ b/docs/reference/snmp-traps.md
@@ -36,8 +36,12 @@ confidential data.
 - **Embedded catalog** loaded via `go:embed` from
   `resources/_common/traps.json` at startup — no filesystem dependency
   for the out-of-box experience. `-trap-catalog <path>` replaces the
-  embedded default with a user-supplied JSON file (complete override,
-  not merge).
+  entire catalog surface (universal + per-type overlays) with a single
+  user-supplied JSON file.
+- **Per-device-type catalog overlays** loaded from
+  `resources/<slug>/traps.json` when present. Each device of type
+  `<slug>` fires from the merged catalog (universal + per-type).
+  See [Per-type catalog overlays](#per-type-catalog-overlays).
 - **Global rate limiter** (`golang.org/x/time/rate`) gates both fresh
   fires and INFORM retransmissions so a collector outage cannot amplify
   wire traffic past the operator-configured ceiling.
@@ -76,9 +80,19 @@ that list either reserved OID:
 |----------|-----|------|--------|
 | 1 | `1.3.6.1.2.1.1.3.0` (`sysUpTime.0`) | TimeTicks (`0x43`) | Device uptime in 1/100-second ticks |
 | 2 | `1.3.6.1.6.3.1.1.4.1.0` (`snmpTrapOID.0`) | OID (`0x06`) | Catalog entry's `snmpTrapOID` |
+| 3 (optional) | `1.3.6.1.6.3.1.1.4.3.0` (`snmpTrapEnterprise.0`) | OID (`0x06`) | Catalog entry's `snmpTrapEnterprise` field, when set |
 
-Everything after position 2 is the catalog entry's body varbinds with
-templates resolved to concrete values.
+Positions 1 and 2 are unconditional per RFC 3416 §4.2.6. Position 3 is
+emitted only when the catalog entry declares a non-empty
+`snmpTrapEnterprise` field — per SNMPv2-MIB §10 this additional-info
+varbind aids v1↔v2c cross-compatibility on collectors that expect the
+enterprise OID, and RFC 3584 §4.1 pins the positional ordering. All
+three reserved OIDs (`sysUpTime.0`, `snmpTrapOID.0`,
+`snmpTrapEnterprise.0`) are rejected when they appear as body varbind
+OIDs — the encoder emits them automatically.
+
+Everything after the auto-prepended varbinds is the catalog entry's
+body varbinds with templates resolved to concrete values.
 
 ### INFORM acknowledgement
 
@@ -116,6 +130,7 @@ Top-level object:
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
 | `traps` | array | yes | List of catalog entries. Must contain at least one. |
+| `extends` | bool | no (default `true`) | **Per-type overlays only.** Controls whether the per-type catalog merges on top of the universal (`true`) or fully replaces it for devices of that type (`false`). Ignored on the universal catalog itself. |
 
 Per-entry object:
 
@@ -123,8 +138,9 @@ Per-entry object:
 |-------|------|----------|---------|
 | `name` | string | yes | Unique within the catalog. Used by the HTTP fire-on-demand endpoint and for log attribution. |
 | `snmpTrapOID` | string | yes | Dotted-decimal OID. Becomes the value of the auto-prepended `snmpTrapOID.0` varbind. |
+| `snmpTrapEnterprise` | string | no | Dotted-decimal OID for the optional `snmpTrapEnterprise.0` varbind. When set, the encoder emits a third prepended varbind after `snmpTrapOID.0` and before body varbinds. Useful for v1↔v2c proxy compatibility (RFC 3584 §4.1); conventionally the MIB module root. |
 | `weight` | integer | no (default `1`) | Relative weight for weighted-random selection by the scheduler. Zero means omit the entry from scheduled firing (still reachable via the HTTP endpoint). |
-| `varbinds` | array | yes (may be empty) | Body varbinds following the two auto-prepended ones. |
+| `varbinds` | array | yes (may be empty) | Body varbinds following the auto-prepended ones. |
 
 Per-varbind object:
 
@@ -152,20 +168,59 @@ exercising the other three types.
 
 ### Template vocabulary
 
-Both `oid` and `value` fields are evaluated as Go `text/template` strings
-per fire. The current vocabulary (see `go/simulator/trap_catalog.go` for
-the ground truth) is restricted to four fields:
+Both `oid` and `value` fields are evaluated as Go `text/template`
+strings per fire. The vocabulary is **unified with the syslog
+subsystem** — the same nine fields work on both sides:
 
 | Field | Evaluation |
 |-------|-----------|
 | `{{.IfIndex}}` | Random ifIndex drawn from the device's simulated interface set at fire time |
+| `{{.IfName}}` | `ifDescr.<IfIndex>` live lookup from the device's SNMP OID table; falls back to synthesised `GigabitEthernet0/<N>` on miss |
 | `{{.Uptime}}` | Device uptime in 1/100-second ticks |
 | `{{.Now}}` | Unix epoch seconds |
 | `{{.DeviceIP}}` | Dotted-quad IPv4 of the device |
+| `{{.SysName}}` | Device's `sysName.0` value (captured at construction) |
+| `{{.Model}}` | Human-readable model string derived from device-type slug (e.g., `cisco_ios` → `Cisco IOS`) |
+| `{{.Serial}}` | Deterministic `SN` + 8-hex-digit serial synthesised from the device's IPv4 |
+| `{{.ChassisID}}` | Deterministic locally-administered MAC-style chassis ID synthesised from the device's IPv4 (`02:42:xx:xx:xx:xx`) |
 
 References to any other field are rejected at catalog load — the
-simulator refuses to start rather than silently emitting a trap with an
-empty OID component.
+simulator refuses to start rather than silently emitting a trap with
+an empty OID component. Class 2 random-per-fire fields (`PeerIP`,
+`User`, `SourceIP`, `RuleName`, `NeighborRouterID`, `PeerAS`) are
+explicitly unsupported and tracked as follow-up work.
+
+## Per-type catalog overlays
+
+Devices can ship vendor-flavoured trap content via per-type JSON files
+at `resources/<slug>/traps.json`. When a per-type file exists, the
+simulator merges it with the universal catalog using **name-based
+overlay semantics**:
+
+1. Entries whose names are unique to the per-type file are **added**.
+2. Entries whose names match a universal entry **override** the
+   universal entry for devices of that type.
+3. Universal entries with no matching per-type name **carry through**.
+
+Set `"extends": false` at the top of the per-type file for a pure
+replacement. Weights are recomputed over the merged entry set after
+overlay — operators tuning the distribution should check
+`GET /api/v1/traps/status` → `catalogs_by_type` for the resulting
+entry counts.
+
+### Shipped vendor catalogs
+
+| Slug | Count | Notable entries |
+|------|-------|-----------------|
+| `cisco_ios` | 7 Cisco-MIB entries (merged total 12) | `ciscoConfigManEvent`, `ciscoEnvMonSupplyStatusChangeNotif`, `ciscoEnvMonTemperatureNotification`, `cefcModuleStatusChange`, `cefcFanTrayStatusChangeNotif`, `ciscoEntSensorThresholdNotification`, `ciscoFlashDeviceChangeTrap`. All with `snmpTrapEnterprise` set to `1.3.6.1.4.1.9.9.<mib-root>`. |
+| `juniper_mx240` | 7 JUNIPER-MIB entries (merged total 12) | `jnxPowerSupplyFailure`, `jnxFanFailure`, `jnxOverTemperature`, `jnxFruRemoval`, `jnxFruInsertion`, `jnxFruPowerOff`, `jnxFruFailed` (all `jnxChassisTraps` family). `snmpTrapEnterprise` = `1.3.6.1.4.1.2636` on all entries. |
+
+Other cisco_* slugs (`cisco_catalyst_9500`, `cisco_crs_x`,
+`cisco_nexus_9500`, `asr9k`), `juniper_mx960`, Arista, Linux, and
+Palo Alto fall back to the universal catalog — their realistic
+content depends on Class 2 random fields deferred to a follow-up.
+Family-catalog concept (one catalog shared by all `cisco_*` slugs) is
+also a follow-up refactor.
 
 ## HTTP endpoints
 
@@ -192,9 +247,9 @@ Responses:
 | Status | Body | When |
 |--------|------|------|
 | `202 Accepted` | `{"requestId": <uint32>}` | Success; the trap has been enqueued. For INFORM mode the `requestId` is the INFORM PDU's `request-id` — correlate with `/api/v1/traps/status` to watch its lifecycle. |
-| `400 Bad Request` | `{"success": false, "message": "..."}` | Malformed JSON body, missing/empty `name` field, or unknown catalog entry name. |
+| `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for the device. The enriched body tells the caller which catalog the device resolved to (`cisco_ios`, `_universal`, etc.) and lists its entries alphabetically so a scripted caller can self-service when it targeted the wrong vendor. For malformed JSON or missing `name`, the legacy envelope form `{"success": false, "message": "..."}` applies. |
 | `404 Not Found` | `{"success": false, "message": "..."}` | Unknown device IP. |
-| `500 Internal Server Error` | `{"success": false, "message": "..."}` | `Fire` failed for a non-lookup reason — template resolve error or write failure. Logs on the simulator side carry the detail. |
+| `500 Internal Server Error` | `{"success": false, "message": "..."}` | `Fire` failed for a non-lookup reason — template resolve error, catalog resolution returned nil despite feature active (pathological manager state), or write failure. Logs on the simulator side carry the detail. |
 | `503 Service Unavailable` | `{"success": false, "message": "..."}` | Trap export is disabled (`-trap-collector` not set). |
 
 The endpoint is fire-and-forget — it does **not** block waiting for an
@@ -221,9 +276,22 @@ response shape):
   "informs_failed": 33,
   "informs_dropped": 0,
   "rate_limiter_tokens_available": 94,
-  "devices_exporting": 100
+  "devices_exporting": 100,
+  "catalogs_by_type": {
+    "_universal":    {"entries": 5,  "source": "embedded"},
+    "cisco_ios":     {"entries": 12, "source": "file:resources/cisco_ios/traps.json"},
+    "juniper_mx240": {"entries": 12, "source": "file:resources/juniper_mx240/traps.json"}
+  }
 }
 ```
+
+`catalogs_by_type` is present whenever the feature is enabled. Keys
+are device-type slugs with the reserved `_universal` entry for the
+fallback catalog. Values include the merged entry count and the
+catalog's provenance: `"embedded"` (compiled-in universal),
+`"file:<path>"` (per-type overlay on disk), or
+`"override:<path>"` when `-trap-catalog` was supplied (in which case
+`catalogs_by_type` contains a single `_universal` entry).
 
 When enabled in TRAP mode, the four `informs_*` fields are omitted (no
 INFORM state to report). When disabled the response is:

--- a/docs/reference/syslog-export.md
+++ b/docs/reference/syslog-export.md
@@ -1,0 +1,368 @@
+# UDP syslog reference
+
+l8opensim emits UDP syslog messages in either **RFC 5424** (modern,
+structured) or **RFC 3164** (legacy BSD) format. Only one format is
+active per simulator process. The two encoders sit behind a shared
+`SyslogEncoder` interface in `go/simulator/syslog_wire.go`; the per-
+device `SyslogExporter` holds a UDP socket (per-device or shared) and
+fires messages at times drawn by a central Poisson scheduler. This
+page covers the wire format, the catalog JSON schema, the HTTP
+endpoints, and the status JSON shape. For enabling the feature, CLI
+flags, and troubleshooting see
+[UDP syslog export (operator guide)](../ops/syslog-export.md) and
+[CLI flags → UDP syslog export](cli-flags.md#udp-syslog-export-flags).
+
+## Architecture
+
+- **Central scheduler goroutine** (`syslog_scheduler.go`) owns a
+  min-heap of `(nextFire, deviceIP)` entries. Single goroutine
+  regardless of device count — identical design to
+  [trap export](snmp-traps.md#architecture).
+- **Per-device `SyslogExporter`** (`syslog_exporter.go`) owns the
+  device's UDP socket and stats. Class 1 device-context fields
+  (`SysName`, `Model`, `Serial`, `ChassisID`) are captured at
+  exporter construction — stable for the device's lifetime.
+- **Shared `SyslogEncoder` interface** (`syslog_wire.go`) with two
+  implementations: `RFC5424Encoder` and `RFC3164Encoder`. Both
+  produce a single UDP datagram per message.
+- **Embedded catalog** loaded via `go:embed` from
+  `resources/_common/syslog.json` at startup. `-syslog-catalog <path>`
+  replaces the entire catalog surface (universal + per-type overlays)
+  with a single user-supplied JSON file.
+- **Per-device-type catalog overlays** loaded from
+  `resources/<slug>/syslog.json` when present. Each device of type
+  `<slug>` fires from the merged catalog (universal + per-type) —
+  see [Per-type catalog overlays](#per-type-catalog-overlays).
+- **Global rate limiter** (`golang.org/x/time/rate`) gates scheduled
+  fires. On-demand fires via the HTTP endpoint **bypass** the cap —
+  they're for fault injection, not load shaping.
+
+## Scope
+
+The simulator emits syslog over **UDP only** — TCP (RFC 6587) and TLS
+(RFC 5425) transports are follow-up work
+([#92](https://github.com/labmonkeys-space/l8opensim/issues/92),
+[#93](https://github.com/labmonkeys-space/l8opensim/issues/93)).
+UDP is the form most network-device simulation scenarios test against;
+adding TCP/TLS requires connection management that doesn't fit the
+fire-and-forget single-socket design.
+
+## RFC 5424 wire format
+
+```
+<PRI>1 TIMESTAMP HOSTNAME APP-NAME PROCID MSGID [SD-PARAM]* MSG
+```
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `<PRI>` | `facility * 8 + severity` | `<187>` (local7.debug) |
+| Version | Always `1` | `1` |
+| `TIMESTAMP` | ISO 8601 UTC with fractional seconds | `2026-04-21T13:30:45.123Z` |
+| `HOSTNAME` | Catalog `hostname` template → `sysName.0` → `DeviceIP` | `rtr-dc-01` |
+| `APP-NAME` | Catalog entry's `appName` (required) | `IFMGR` |
+| `PROCID` | Always `NILVALUE` (`-`) | `-` |
+| `MSGID` | Catalog entry's `msgId` (optional; NILVALUE if omitted) | `LINKDOWN` |
+| `[SD-PARAM]` | Zero or more structured-data blocks from the catalog's `structuredData` map | `[ifIndex="3" ifName="ge-0/0/3"]` |
+| `MSG` | Catalog entry's `template` rendered | `Interface ge-0/0/3 changed state to down` |
+
+All header tokens pass through sanitisation per RFC 5424 §6: spaces
+become hyphens, non-ASCII bytes become `_`, lengths are capped. The
+dry-render check at catalog load rejects any entry whose worst-case
+expansion exceeds 1400 bytes.
+
+### Structured-data grammar
+
+Each key in the catalog's `structuredData` map becomes one SD-PARAM
+inside a single `[<SD-ID>=...]` block whose SD-ID is the catalog entry
+`appName`. Keys must match the RFC 5424 §6.3.3 SD-NAME grammar
+(PRINTUSASCII, no space / `=` / `]` / `"`, 1..32 chars). Values are
+rendered through the standard template vocabulary. SD-PARAM value
+escapes (`"` → `\"`, `\` → `\\`, `]` → `\]`) are applied automatically.
+
+## RFC 3164 wire format
+
+```
+<PRI>TIMESTAMP HOSTNAME TAG[pid]: MSG
+```
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `<PRI>` | Same computation as 5424 | `<187>` |
+| `TIMESTAMP` | BSD-style, no year | `Apr 21 13:30:45` |
+| `HOSTNAME` | Same derivation chain as 5424 | `rtr-dc-01` |
+| `TAG` | Catalog entry's `appName` | `IFMGR` |
+| Pid | Always `[-]` (placeholder; simulator doesn't track per-device pids) | `[-]` |
+| `MSG` | Catalog entry's `template` rendered | `Interface ge-0/0/3 changed state to down` |
+
+RFC 3164 has **no structured-data support**; the catalog's
+`structuredData` and `msgId` fields are silently dropped for this
+format. If a catalog entry depends on structured data for
+correlation, stay on 5424.
+
+## PRI calculation
+
+Per RFC 5424 §6.2.1 (shared by both formats):
+
+```
+PRI = facility * 8 + severity
+```
+
+Range 0..191. No leading zeros on the wire.
+
+| Facility name | Value |
+|---------------|-------|
+| `kern` | 0 |
+| `user` | 1 |
+| `mail` | 2 |
+| `daemon` | 3 |
+| `auth` | 4 |
+| `syslog` | 5 |
+| `lpr` | 6 |
+| `news` | 7 |
+| `uucp` | 8 |
+| `cron` | 9 |
+| `authpriv` | 10 |
+| `ftp` | 11 |
+| `local0`..`local7` | 16..23 |
+
+| Severity name | Value | Aliases |
+|---------------|-------|---------|
+| `emerg` | 0 | |
+| `alert` | 1 | |
+| `crit` | 2 | |
+| `err` | 3 | `error` |
+| `warning` | 4 | `warn` |
+| `notice` | 5 | |
+| `info` | 6 | |
+| `debug` | 7 | |
+
+The catalog loader accepts either the canonical name or the integer
+value; out-of-range integers or unknown names are rejected.
+
+## HOSTNAME derivation
+
+Resolved at fire time, in priority order:
+
+1. **Catalog `hostname` template** — if the entry defines a non-empty
+   `hostname` field, render it through the template vocabulary and
+   use the result.
+2. **Device's `sysName.0`** — captured at device construction from
+   the SNMP OID table. Used when the catalog entry has no `hostname`
+   template and the device's sysName is non-empty.
+3. **Device's IPv4** — dotted-quad fallback when sysName is also
+   empty.
+
+Whatever branch fires, the result is passed through hostname
+sanitisation: spaces → hyphens (mandated by both RFCs), non-ASCII
+and control chars → `_`.
+
+## Catalog JSON schema
+
+The embedded universal catalog at
+`go/simulator/resources/_common/syslog.json` is the authoritative
+example:
+
+```json
+{
+  "entries": [
+    {
+      "name": "interface-down",
+      "weight": 40,
+      "facility": "local7",
+      "severity": "error",
+      "appName": "IFMGR",
+      "msgId": "LINKDOWN",
+      "structuredData": {
+        "ifIndex": "{{.IfIndex}}",
+        "ifName": "{{.IfName}}"
+      },
+      "template": "Interface {{.IfName}} (ifIndex={{.IfIndex}}) changed state to down"
+    }
+  ]
+}
+```
+
+Top-level:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `entries` | array | yes | List of catalog entries. Must contain at least one. |
+| `extends` | bool | no (default `true`) | **Per-type overlays only.** Controls whether the per-type catalog merges on top of the universal (`true`) or fully replaces it for devices of that type (`false`). Ignored on the universal catalog itself. |
+
+Per-entry:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `name` | string | yes | Unique within the catalog. Used by the HTTP fire-on-demand endpoint and for log attribution. |
+| `weight` | integer | no (default `1`) | Relative weight for weighted-random selection. Zero means omit from scheduled firing (still reachable via HTTP). |
+| `facility` | string or integer | yes | Canonical name (`kern`..`local7`) or integer 0..23. |
+| `severity` | string or integer | yes | Canonical name (`emerg`..`debug`) or integer 0..7. |
+| `appName` | string | yes | RFC 5424 APP-NAME / RFC 3164 TAG. 1..48 ASCII chars; sanitised at render time. |
+| `msgId` | string | no | RFC 5424 MSGID. Dropped in 3164. |
+| `hostname` | string | no | HOSTNAME override template. Empty means use the default derivation (sysName → DeviceIP). |
+| `structuredData` | object | no | Map of SD-NAME → value-template. Keys must be RFC 5424 §6.3.3 SD-NAME compliant. Dropped entirely in 3164. |
+| `template` | string | yes | MSG body template. |
+
+### Universal catalog (embedded default)
+
+Ships six generic entries matching common network-device semantics:
+
+| Name | Facility.Severity | APP-NAME | MSGID | Weight |
+|------|-------------------|----------|-------|--------|
+| `interface-up` | `local7.notice` | `IFMGR` | `LINKUP` | 40 |
+| `interface-down` | `local7.error` | `IFMGR` | `LINKDOWN` | 40 |
+| `auth-success` | `authpriv.info` | `sshd` | `LOGIN` | 20 |
+| `auth-failure` | `authpriv.warning` | `sshd` | `FAIL` | 20 |
+| `config-change` | `local7.notice` | `SYSMGR` | `CONFIG` | 10 |
+| `system-restart` | `local7.warning` | `SYSMGR` | `RESTART` | 5 |
+
+Weights sum to 135. Interface state dominates; authentication and
+system events round out the tail.
+
+### Template vocabulary
+
+Both the `template` body, `hostname` override, and every value in
+`structuredData` are evaluated as Go `text/template` strings per fire.
+The vocabulary is **unified with the trap subsystem** — the same
+nine fields work on both sides:
+
+| Field | Evaluation |
+|-------|-----------|
+| `{{.IfIndex}}` | Random ifIndex drawn from the device's simulated interface set at fire time |
+| `{{.IfName}}` | `ifDescr.<IfIndex>` live lookup from the device's SNMP OID table; falls back to synthesised `GigabitEthernet0/<N>` on miss |
+| `{{.Uptime}}` | Device uptime in 1/100-second ticks |
+| `{{.Now}}` | Unix epoch seconds |
+| `{{.DeviceIP}}` | Dotted-quad IPv4 of the device |
+| `{{.SysName}}` | Device's `sysName.0` value (captured at construction) |
+| `{{.Model}}` | Human-readable model string derived from device-type slug (e.g., `cisco_ios` → `Cisco IOS`) |
+| `{{.Serial}}` | Deterministic `SN` + 8-hex-digit serial synthesised from the device's IPv4 |
+| `{{.ChassisID}}` | Deterministic locally-administered MAC-style chassis ID synthesised from the device's IPv4 (`02:42:xx:xx:xx:xx`) |
+
+References to any other field are rejected at catalog load.
+Class 2 random-per-fire fields (`PeerIP`, `User`, `SourceIP`,
+`RuleName`, `NeighborRouterID`) are explicitly unsupported — they're
+tracked as follow-up work so syslog entries that semantically
+require them (sshd auth, BGP/OSPF events, firewall rules) are either
+shipped bland or deferred.
+
+## Per-type catalog overlays
+
+Devices can ship vendor-flavoured syslog content via per-type JSON
+files at `resources/<slug>/syslog.json`. When a per-type file exists,
+the simulator merges it with the universal catalog using **name-based
+overlay semantics**:
+
+1. Entries whose names are unique to the per-type file are **added**.
+2. Entries whose names match a universal entry **override** the
+   universal entry for devices of that type.
+3. Universal entries with no matching per-type name **carry through**.
+
+Set `"extends": false` at the top of the per-type file for a pure
+replacement (no universal entries carry through for that type). The
+default is `"extends": true`.
+
+### Shipped vendor catalogs
+
+| Slug | Count | Notable entries |
+|------|-------|-----------------|
+| `cisco_ios` | 8 Cisco-format entries (merged total 14) | `cisco-link-updown-up/down` (`%LINK-3-UPDOWN:`), `cisco-lineproto-updown-up/down` (`%LINEPROTO-5-UPDOWN:`), `cisco-sys-config` (`%SYS-5-CONFIG_I:`), `cisco-snmp-coldstart`, `cisco-sys-restart` (uses `{{.Model}}` / `{{.Serial}}` / `{{.ChassisID}}`), `cisco-envmon-temp-ok` |
+| `juniper_mx240` | 7 Junos-format entries (merged total 13) | `juniper-snmp-link-up/down` (`SNMP_TRAP_LINK_*`), `juniper-mib2d-encaps-mismatch` (`MIB2D_IFD_IFL_ENCAPS_MISMATCH`), `juniper-chassisd-temp-critical` (`CHASSISD_FRU_TEMP_CRITICAL`), `juniper-chassisd-eeprom-fail` (uses `{{.ChassisID}}` / `{{.Serial}}`), `juniper-license-expired`, `juniper-ui-commit-complete` |
+
+Message bodies match the vendor's canonical shape verbatim so
+OpenNMS `syslogd` UEI matchers tuned for Cisco / Juniper strings
+fire correctly. Other cisco_* slugs (`cisco_catalyst_9500`,
+`cisco_crs_x`, etc.), `juniper_mx960`, Arista, Linux, and Palo Alto
+fall back to the universal catalog in this epic — their realistic
+content depends on Class 2 random fields deferred to a follow-up.
+
+Family-catalog concept (one catalog shared by all `cisco_*` slugs,
+one by all `juniper_*`) is also a follow-up refactor.
+
+## HTTP endpoints
+
+### Fire a syslog message on demand
+
+`POST /api/v1/devices/{ip}/syslog` — fires one message for the
+named device immediately, bypassing the Poisson scheduler and the
+global rate cap. Body:
+
+```json
+{
+  "name": "interface-down",
+  "templateOverrides": {
+    "IfIndex": "7",
+    "IfName": "GigabitEthernet0/7"
+  }
+}
+```
+
+`name` is required and must match an entry in the **device's
+resolved catalog** (per-type overlay if present, universal otherwise).
+`templateOverrides` is optional — supplied keys pin the corresponding
+template field for this fire only.
+
+Responses:
+
+| Status | Body | When |
+|--------|------|------|
+| `202 Accepted` | `{}` | Success; the message was emitted. |
+| `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for the device. The enriched body tells the caller which catalog the device resolved to and lists its entries so a scripted caller can self-service. |
+| `404 Not Found` | error JSON | Unknown device IP. |
+| `503 Service Unavailable` | error JSON | Syslog export is disabled (`-syslog-collector` not set). |
+| `500 Internal Server Error` | error JSON | Pathological: catalog resolution returned nil while the feature reports active. Indicates a broken manager invariant, not a transient issue. |
+
+On-demand fires **do not** consume global rate-cap tokens.
+
+### Syslog export status
+
+`GET /api/v1/syslog/status` — current snapshot of the syslog subsystem.
+
+When enabled:
+
+```json
+{
+  "enabled": true,
+  "format": "5424",
+  "collector": "192.168.1.10:514",
+  "sent": 18240,
+  "send_failures": 12,
+  "rate_limiter_tokens_available": 380,
+  "devices_exporting": 100,
+  "catalogs_by_type": {
+    "_universal":    {"entries": 6,  "source": "embedded"},
+    "cisco_ios":     {"entries": 14, "source": "file:resources/cisco_ios/syslog.json"},
+    "juniper_mx240": {"entries": 13, "source": "file:resources/juniper_mx240/syslog.json"}
+  }
+}
+```
+
+Fields:
+
+| Field | Meaning |
+|-------|---------|
+| `enabled` | Feature is active (`-syslog-collector` set and scheduler running). |
+| `format` | `"5424"` or `"3164"`. Absent when disabled. |
+| `collector` | Target `host:port`. |
+| `sent` | Total wire emissions. |
+| `send_failures` | UDP write errors (collector unreachable, socket-level failure). |
+| `rate_limiter_tokens_available` | Present only when `-syslog-global-cap` is set; instantaneous snapshot, not synchronised with concurrent waits. |
+| `devices_exporting` | Device count with an active `SyslogExporter`. |
+| `catalogs_by_type` | Map of `<slug>` → `{entries, source}` showing the merged-catalog state. `_universal` key is always present when the feature is enabled. `source` is `"embedded"`, `"file:<path>"`, or `"override:<path>"` when `-syslog-catalog` was supplied. |
+
+When disabled:
+
+```json
+{"enabled": false}
+```
+
+## CLI flags
+
+Documented with types, defaults, and purposes at
+[CLI flags → UDP syslog export](cli-flags.md#udp-syslog-export-flags).
+
+## Related
+
+- [UDP syslog export (operator guide)](../ops/syslog-export.md) — enabling, per-device source binding, smoke test
+- [SNMP trap reference](snmp-traps.md) — sibling feature; unified template vocabulary and catalog overlay semantics
+- [Web API](web-api.md) — control-plane REST surface
+- Epic [#76](https://github.com/labmonkeys-space/l8opensim/issues/76) for original design and implementation context; epic [#103](https://github.com/labmonkeys-space/l8opensim/issues/103) for per-type catalogs + unified vocabulary

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -19,8 +19,10 @@ management web UI at `/`.
 | `/api/v1/status` | GET | Manager status. |
 | `/api/v1/system-stats` | GET | System stats (file descriptors, memory). |
 | `/api/v1/flows/status` | GET | Flow export status and cumulative counters. |
-| `/api/v1/traps/status` | GET | SNMP trap export status and INFORM counters. |
+| `/api/v1/traps/status` | GET | SNMP trap export status, INFORM counters, and per-type catalog map. |
 | `/api/v1/devices/{ip}/trap` | POST | Fire a named catalog trap on a specific device. |
+| `/api/v1/syslog/status` | GET | UDP syslog export status, counters, and per-type catalog map. |
+| `/api/v1/devices/{ip}/syslog` | POST | Fire a named catalog syslog message on a specific device. |
 | `/health` | GET | Health check endpoint. |
 
 ## Create devices
@@ -177,12 +179,20 @@ response shape):
   "informs_failed": 33,
   "informs_dropped": 0,
   "rate_limiter_tokens_available": 94,
-  "devices_exporting": 100
+  "devices_exporting": 100,
+  "catalogs_by_type": {
+    "_universal":    {"entries": 5,  "source": "embedded"},
+    "cisco_ios":     {"entries": 12, "source": "file:resources/cisco_ios/traps.json"},
+    "juniper_mx240": {"entries": 12, "source": "file:resources/juniper_mx240/traps.json"}
+  }
 }
 ```
 
-In TRAP mode the four `informs_*` fields are omitted. When trap export is
-disabled the response is:
+`catalogs_by_type` keys are device-type slugs (plus the reserved
+`_universal` entry for the fallback catalog). `source` is
+`"embedded"`, `"file:<path>"`, or `"override:<path>"` when
+`-trap-catalog` was supplied. In TRAP mode the four `informs_*`
+fields are omitted. When trap export is disabled the response is:
 
 ```json
 {"enabled": false, "sent": 0, "devices_exporting": 0}
@@ -208,21 +218,79 @@ Request body:
 
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
-| `name` | string | yes | Catalog entry name (e.g. `linkDown`, `linkUp`, `coldStart`). |
-| `varbindOverrides` | object | no | Map of template-field → string-value overrides. Only fields from the catalog template vocabulary are accepted (`IfIndex`, `Uptime`, `Now`, `DeviceIP`). |
+| `name` | string | yes | Catalog entry name (e.g. `linkDown`, `ciscoConfigManEvent`). Must match an entry in the **device's resolved catalog** (per-type overlay if present, universal otherwise) — not the universal catalog globally. |
+| `varbindOverrides` | object | no | Map of template-field → string-value overrides. Only fields from the nine-field unified vocabulary are accepted (`IfIndex`, `IfName`, `Uptime`, `Now`, `DeviceIP`, `SysName`, `Model`, `Serial`, `ChassisID`). |
 
 Response:
 
 | Status | Body | When |
 |--------|------|------|
 | `202 Accepted` | `{"requestId": <uint32>}` | Trap has been enqueued. In INFORM mode the `requestId` is the INFORM PDU's `request-id`. |
-| `400 Bad Request` | error JSON | Malformed JSON body, missing/empty `name`, or unknown catalog entry. |
+| `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for this device. The enriched body reports which catalog the device resolved to (`cisco_ios`, `_universal`, etc.) and lists its entries alphabetically so a scripted caller can fix its call without a separate discovery endpoint. For malformed JSON or missing `name`, the legacy envelope form `{"success": false, "message": "..."}` applies. |
 | `404 Not Found` | error JSON | Unknown device IP. |
-| `500 Internal Server Error` | error JSON | Template resolve or write failure (`Fire` returned 0). |
+| `500 Internal Server Error` | error JSON | Template resolve error, catalog resolution returned nil despite feature active (pathological manager state), or write failure. |
 | `503 Service Unavailable` | error JSON | Trap export is disabled. |
 
 The endpoint does not block waiting for an INFORM ack — use
 `/api/v1/traps/status` to observe INFORM lifecycle counters.
+
+## Syslog export status
+
+```bash
+curl http://localhost:8080/api/v1/syslog/status
+```
+
+When syslog export is enabled:
+
+```json
+{
+  "enabled": true,
+  "format": "5424",
+  "collector": "192.168.1.10:514",
+  "sent": 18240,
+  "send_failures": 12,
+  "rate_limiter_tokens_available": 380,
+  "devices_exporting": 100,
+  "catalogs_by_type": {
+    "_universal":    {"entries": 6,  "source": "embedded"},
+    "cisco_ios":     {"entries": 14, "source": "file:resources/cisco_ios/syslog.json"},
+    "juniper_mx240": {"entries": 13, "source": "file:resources/juniper_mx240/syslog.json"}
+  }
+}
+```
+
+`format` is `"5424"` or `"3164"`. `catalogs_by_type` follows the same
+shape as the trap endpoint. `rate_limiter_tokens_available` is present
+only when `-syslog-global-cap` is set. When disabled the response is
+`{"enabled": false}`.
+
+See [UDP syslog export (operator guide)](../ops/syslog-export.md) and
+[UDP syslog reference](syslog-export.md) for the full feature details.
+
+## Fire a syslog message on demand
+
+```bash
+curl -X POST http://localhost:8080/api/v1/devices/192.168.100.1/syslog \
+  -H "Content-Type: application/json" \
+  -d '{"name":"interface-down","templateOverrides":{"IfIndex":"3"}}'
+```
+
+Request body:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `name` | string | yes | Catalog entry name. Same device's-catalog resolution rule as the trap endpoint. |
+| `templateOverrides` | object | no | Nine-field unified vocabulary (same set as `varbindOverrides` on the trap side). |
+
+Response:
+
+| Status | Body | When |
+|--------|------|------|
+| `202 Accepted` | `{}` | Message emitted. On-demand fires **do not** consume global rate-cap tokens. |
+| `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for this device. Same enriched-error shape as the trap endpoint. |
+| `404 Not Found` | error JSON | Unknown device IP. |
+| `500 Internal Server Error` | error JSON | Pathological catalog-resolution-nil state. |
+| `503 Service Unavailable` | error JSON | Syslog export is disabled. |
 
 ## Device interaction
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'ops/network-namespace',
         'ops/flow-export',
         'ops/snmp-traps',
+        'ops/syslog-export',
         'ops/troubleshooting',
       ],
     },
@@ -42,6 +43,7 @@ const sidebars: SidebarsConfig = {
         'reference/device-types',
         'reference/snmp',
         'reference/snmp-traps',
+        'reference/syslog-export',
         'reference/flow-export',
         'reference/resource-files',
         {


### PR DESCRIPTION
Closes the docs debt from epic #76 (UDP syslog export, merged back in April) and wires in the per-type catalog / unified vocabulary content shipped by epic #103.

## What's in

**New pages**
- \`docs/ops/syslog-export.md\` — operator guide (sibling of \`ops/snmp-traps.md\`)
- \`docs/reference/syslog-export.md\` — wire-format + schema reference (sibling of \`reference/snmp-traps.md\`)

**Updated pages**
- \`docs/ops/snmp-traps.md\` — mentions vendor-flavoured per-type catalogs + links syslog sibling
- \`docs/reference/snmp-traps.md\` — auto-prepended varbinds grow to 3 (snmpTrapEnterprise.0 optional per RFC 3584 §4.1); schema + template vocab extended to 9 fields (unified with syslog); new "Per-type catalog overlays" section; enriched POST 400 body; status JSON gains \`catalogs_by_type\`
- \`docs/reference/cli-flags.md\` — new "UDP syslog export flags" section
- \`docs/reference/web-api.md\` — endpoint catalog grows by 2 rows; full docs for \`/api/v1/syslog/status\` and \`/api/v1/devices/{ip}/syslog\`
- \`sidebars.ts\` — registers the two new doc IDs

## Verification

- \`npm run build\` passes (Docusaurus static build)
- All internal links resolve
- Content matches \`main @ 13dae6a\`