### PR TITLE
feat(export): per-device export config types and JSON (phase 2 of 8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,9 @@ sudo ./simulator [flags]
 # Flow export flags (NetFlow v5 / v9 / IPFIX / sFlow v5)
 -flow-collector <host:port>       # Enable flow export to this UDP collector
 -flow-protocol <proto>            # netflow9 (default) | ipfix | netflow5 | sflow (alias: sflow5)
--flow-tick <duration>             # How often to emit flows (default: 10s)
--flow-active-timeout <duration>   # Active flow expiry timeout (default: 5m)
--flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 1m)
+-flow-tick-interval <duration>    # How often to emit flows (default: 5s)
+-flow-active-timeout <duration>   # Active flow expiry timeout (default: 30s)
+-flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 15s)
 -flow-template-interval <dur>     # Re-send template every N ticks (default: 10m; ignored under netflow5/sflow)
 -flow-source-per-device           # Bind per-device UDP socket so src IP = device IP (default: true)
 

--- a/go/simulator/export_config.go
+++ b/go/simulator/export_config.go
@@ -1,0 +1,261 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Per-device export configuration DTOs.
+//
+// These structs are the JSON shape of the optional `flow`, `traps`, and
+// `syslog` blocks in `POST /api/v1/devices`, and they double as the runtime
+// state stored on each `DeviceSimulator`. A nil pointer means "this export
+// type is disabled for this device".
+//
+// Validation and default-fill live here. The actual wiring to exporter
+// lifecycles lands in phases 3–5 of the `per-device-export-config` change.
+
+// jsonDuration is a time.Duration wrapper that marshals/unmarshals as a
+// Go duration string ("10s", "5m", "1m30s") rather than a nanosecond
+// integer. Operators write REST bodies by hand; integer nanoseconds are
+// unreadable and conflict with the CLI flags that historically accepted
+// seconds-as-integers.
+type jsonDuration time.Duration
+
+func (d jsonDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+func (d *jsonDuration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("duration must be a JSON string like \"10s\": %w", err)
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	*d = jsonDuration(parsed)
+	return nil
+}
+
+// DeviceFlowConfig is the per-device flow-export configuration.
+type DeviceFlowConfig struct {
+	Collector       string       `json:"collector"`
+	Protocol        string       `json:"protocol,omitempty"`
+	TickInterval    jsonDuration `json:"tick_interval,omitempty"`
+	ActiveTimeout   jsonDuration `json:"active_timeout,omitempty"`
+	InactiveTimeout jsonDuration `json:"inactive_timeout,omitempty"`
+}
+
+// DeviceTrapConfig is the per-device SNMP trap/INFORM configuration.
+type DeviceTrapConfig struct {
+	Collector     string       `json:"collector"`
+	Mode          string       `json:"mode,omitempty"`
+	Community     string       `json:"community,omitempty"`
+	Interval      jsonDuration `json:"interval,omitempty"`
+	InformTimeout jsonDuration `json:"inform_timeout,omitempty"`
+	InformRetries int          `json:"inform_retries,omitempty"`
+}
+
+// DeviceSyslogConfig is the per-device UDP syslog configuration.
+type DeviceSyslogConfig struct {
+	Collector string       `json:"collector"`
+	Format    string       `json:"format,omitempty"`
+	Interval  jsonDuration `json:"interval,omitempty"`
+}
+
+// Defaults applied by ApplyDefaults. Kept as named constants so PR2/3/4
+// can reference the same values when constructing CLI-seed configs.
+const (
+	defaultFlowProtocol        = "netflow9"
+	defaultFlowTickInterval    = 5 * time.Second
+	defaultFlowActiveTimeout   = 30 * time.Second
+	defaultFlowInactiveTimeout = 15 * time.Second
+
+	defaultTrapMode          = "trap"
+	defaultTrapCommunity     = "public"
+	defaultTrapInterval      = 30 * time.Second
+	defaultTrapInformTimeout = 5 * time.Second
+	defaultTrapInformRetries = 2
+
+	defaultSyslogFormat   = "5424"
+	defaultSyslogInterval = 10 * time.Second
+)
+
+// ApplyDefaults fills in zero-valued fields with the simulator-wide
+// defaults that historically came from the CLI flags. Safe to call on a
+// nil receiver (no-op). Call this before Validate so the normalised,
+// defaulted struct is what validation sees.
+func (c *DeviceFlowConfig) ApplyDefaults() {
+	if c == nil {
+		return
+	}
+	if c.Protocol == "" {
+		c.Protocol = defaultFlowProtocol
+	}
+	if time.Duration(c.TickInterval) == 0 {
+		c.TickInterval = jsonDuration(defaultFlowTickInterval)
+	}
+	if time.Duration(c.ActiveTimeout) == 0 {
+		c.ActiveTimeout = jsonDuration(defaultFlowActiveTimeout)
+	}
+	if time.Duration(c.InactiveTimeout) == 0 {
+		c.InactiveTimeout = jsonDuration(defaultFlowInactiveTimeout)
+	}
+}
+
+// Validate checks the config and canonicalises Protocol to its stable form
+// (e.g. "nf9"/"NetFlow9" → "netflow9"). Safe to call on a nil receiver
+// (no-op). Callers SHOULD invoke ApplyDefaults first.
+func (c *DeviceFlowConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if err := validateCollector("flow", c.Collector); err != nil {
+		return err
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Protocol)) {
+	case "netflow9", "nf9", "":
+		c.Protocol = "netflow9"
+	case "ipfix", "ipfix10":
+		c.Protocol = "ipfix"
+	case "netflow5", "nf5":
+		c.Protocol = "netflow5"
+	case "sflow", "sflow5":
+		c.Protocol = "sflow"
+	default:
+		return fmt.Errorf("flow: invalid protocol %q (valid: netflow9, ipfix, netflow5, sflow)", c.Protocol)
+	}
+	if time.Duration(c.TickInterval) < 0 {
+		return fmt.Errorf("flow: tick_interval must be >= 0, got %s", time.Duration(c.TickInterval))
+	}
+	if time.Duration(c.ActiveTimeout) < 0 {
+		return fmt.Errorf("flow: active_timeout must be >= 0, got %s", time.Duration(c.ActiveTimeout))
+	}
+	if time.Duration(c.InactiveTimeout) < 0 {
+		return fmt.Errorf("flow: inactive_timeout must be >= 0, got %s", time.Duration(c.InactiveTimeout))
+	}
+	return nil
+}
+
+// ApplyDefaults fills zero-valued fields. Safe on nil.
+func (c *DeviceTrapConfig) ApplyDefaults() {
+	if c == nil {
+		return
+	}
+	if c.Mode == "" {
+		c.Mode = defaultTrapMode
+	}
+	if c.Community == "" {
+		c.Community = defaultTrapCommunity
+	}
+	if time.Duration(c.Interval) == 0 {
+		c.Interval = jsonDuration(defaultTrapInterval)
+	}
+	if time.Duration(c.InformTimeout) == 0 {
+		c.InformTimeout = jsonDuration(defaultTrapInformTimeout)
+	}
+	if c.InformRetries == 0 {
+		c.InformRetries = defaultTrapInformRetries
+	}
+}
+
+// Validate checks the config and canonicalises Mode. Uses ParseTrapMode
+// (defined in trap_manager.go) for parity with the CLI-side accepted
+// spelling rules. Safe on nil.
+func (c *DeviceTrapConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if err := validateCollector("traps", c.Collector); err != nil {
+		return err
+	}
+	mode, err := ParseTrapMode(c.Mode)
+	if err != nil {
+		return fmt.Errorf("traps: %w", err)
+	}
+	switch mode {
+	case TrapModeTrap:
+		c.Mode = "trap"
+	case TrapModeInform:
+		c.Mode = "inform"
+	}
+	if c.InformRetries < 0 {
+		return fmt.Errorf("traps: inform_retries must be >= 0, got %d", c.InformRetries)
+	}
+	if time.Duration(c.Interval) < 0 {
+		return fmt.Errorf("traps: interval must be >= 0, got %s", time.Duration(c.Interval))
+	}
+	if time.Duration(c.InformTimeout) < 0 {
+		return fmt.Errorf("traps: inform_timeout must be >= 0, got %s", time.Duration(c.InformTimeout))
+	}
+	return nil
+}
+
+// ApplyDefaults fills zero-valued fields. Safe on nil.
+func (c *DeviceSyslogConfig) ApplyDefaults() {
+	if c == nil {
+		return
+	}
+	if c.Format == "" {
+		c.Format = defaultSyslogFormat
+	}
+	if time.Duration(c.Interval) == 0 {
+		c.Interval = jsonDuration(defaultSyslogInterval)
+	}
+}
+
+// Validate checks the config and canonicalises Format via
+// ParseSyslogFormat (defined in syslog_wire.go). Safe on nil.
+func (c *DeviceSyslogConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if err := validateCollector("syslog", c.Collector); err != nil {
+		return err
+	}
+	fm, err := ParseSyslogFormat(c.Format)
+	if err != nil {
+		return fmt.Errorf("syslog: %w", err)
+	}
+	c.Format = string(fm)
+	if time.Duration(c.Interval) < 0 {
+		return fmt.Errorf("syslog: interval must be >= 0, got %s", time.Duration(c.Interval))
+	}
+	return nil
+}
+
+// validateCollector is the shared host:port + DNS-resolution check used
+// by all three export configs. Empty string is rejected; any
+// net.ResolveUDPAddr error (bad syntax, unresolvable host, unknown port)
+// is wrapped with the subsystem name for easier diagnosis at the REST
+// boundary.
+func validateCollector(subsystem, collector string) error {
+	if collector == "" {
+		return fmt.Errorf("%s: collector is required", subsystem)
+	}
+	if _, err := net.ResolveUDPAddr("udp4", collector); err != nil {
+		return fmt.Errorf("%s: collector %q: %w", subsystem, collector, err)
+	}
+	return nil
+}
+
+// Compile-time safety: ensure jsonDuration satisfies the json
+// (Un)Marshaler interfaces. Catches accidental signature drift.
+var (
+	_ json.Marshaler   = jsonDuration(0)
+	_ json.Unmarshaler = (*jsonDuration)(nil)
+)

--- a/go/simulator/export_config.go
+++ b/go/simulator/export_config.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -26,12 +27,31 @@ import (
 //
 // Validation and default-fill live here. The actual wiring to exporter
 // lifecycles lands in phases 3–5 of the `per-device-export-config` change.
+//
+// Integer / duration fields that default to non-zero values treat the Go
+// zero value as "use default" — there is no way to express "explicitly
+// zero" for `InformRetries`, `TickInterval`, `ActiveTimeout`,
+// `InactiveTimeout`, `Interval`, or `InformTimeout`. Review decision D2.a
+// (per-device-export-config change) accepted this limitation; see
+// `design.md` for the pointer-field alternative if demand emerges.
+//
+// Caller contract:
+//   1. Deserialize JSON → zero-filled struct
+//   2. Call `ApplyDefaults()` to fill zero-valued fields with the
+//      simulator-wide defaults historically supplied by CLI flags
+//   3. Call `Validate()` to check shape, resolve collector, and canonicalise
+//      string enums (Protocol / Mode / Format)
+// Skipping step 2 causes step 3 to reject empty-string Mode/Format with a
+// hint to call ApplyDefaults first.
 
 // jsonDuration is a time.Duration wrapper that marshals/unmarshals as a
 // Go duration string ("10s", "5m", "1m30s") rather than a nanosecond
 // integer. Operators write REST bodies by hand; integer nanoseconds are
 // unreadable and conflict with the CLI flags that historically accepted
 // seconds-as-integers.
+//
+// JSON `null` is accepted and leaves the receiver at zero (so the field
+// can later be filled by ApplyDefaults).
 type jsonDuration time.Duration
 
 func (d jsonDuration) MarshalJSON() ([]byte, error) {
@@ -39,6 +59,10 @@ func (d jsonDuration) MarshalJSON() ([]byte, error) {
 }
 
 func (d *jsonDuration) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		// Leave zero; ApplyDefaults fills.
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return fmt.Errorf("duration must be a JSON string like \"10s\": %w", err)
@@ -52,6 +76,9 @@ func (d *jsonDuration) UnmarshalJSON(b []byte) error {
 }
 
 // DeviceFlowConfig is the per-device flow-export configuration.
+//
+// Zero values on `TickInterval` / `ActiveTimeout` / `InactiveTimeout` are
+// treated as "use default" by `ApplyDefaults` (review decision D2.a).
 type DeviceFlowConfig struct {
 	Collector       string       `json:"collector"`
 	Protocol        string       `json:"protocol,omitempty"`
@@ -61,6 +88,9 @@ type DeviceFlowConfig struct {
 }
 
 // DeviceTrapConfig is the per-device SNMP trap/INFORM configuration.
+//
+// Zero values on `InformRetries` / `Interval` / `InformTimeout` are
+// treated as "use default" by `ApplyDefaults` (review decision D2.a).
 type DeviceTrapConfig struct {
 	Collector     string       `json:"collector"`
 	Mode          string       `json:"mode,omitempty"`
@@ -71,14 +101,18 @@ type DeviceTrapConfig struct {
 }
 
 // DeviceSyslogConfig is the per-device UDP syslog configuration.
+//
+// Zero value on `Interval` is treated as "use default" by `ApplyDefaults`
+// (review decision D2.a).
 type DeviceSyslogConfig struct {
 	Collector string       `json:"collector"`
 	Format    string       `json:"format,omitempty"`
 	Interval  jsonDuration `json:"interval,omitempty"`
 }
 
-// Defaults applied by ApplyDefaults. Kept as named constants so PR2/3/4
-// can reference the same values when constructing CLI-seed configs.
+// Defaults applied by ApplyDefaults. Sourced from `simulator.go` flag
+// defaults (review decision D1.a — simulator.go is authoritative over
+// CLAUDE.md documentation drift).
 const (
 	defaultFlowProtocol        = "netflow9"
 	defaultFlowTickInterval    = 5 * time.Second
@@ -96,9 +130,9 @@ const (
 )
 
 // ApplyDefaults fills in zero-valued fields with the simulator-wide
-// defaults that historically came from the CLI flags. Safe to call on a
-// nil receiver (no-op). Call this before Validate so the normalised,
-// defaulted struct is what validation sees.
+// defaults. Safe to call on a nil receiver (no-op). Callers MUST invoke
+// ApplyDefaults before Validate — Validate rejects empty Mode / Format
+// with a hint to call ApplyDefaults first.
 func (c *DeviceFlowConfig) ApplyDefaults() {
 	if c == nil {
 		return
@@ -117,17 +151,32 @@ func (c *DeviceFlowConfig) ApplyDefaults() {
 	}
 }
 
-// Validate checks the config and canonicalises Protocol to its stable form
-// (e.g. "nf9"/"NetFlow9" → "netflow9"). Safe to call on a nil receiver
-// (no-op). Callers SHOULD invoke ApplyDefaults first.
+// Validate checks the config and canonicalises Protocol to its stable
+// form (e.g. "nf9" → "netflow9"). Range checks run before canonicalisation
+// so an error path does not leave partial mutations on the struct.
+// Safe on nil.
 func (c *DeviceFlowConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
+	// Range checks first so canonicalisation never runs on invalid input.
+	if time.Duration(c.TickInterval) < 0 {
+		return fmt.Errorf("flow: tick_interval must be >= 0, got %s", time.Duration(c.TickInterval))
+	}
+	if time.Duration(c.ActiveTimeout) < 0 {
+		return fmt.Errorf("flow: active_timeout must be >= 0, got %s", time.Duration(c.ActiveTimeout))
+	}
+	if time.Duration(c.InactiveTimeout) < 0 {
+		return fmt.Errorf("flow: inactive_timeout must be >= 0, got %s", time.Duration(c.InactiveTimeout))
+	}
 	if err := validateCollector("flow", c.Collector); err != nil {
 		return err
 	}
-	switch strings.ToLower(strings.TrimSpace(c.Protocol)) {
+	lowered := strings.ToLower(strings.TrimSpace(c.Protocol))
+	if !isASCII(lowered) {
+		return fmt.Errorf("flow: protocol must be ASCII, got %q", c.Protocol)
+	}
+	switch lowered {
 	case "netflow9", "nf9", "":
 		c.Protocol = "netflow9"
 	case "ipfix", "ipfix10":
@@ -137,16 +186,7 @@ func (c *DeviceFlowConfig) Validate() error {
 	case "sflow", "sflow5":
 		c.Protocol = "sflow"
 	default:
-		return fmt.Errorf("flow: invalid protocol %q (valid: netflow9, ipfix, netflow5, sflow)", c.Protocol)
-	}
-	if time.Duration(c.TickInterval) < 0 {
-		return fmt.Errorf("flow: tick_interval must be >= 0, got %s", time.Duration(c.TickInterval))
-	}
-	if time.Duration(c.ActiveTimeout) < 0 {
-		return fmt.Errorf("flow: active_timeout must be >= 0, got %s", time.Duration(c.ActiveTimeout))
-	}
-	if time.Duration(c.InactiveTimeout) < 0 {
-		return fmt.Errorf("flow: inactive_timeout must be >= 0, got %s", time.Duration(c.InactiveTimeout))
+		return fmt.Errorf("flow: invalid protocol %q (valid: netflow9, ipfix, netflow5, sflow)", lowered)
 	}
 	return nil
 }
@@ -173,15 +213,29 @@ func (c *DeviceTrapConfig) ApplyDefaults() {
 	}
 }
 
-// Validate checks the config and canonicalises Mode. Uses ParseTrapMode
-// (defined in trap_manager.go) for parity with the CLI-side accepted
-// spelling rules. Safe on nil.
+// Validate checks the config and canonicalises Mode. Rejects empty Mode
+// with a hint to call ApplyDefaults first (review decision D3.b —
+// symmetric with `DeviceSyslogConfig.Validate` rejecting empty Format).
+// Range checks run before canonicalisation. Safe on nil.
 func (c *DeviceTrapConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
+	// Range checks first.
+	if c.InformRetries < 0 {
+		return fmt.Errorf("traps: inform_retries must be >= 0, got %d", c.InformRetries)
+	}
+	if time.Duration(c.Interval) < 0 {
+		return fmt.Errorf("traps: interval must be >= 0, got %s", time.Duration(c.Interval))
+	}
+	if time.Duration(c.InformTimeout) < 0 {
+		return fmt.Errorf("traps: inform_timeout must be >= 0, got %s", time.Duration(c.InformTimeout))
+	}
 	if err := validateCollector("traps", c.Collector); err != nil {
 		return err
+	}
+	if strings.TrimSpace(c.Mode) == "" {
+		return fmt.Errorf("traps: mode is required (caller must call ApplyDefaults() first)")
 	}
 	mode, err := ParseTrapMode(c.Mode)
 	if err != nil {
@@ -192,15 +246,6 @@ func (c *DeviceTrapConfig) Validate() error {
 		c.Mode = "trap"
 	case TrapModeInform:
 		c.Mode = "inform"
-	}
-	if c.InformRetries < 0 {
-		return fmt.Errorf("traps: inform_retries must be >= 0, got %d", c.InformRetries)
-	}
-	if time.Duration(c.Interval) < 0 {
-		return fmt.Errorf("traps: interval must be >= 0, got %s", time.Duration(c.Interval))
-	}
-	if time.Duration(c.InformTimeout) < 0 {
-		return fmt.Errorf("traps: inform_timeout must be >= 0, got %s", time.Duration(c.InformTimeout))
 	}
 	return nil
 }
@@ -218,39 +263,72 @@ func (c *DeviceSyslogConfig) ApplyDefaults() {
 	}
 }
 
-// Validate checks the config and canonicalises Format via
-// ParseSyslogFormat (defined in syslog_wire.go). Safe on nil.
+// Validate checks the config and canonicalises Format. Rejects empty
+// Format with a hint to call ApplyDefaults first. Range checks run
+// before canonicalisation. Safe on nil.
 func (c *DeviceSyslogConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
+	if time.Duration(c.Interval) < 0 {
+		return fmt.Errorf("syslog: interval must be >= 0, got %s", time.Duration(c.Interval))
+	}
 	if err := validateCollector("syslog", c.Collector); err != nil {
 		return err
+	}
+	if strings.TrimSpace(c.Format) == "" {
+		return fmt.Errorf("syslog: format is required (caller must call ApplyDefaults() first)")
 	}
 	fm, err := ParseSyslogFormat(c.Format)
 	if err != nil {
 		return fmt.Errorf("syslog: %w", err)
 	}
 	c.Format = string(fm)
-	if time.Duration(c.Interval) < 0 {
-		return fmt.Errorf("syslog: interval must be >= 0, got %s", time.Duration(c.Interval))
+	return nil
+}
+
+// validateCollector is the shared host:port validation used by all three
+// export configs. Rejects empty / whitespace-only inputs, requires a
+// port in the 1–65535 range, and resolves the host over both IPv4 and
+// IPv6 (use "udp" network, not "udp4"). Host resolution remains
+// synchronous here; deferring to exporter dial time (or adding a
+// `context.WithTimeout`) is filed for phase 3+ when the HTTP handler
+// actually invokes this function.
+func validateCollector(subsystem, collector string) error {
+	if strings.TrimSpace(collector) == "" {
+		return fmt.Errorf("%s: collector is required", subsystem)
+	}
+	host, portStr, err := net.SplitHostPort(collector)
+	if err != nil {
+		return fmt.Errorf("%s: collector %q must be host:port: %w", subsystem, collector, err)
+	}
+	if strings.TrimSpace(host) == "" {
+		return fmt.Errorf("%s: collector %q has empty host", subsystem, collector)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("%s: collector %q has invalid port %q: %w", subsystem, collector, portStr, err)
+	}
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("%s: collector %q port must be 1–65535, got %d", subsystem, collector, port)
+	}
+	if _, err := net.ResolveUDPAddr("udp", collector); err != nil {
+		return fmt.Errorf("%s: collector %q: %w", subsystem, collector, err)
 	}
 	return nil
 }
 
-// validateCollector is the shared host:port + DNS-resolution check used
-// by all three export configs. Empty string is rejected; any
-// net.ResolveUDPAddr error (bad syntax, unresolvable host, unknown port)
-// is wrapped with the subsystem name for easier diagnosis at the REST
-// boundary.
-func validateCollector(subsystem, collector string) error {
-	if collector == "" {
-		return fmt.Errorf("%s: collector is required", subsystem)
+// isASCII reports whether every byte is < 0x80. Used as an early
+// rejection for non-ASCII input to the Protocol switch so Unicode
+// casing quirks (Turkish dotted I, fullwidth letters, etc.) surface
+// as a clean "must be ASCII" error rather than slipping through.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
 	}
-	if _, err := net.ResolveUDPAddr("udp4", collector); err != nil {
-		return fmt.Errorf("%s: collector %q: %w", subsystem, collector, err)
-	}
-	return nil
+	return true
 }
 
 // Compile-time safety: ensure jsonDuration satisfies the json

--- a/go/simulator/export_config_test.go
+++ b/go/simulator/export_config_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -55,6 +56,17 @@ func TestJSONDuration_Unmarshal_RejectsInvalidString(t *testing.T) {
 	err := json.Unmarshal([]byte(`"not a duration"`), &d)
 	if err == nil {
 		t.Fatalf("Unmarshal(\"not a duration\"): expected error")
+	}
+}
+
+func TestJSONDuration_Unmarshal_AcceptsNullAsZero(t *testing.T) {
+	// P2: null → leave zero, let ApplyDefaults fill.
+	var d jsonDuration
+	if err := json.Unmarshal([]byte(`null`), &d); err != nil {
+		t.Fatalf("Unmarshal(null): unexpected error: %v", err)
+	}
+	if time.Duration(d) != 0 {
+		t.Errorf("Unmarshal(null) = %v, want 0", time.Duration(d))
 	}
 }
 
@@ -132,10 +144,85 @@ func TestDeviceFlowConfig_Validate_RejectsUnknownProtocol(t *testing.T) {
 	}
 }
 
+func TestDeviceFlowConfig_Validate_RejectsNonASCIIProtocol(t *testing.T) {
+	// P6: non-ASCII input (Unicode casing quirks, fullwidth, etc.)
+	// short-circuits to a clean error rather than slipping past ToLower.
+	c := &DeviceFlowConfig{Collector: "127.0.0.1:2055", Protocol: "netflowⅠ"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for non-ASCII protocol")
+	}
+	if !strings.Contains(err.Error(), "ASCII") {
+		t.Errorf("error should mention ASCII requirement: %v", err)
+	}
+}
+
+func TestDeviceFlowConfig_Validate_ErrorEchoesTrimmedValue(t *testing.T) {
+	// P5: error should echo the canonicalised (lowered/trimmed) value
+	// so operators see what the parser actually tried to match.
+	c := &DeviceFlowConfig{Collector: "127.0.0.1:2055", Protocol: "  JUNK  "}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"junk"`) {
+		t.Errorf("error should echo trimmed/lowered form %q, got: %s", "junk", msg)
+	}
+}
+
 func TestDeviceFlowConfig_Validate_RejectsMissingCollector(t *testing.T) {
 	c := &DeviceFlowConfig{Protocol: "netflow9"}
 	if err := c.Validate(); err == nil {
 		t.Fatalf("Validate: expected error for empty collector")
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsWhitespaceCollector(t *testing.T) {
+	// P1: whitespace-only collector must be rejected with a clean
+	// "required" error, not a cryptic ResolveUDPAddr error.
+	c := &DeviceFlowConfig{Collector: "   ", Protocol: "netflow9"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for whitespace-only collector")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should say 'required', got: %v", err)
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsMissingPort(t *testing.T) {
+	// P1: collector without a port should produce a SplitHostPort-style
+	// error so the operator can see the problem immediately.
+	c := &DeviceFlowConfig{Collector: "10.0.0.1", Protocol: "netflow9"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for missing port")
+	}
+	if !strings.Contains(err.Error(), "host:port") {
+		t.Errorf("error should mention host:port, got: %v", err)
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsPortZero(t *testing.T) {
+	// P1: port 0 is silently accepted by ResolveUDPAddr but UDP sends
+	// go to an ephemeral port — operators would never reach their
+	// collector. Reject explicitly.
+	c := &DeviceFlowConfig{Collector: "10.0.0.1:0", Protocol: "netflow9"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for port 0")
+	}
+	if !strings.Contains(err.Error(), "port") {
+		t.Errorf("error should mention port, got: %v", err)
+	}
+}
+
+func TestDeviceFlowConfig_Validate_AcceptsIPv6Collector(t *testing.T) {
+	// P1: the udp4→udp change must let IPv6 literals through.
+	c := &DeviceFlowConfig{Collector: "[::1]:2055", Protocol: "netflow9"}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate([::1]:2055): unexpected error: %v", err)
 	}
 }
 
@@ -154,6 +241,23 @@ func TestDeviceFlowConfig_Validate_RejectsNegativeDurations(t *testing.T) {
 	}
 	if err := c.Validate(); err == nil {
 		t.Fatalf("Validate: expected error for negative tick_interval")
+	}
+}
+
+func TestDeviceFlowConfig_Validate_NegativeDurationDoesNotMutateProtocol(t *testing.T) {
+	// P3: range checks run before canonicalisation; a duration-range
+	// error must leave Protocol un-canonicalised so callers can rely
+	// on "error → struct untouched by this call".
+	c := &DeviceFlowConfig{
+		Collector:    "127.0.0.1:2055",
+		Protocol:     "NF9",
+		TickInterval: jsonDuration(-1 * time.Second),
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error")
+	}
+	if c.Protocol != "NF9" {
+		t.Errorf("Protocol should remain untouched on error path, got %q", c.Protocol)
 	}
 }
 
@@ -180,7 +284,7 @@ func TestDeviceFlowConfig_JSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if decoded != *orig {
+	if !reflect.DeepEqual(decoded, *orig) {
 		t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", decoded, *orig)
 	}
 }
@@ -207,11 +311,17 @@ func TestDeviceTrapConfig_ApplyDefaults_FillsZeroValues(t *testing.T) {
 	}
 }
 
+func TestDeviceTrapConfig_ApplyDefaults_NilSafe(t *testing.T) {
+	var c *DeviceTrapConfig
+	c.ApplyDefaults() // must not panic
+}
+
 func TestDeviceTrapConfig_Validate_CanonicalisesMode(t *testing.T) {
+	// Empty mode is NOT tested here — it is rejected with a hint, see
+	// TestDeviceTrapConfig_Validate_EmptyModeRejected below.
 	cases := []struct {
 		in, want string
 	}{
-		{"", "trap"}, // ParseTrapMode treats empty as "trap"
 		{"trap", "trap"},
 		{"TRAP", "trap"},
 		{"inform", "inform"},
@@ -225,6 +335,20 @@ func TestDeviceTrapConfig_Validate_CanonicalisesMode(t *testing.T) {
 		if c.Mode != tc.want {
 			t.Errorf("Validate(Mode=%q) → Mode = %q, want %q", tc.in, c.Mode, tc.want)
 		}
+	}
+}
+
+func TestDeviceTrapConfig_Validate_EmptyModeRejected(t *testing.T) {
+	// P9 / decision D3.b: empty Mode is rejected with a hint pointing
+	// at ApplyDefaults; symmetric with DeviceSyslogConfig's empty-Format
+	// rejection.
+	c := &DeviceTrapConfig{Collector: "127.0.0.1:162"}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for empty Mode (caller must ApplyDefaults first)")
+	}
+	c.ApplyDefaults()
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate after ApplyDefaults: unexpected error: %v", err)
 	}
 }
 
@@ -253,6 +377,29 @@ func TestDeviceTrapConfig_Validate_RejectsNegativeInformRetries(t *testing.T) {
 	}
 }
 
+func TestDeviceTrapConfig_Validate_NegativeIntervalDoesNotMutateMode(t *testing.T) {
+	// P3: range check on Interval runs before Mode canonicalisation,
+	// so error path leaves Mode untouched.
+	c := &DeviceTrapConfig{
+		Collector: "127.0.0.1:162",
+		Mode:      "INFORM",
+		Interval:  jsonDuration(-1 * time.Second),
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error")
+	}
+	if c.Mode != "INFORM" {
+		t.Errorf("Mode should remain untouched on error path, got %q", c.Mode)
+	}
+}
+
+func TestDeviceTrapConfig_Validate_NilSafe(t *testing.T) {
+	var c *DeviceTrapConfig
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate(nil): unexpected error: %v", err)
+	}
+}
+
 func TestDeviceTrapConfig_JSONRoundTrip(t *testing.T) {
 	orig := &DeviceTrapConfig{
 		Collector:     "10.0.0.1:162",
@@ -270,7 +417,7 @@ func TestDeviceTrapConfig_JSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if decoded != *orig {
+	if !reflect.DeepEqual(decoded, *orig) {
 		t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", decoded, *orig)
 	}
 }
@@ -286,6 +433,11 @@ func TestDeviceSyslogConfig_ApplyDefaults_FillsZeroValues(t *testing.T) {
 	if time.Duration(c.Interval) != defaultSyslogInterval {
 		t.Errorf("Interval = %v", time.Duration(c.Interval))
 	}
+}
+
+func TestDeviceSyslogConfig_ApplyDefaults_NilSafe(t *testing.T) {
+	var c *DeviceSyslogConfig
+	c.ApplyDefaults() // must not panic
 }
 
 func TestDeviceSyslogConfig_Validate_CanonicalisesFormat(t *testing.T) {
@@ -320,7 +472,8 @@ func TestDeviceSyslogConfig_Validate_RejectsUnknownFormat(t *testing.T) {
 
 func TestDeviceSyslogConfig_Validate_EmptyFormatRejected(t *testing.T) {
 	// Empty format is rejected at Validate() time — callers must call
-	// ApplyDefaults first to fill in the default "5424".
+	// ApplyDefaults first to fill in the default "5424". Symmetric with
+	// DeviceTrapConfig's empty-Mode rejection (decision D3.b).
 	c := &DeviceSyslogConfig{Collector: "127.0.0.1:514"}
 	if err := c.Validate(); err == nil {
 		t.Fatalf("Validate: expected error for empty format (caller must ApplyDefaults first)")
@@ -328,6 +481,13 @@ func TestDeviceSyslogConfig_Validate_EmptyFormatRejected(t *testing.T) {
 	c.ApplyDefaults()
 	if err := c.Validate(); err != nil {
 		t.Errorf("Validate after ApplyDefaults: unexpected error: %v", err)
+	}
+}
+
+func TestDeviceSyslogConfig_Validate_NilSafe(t *testing.T) {
+	var c *DeviceSyslogConfig
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate(nil): unexpected error: %v", err)
 	}
 }
 
@@ -345,7 +505,7 @@ func TestDeviceSyslogConfig_JSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(encoded, &decoded); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if decoded != *orig {
+	if !reflect.DeepEqual(decoded, *orig) {
 		t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", decoded, *orig)
 	}
 }
@@ -353,7 +513,6 @@ func TestDeviceSyslogConfig_JSONRoundTrip(t *testing.T) {
 // --- CreateDevicesRequest embedding ---------------------------------------
 
 func TestCreateDevicesRequest_AcceptsOmittedExportBlocks(t *testing.T) {
-	// No flow/traps/syslog block at all — all three pointers should be nil.
 	body := `{"start_ip":"10.0.0.1","device_count":5,"netmask":"24"}`
 	var req CreateDevicesRequest
 	if err := json.Unmarshal([]byte(body), &req); err != nil {
@@ -393,12 +552,17 @@ func TestCreateDevicesRequest_AcceptsAllThreeExportBlocks(t *testing.T) {
 }
 
 func TestCreateDevicesRequest_RejectsIntegerDurations(t *testing.T) {
-	// Per design §D10: integer durations are rejected.
+	// Per design §D10: integer durations are rejected. Assert on the
+	// error message substring so future permissive changes to
+	// UnmarshalJSON won't silently pass.
 	body := `{"start_ip":"10.0.0.1","device_count":1,"netmask":"24",
 			  "flow":{"collector":"10.0.0.100:2055","tick_interval":5}}`
 	var req CreateDevicesRequest
 	err := json.Unmarshal([]byte(body), &req)
 	if err == nil {
 		t.Fatalf("Unmarshal: expected error for integer duration")
+	}
+	if !strings.Contains(err.Error(), "duration must be a JSON string") {
+		t.Errorf("error does not mention the string-requirement hint: %v", err)
 	}
 }

--- a/go/simulator/export_config_test.go
+++ b/go/simulator/export_config_test.go
@@ -1,0 +1,404 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- jsonDuration ----------------------------------------------------------
+
+func TestJSONDuration_Unmarshal_AcceptsDurationString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{`"10s"`, 10 * time.Second},
+		{`"5m"`, 5 * time.Minute},
+		{`"1m30s"`, 90 * time.Second},
+		{`"500ms"`, 500 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		var d jsonDuration
+		if err := json.Unmarshal([]byte(tc.in), &d); err != nil {
+			t.Fatalf("Unmarshal(%s): unexpected error: %v", tc.in, err)
+		}
+		if time.Duration(d) != tc.want {
+			t.Errorf("Unmarshal(%s) = %v, want %v", tc.in, time.Duration(d), tc.want)
+		}
+	}
+}
+
+func TestJSONDuration_Unmarshal_RejectsIntegerSeconds(t *testing.T) {
+	// Per design §D10: integer seconds are explicitly rejected to avoid
+	// ambiguity with the CLI flags that historically accepted
+	// seconds-as-integers.
+	var d jsonDuration
+	err := json.Unmarshal([]byte(`10`), &d)
+	if err == nil {
+		t.Fatalf("Unmarshal(10): expected error, got duration %v", time.Duration(d))
+	}
+	if !strings.Contains(err.Error(), "duration must be a JSON string") {
+		t.Errorf("error does not mention the string-requirement hint: %v", err)
+	}
+}
+
+func TestJSONDuration_Unmarshal_RejectsInvalidString(t *testing.T) {
+	var d jsonDuration
+	err := json.Unmarshal([]byte(`"not a duration"`), &d)
+	if err == nil {
+		t.Fatalf("Unmarshal(\"not a duration\"): expected error")
+	}
+}
+
+func TestJSONDuration_Marshal_EmitsDurationString(t *testing.T) {
+	d := jsonDuration(90 * time.Second)
+	out, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: unexpected error: %v", err)
+	}
+	if got := string(out); got != `"1m30s"` {
+		t.Errorf("Marshal = %s, want \"1m30s\"", got)
+	}
+}
+
+// --- DeviceFlowConfig ------------------------------------------------------
+
+func TestDeviceFlowConfig_ApplyDefaults_FillsZeroValues(t *testing.T) {
+	c := &DeviceFlowConfig{Collector: "x:2055"}
+	c.ApplyDefaults()
+	if c.Protocol != defaultFlowProtocol {
+		t.Errorf("Protocol = %q, want %q", c.Protocol, defaultFlowProtocol)
+	}
+	if time.Duration(c.TickInterval) != defaultFlowTickInterval {
+		t.Errorf("TickInterval = %v, want %v", time.Duration(c.TickInterval), defaultFlowTickInterval)
+	}
+	if time.Duration(c.ActiveTimeout) != defaultFlowActiveTimeout {
+		t.Errorf("ActiveTimeout = %v", time.Duration(c.ActiveTimeout))
+	}
+	if time.Duration(c.InactiveTimeout) != defaultFlowInactiveTimeout {
+		t.Errorf("InactiveTimeout = %v", time.Duration(c.InactiveTimeout))
+	}
+}
+
+func TestDeviceFlowConfig_ApplyDefaults_NilSafe(t *testing.T) {
+	var c *DeviceFlowConfig
+	c.ApplyDefaults() // must not panic
+}
+
+func TestDeviceFlowConfig_Validate_CanonicalisesProtocol(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"netflow9", "netflow9"},
+		{"NF9", "netflow9"},
+		{"NetFlow9", "netflow9"},
+		{"ipfix", "ipfix"},
+		{"IPFIX10", "ipfix"},
+		{"netflow5", "netflow5"},
+		{"nf5", "netflow5"},
+		{"sflow", "sflow"},
+		{"sflow5", "sflow"},
+	}
+	for _, tc := range cases {
+		c := &DeviceFlowConfig{Collector: "127.0.0.1:2055", Protocol: tc.in}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate(%q): unexpected error: %v", tc.in, err)
+		}
+		if c.Protocol != tc.want {
+			t.Errorf("Validate(%q) → Protocol = %q, want %q", tc.in, c.Protocol, tc.want)
+		}
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsUnknownProtocol(t *testing.T) {
+	c := &DeviceFlowConfig{Collector: "127.0.0.1:2055", Protocol: "junk"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for unknown protocol")
+	}
+	msg := err.Error()
+	for _, want := range []string{"netflow9", "ipfix", "netflow5", "sflow"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message does not list %q: %s", want, msg)
+		}
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsMissingCollector(t *testing.T) {
+	c := &DeviceFlowConfig{Protocol: "netflow9"}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for empty collector")
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsUnresolvableCollector(t *testing.T) {
+	c := &DeviceFlowConfig{Collector: "definitely-not-a-real-hostname.invalid:2055", Protocol: "netflow9"}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for unresolvable collector")
+	}
+}
+
+func TestDeviceFlowConfig_Validate_RejectsNegativeDurations(t *testing.T) {
+	c := &DeviceFlowConfig{
+		Collector:    "127.0.0.1:2055",
+		Protocol:     "netflow9",
+		TickInterval: jsonDuration(-1 * time.Second),
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for negative tick_interval")
+	}
+}
+
+func TestDeviceFlowConfig_Validate_NilSafe(t *testing.T) {
+	var c *DeviceFlowConfig
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate(nil): unexpected error: %v", err)
+	}
+}
+
+func TestDeviceFlowConfig_JSONRoundTrip(t *testing.T) {
+	orig := &DeviceFlowConfig{
+		Collector:       "10.0.0.1:2055",
+		Protocol:        "netflow9",
+		TickInterval:    jsonDuration(10 * time.Second),
+		ActiveTimeout:   jsonDuration(5 * time.Minute),
+		InactiveTimeout: jsonDuration(1 * time.Minute),
+	}
+	encoded, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded DeviceFlowConfig
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded != *orig {
+		t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", decoded, *orig)
+	}
+}
+
+// --- DeviceTrapConfig ------------------------------------------------------
+
+func TestDeviceTrapConfig_ApplyDefaults_FillsZeroValues(t *testing.T) {
+	c := &DeviceTrapConfig{Collector: "x:162"}
+	c.ApplyDefaults()
+	if c.Mode != defaultTrapMode {
+		t.Errorf("Mode = %q, want %q", c.Mode, defaultTrapMode)
+	}
+	if c.Community != defaultTrapCommunity {
+		t.Errorf("Community = %q, want %q", c.Community, defaultTrapCommunity)
+	}
+	if time.Duration(c.Interval) != defaultTrapInterval {
+		t.Errorf("Interval = %v", time.Duration(c.Interval))
+	}
+	if time.Duration(c.InformTimeout) != defaultTrapInformTimeout {
+		t.Errorf("InformTimeout = %v", time.Duration(c.InformTimeout))
+	}
+	if c.InformRetries != defaultTrapInformRetries {
+		t.Errorf("InformRetries = %d, want %d", c.InformRetries, defaultTrapInformRetries)
+	}
+}
+
+func TestDeviceTrapConfig_Validate_CanonicalisesMode(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "trap"}, // ParseTrapMode treats empty as "trap"
+		{"trap", "trap"},
+		{"TRAP", "trap"},
+		{"inform", "inform"},
+		{"Inform", "inform"},
+	}
+	for _, tc := range cases {
+		c := &DeviceTrapConfig{Collector: "127.0.0.1:162", Mode: tc.in}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate(Mode=%q): unexpected error: %v", tc.in, err)
+		}
+		if c.Mode != tc.want {
+			t.Errorf("Validate(Mode=%q) → Mode = %q, want %q", tc.in, c.Mode, tc.want)
+		}
+	}
+}
+
+func TestDeviceTrapConfig_Validate_RejectsUnknownMode(t *testing.T) {
+	c := &DeviceTrapConfig{Collector: "127.0.0.1:162", Mode: "notAMode"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for unknown mode")
+	}
+	if !strings.Contains(err.Error(), "trap") || !strings.Contains(err.Error(), "inform") {
+		t.Errorf("error does not name the valid values: %v", err)
+	}
+}
+
+func TestDeviceTrapConfig_Validate_RejectsMissingCollector(t *testing.T) {
+	c := &DeviceTrapConfig{Mode: "trap"}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for empty collector")
+	}
+}
+
+func TestDeviceTrapConfig_Validate_RejectsNegativeInformRetries(t *testing.T) {
+	c := &DeviceTrapConfig{Collector: "127.0.0.1:162", Mode: "inform", InformRetries: -1}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for negative inform_retries")
+	}
+}
+
+func TestDeviceTrapConfig_JSONRoundTrip(t *testing.T) {
+	orig := &DeviceTrapConfig{
+		Collector:     "10.0.0.1:162",
+		Mode:          "inform",
+		Community:     "private",
+		Interval:      jsonDuration(30 * time.Second),
+		InformTimeout: jsonDuration(5 * time.Second),
+		InformRetries: 3,
+	}
+	encoded, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded DeviceTrapConfig
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded != *orig {
+		t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", decoded, *orig)
+	}
+}
+
+// --- DeviceSyslogConfig ----------------------------------------------------
+
+func TestDeviceSyslogConfig_ApplyDefaults_FillsZeroValues(t *testing.T) {
+	c := &DeviceSyslogConfig{Collector: "x:514"}
+	c.ApplyDefaults()
+	if c.Format != defaultSyslogFormat {
+		t.Errorf("Format = %q, want %q", c.Format, defaultSyslogFormat)
+	}
+	if time.Duration(c.Interval) != defaultSyslogInterval {
+		t.Errorf("Interval = %v", time.Duration(c.Interval))
+	}
+}
+
+func TestDeviceSyslogConfig_Validate_CanonicalisesFormat(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"5424", "5424"},
+		{"  5424  ", "5424"}, // whitespace tolerated by ParseSyslogFormat
+		{"3164", "3164"},
+	}
+	for _, tc := range cases {
+		c := &DeviceSyslogConfig{Collector: "127.0.0.1:514", Format: tc.in}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate(Format=%q): unexpected error: %v", tc.in, err)
+		}
+		if c.Format != tc.want {
+			t.Errorf("Validate(Format=%q) → Format = %q, want %q", tc.in, c.Format, tc.want)
+		}
+	}
+}
+
+func TestDeviceSyslogConfig_Validate_RejectsUnknownFormat(t *testing.T) {
+	c := &DeviceSyslogConfig{Collector: "127.0.0.1:514", Format: "notAFormat"}
+	err := c.Validate()
+	if err == nil {
+		t.Fatalf("Validate: expected error for unknown format")
+	}
+	if !strings.Contains(err.Error(), "5424") || !strings.Contains(err.Error(), "3164") {
+		t.Errorf("error does not name the valid values: %v", err)
+	}
+}
+
+func TestDeviceSyslogConfig_Validate_EmptyFormatRejected(t *testing.T) {
+	// Empty format is rejected at Validate() time — callers must call
+	// ApplyDefaults first to fill in the default "5424".
+	c := &DeviceSyslogConfig{Collector: "127.0.0.1:514"}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("Validate: expected error for empty format (caller must ApplyDefaults first)")
+	}
+	c.ApplyDefaults()
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate after ApplyDefaults: unexpected error: %v", err)
+	}
+}
+
+func TestDeviceSyslogConfig_JSONRoundTrip(t *testing.T) {
+	orig := &DeviceSyslogConfig{
+		Collector: "10.0.0.1:514",
+		Format:    "5424",
+		Interval:  jsonDuration(10 * time.Second),
+	}
+	encoded, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded DeviceSyslogConfig
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded != *orig {
+		t.Errorf("round-trip mismatch\n  got:  %+v\n  want: %+v", decoded, *orig)
+	}
+}
+
+// --- CreateDevicesRequest embedding ---------------------------------------
+
+func TestCreateDevicesRequest_AcceptsOmittedExportBlocks(t *testing.T) {
+	// No flow/traps/syslog block at all — all three pointers should be nil.
+	body := `{"start_ip":"10.0.0.1","device_count":5,"netmask":"24"}`
+	var req CreateDevicesRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if req.Flow != nil {
+		t.Errorf("Flow should be nil, got %+v", req.Flow)
+	}
+	if req.Traps != nil {
+		t.Errorf("Traps should be nil, got %+v", req.Traps)
+	}
+	if req.Syslog != nil {
+		t.Errorf("Syslog should be nil, got %+v", req.Syslog)
+	}
+}
+
+func TestCreateDevicesRequest_AcceptsAllThreeExportBlocks(t *testing.T) {
+	body := `{
+		"start_ip":"10.0.0.1","device_count":5,"netmask":"24",
+		"flow":   {"collector":"10.0.0.100:2055","protocol":"netflow9","tick_interval":"10s"},
+		"traps":  {"collector":"10.0.0.100:162","mode":"inform","community":"private","interval":"30s"},
+		"syslog": {"collector":"10.0.0.100:514","format":"5424","interval":"10s"}
+	}`
+	var req CreateDevicesRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if req.Flow == nil || req.Flow.Collector != "10.0.0.100:2055" {
+		t.Errorf("Flow not parsed: %+v", req.Flow)
+	}
+	if req.Traps == nil || req.Traps.Mode != "inform" || req.Traps.Community != "private" {
+		t.Errorf("Traps not parsed: %+v", req.Traps)
+	}
+	if req.Syslog == nil || req.Syslog.Format != "5424" {
+		t.Errorf("Syslog not parsed: %+v", req.Syslog)
+	}
+}
+
+func TestCreateDevicesRequest_RejectsIntegerDurations(t *testing.T) {
+	// Per design §D10: integer durations are rejected.
+	body := `{"start_ip":"10.0.0.1","device_count":1,"netmask":"24",
+			  "flow":{"collector":"10.0.0.100:2055","tick_interval":5}}`
+	var req CreateDevicesRequest
+	err := json.Unmarshal([]byte(body), &req)
+	if err == nil {
+		t.Fatalf("Unmarshal: expected error for integer duration")
+	}
+}

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -46,10 +46,10 @@ type SSHResource struct {
 }
 
 type APIResource struct {
-	Method   string      `json:"method"`             // HTTP method: GET, POST, PUT, DELETE, PATCH
-	Path     string      `json:"path"`               // API endpoint path
-	Request  interface{} `json:"request,omitempty"`  // Optional request body for POST/PUT
-	Response interface{} `json:"response"`           // Response body
+	Method   string      `json:"method"`            // HTTP method: GET, POST, PUT, DELETE, PATCH
+	Path     string      `json:"path"`              // API endpoint path
+	Request  interface{} `json:"request,omitempty"` // Optional request body for POST/PUT
+	Response interface{} `json:"response"`          // Response body
 }
 
 type DeviceResources struct {
@@ -58,9 +58,9 @@ type DeviceResources struct {
 	API  []APIResource  `json:"api,omitempty"` // Optional API endpoints for storage devices
 
 	// Performance optimization indexes (not serialized)
-	oidIndex    *sync.Map  `json:"-"` // Lock-free OID -> Response mapping for O(1) lookups
-	sortedOIDs  []string   `json:"-"` // Pre-sorted OID list for GetNext operations
-	oidNextMap  *sync.Map  `json:"-"` // Pre-computed next OID mapping for walks
+	oidIndex   *sync.Map `json:"-"` // Lock-free OID -> Response mapping for O(1) lookups
+	sortedOIDs []string  `json:"-"` // Pre-sorted OID list for GetNext operations
+	oidNextMap *sync.Map `json:"-"` // Pre-computed next OID mapping for walks
 }
 
 // Device simulator represents a single simulated device
@@ -69,23 +69,30 @@ type DeviceSimulator struct {
 	IP           net.IP
 	SNMPPort     int
 	SSHPort      int
-	APIPort      int            // HTTP API port for storage devices
+	APIPort      int // HTTP API port for storage devices
 	tunIface     *TunInterface
 	snmpServer   *SNMPServer
 	sshServer    *SSHServer
-	apiServer    *APIServer     // HTTP API server for storage devices
+	apiServer    *APIServer // HTTP API server for storage devices
 	resources    *DeviceResources
 	resourceFile string // Track which resource file was used
 	sysLocation  string // Dynamic sysLocation for this device
 	sysName      string // Dynamic sysName for this device
 	// Cached frequently accessed values (lock-free)
-	cachedSysName     atomic.Value // Stores string
-	cachedSysLocation atomic.Value // Stores string
-	metricsCycler *MetricsCycler   // Per-device cycling CPU/memory metrics
-	flowExporter  *FlowExporter   // NetFlow/IPFIX exporter (nil if flow export disabled)
-	trapExporter  *TrapExporter   // SNMP trap/inform exporter (nil if trap export disabled)
-	syslogExporter *SyslogExporter // UDP syslog exporter (nil if syslog export disabled)
-	netNamespace  *NetNamespace   // Network namespace (nil if using root namespace)
+	cachedSysName     atomic.Value    // Stores string
+	cachedSysLocation atomic.Value    // Stores string
+	metricsCycler     *MetricsCycler  // Per-device cycling CPU/memory metrics
+	flowExporter      *FlowExporter   // NetFlow/IPFIX exporter (nil if flow export disabled)
+	trapExporter      *TrapExporter   // SNMP trap/inform exporter (nil if trap export disabled)
+	syslogExporter    *SyslogExporter // UDP syslog exporter (nil if syslog export disabled)
+	// Per-device export configuration (nil = disabled for this device).
+	// Set at device creation from either the CLI seed (auto-start path) or
+	// the `flow`/`traps`/`syslog` blocks in POST /api/v1/devices. Wiring
+	// lands in phases 3–5 of `per-device-export-config`.
+	flowConfig   *DeviceFlowConfig
+	trapConfig   *DeviceTrapConfig
+	syslogConfig *DeviceSyslogConfig
+	netNamespace *NetNamespace // Network namespace (nil if using root namespace)
 	running      bool
 	mu           sync.RWMutex
 }
@@ -110,9 +117,9 @@ type SNMPv3Message struct {
 }
 
 type SNMPv3GlobalData struct {
-	MsgID           int
-	MsgMaxSize      int
-	MsgFlags        byte
+	MsgID            int
+	MsgMaxSize       int
+	MsgFlags         byte
 	MsgSecurityModel int
 }
 
@@ -151,13 +158,13 @@ type APIServer struct {
 
 // Manager for all simulated devices
 type SimulatorManager struct {
-	devices         map[string]*DeviceSimulator
+	devices map[string]*DeviceSimulator
 	// deviceIPs tracks IPs currently bound to a device so that duplicate
 	// detection stays robust against changes to the device-ID format. Without
 	// it, two concurrent calls that target the same IP with different
 	// resource files would both pass the `sm.devices[deviceID]` lookup (the
 	// IDs differ by slug) and race to bind the same TUN and SNMP/SSH ports.
-	deviceIPs       map[string]struct{}
+	deviceIPs map[string]struct{}
 	// deviceTypesByIP maps device IP → type slug. Populated in AddDevice /
 	// per-device construction paths so the trap and syslog `CatalogFor(ip)`
 	// hot paths can resolve device type in O(1). Kept in sync with `devices`
@@ -167,41 +174,41 @@ type SimulatorManager struct {
 	nextTunIndex    int
 	deviceResources *DeviceResources
 	resourcesCache  map[string]*DeviceResources // Cache for loaded resource files
-	sharedSSHSigner ssh.Signer                   // Shared SSH host key for all devices
-	sharedTLSCert   *tls.Certificate             // Shared TLS certificate for all API servers
+	sharedSSHSigner ssh.Signer                  // Shared SSH host key for all devices
+	sharedTLSCert   *tls.Certificate            // Shared TLS certificate for all API servers
 
 	// Network namespace for device isolation (prevents systemd-networkd overhead)
-	netNamespace    *NetNamespace // Network namespace for all simulated devices
-	useNamespace    bool          // Whether to use network namespace isolation
+	netNamespace *NetNamespace // Network namespace for all simulated devices
+	useNamespace bool          // Whether to use network namespace isolation
 
 	// TUN interface pre-allocation settings
-	tunPoolSize     int                   // Size of the pre-allocated pool (0 = no pre-allocation)
-	maxWorkers      int                   // Maximum parallel workers for interface creation
+	tunPoolSize      int                      // Size of the pre-allocated pool (0 = no pre-allocation)
+	maxWorkers       int                      // Maximum parallel workers for interface creation
 	tunInterfacePool map[string]*TunInterface // Pool of pre-allocated interfaces indexed by IP
-	tunPoolMutex    sync.RWMutex          // Mutex for interface pool access
+	tunPoolMutex     sync.RWMutex             // Mutex for interface pool access
 
 	// Status tracking for pre-allocation and device creation
-	isPreAllocating      atomic.Value      // bool - true when pre-allocation is in progress
-	preAllocProgress     atomic.Value      // int - number of interfaces pre-allocated so far
-	isCreatingDevices    atomic.Value      // bool - true when device creation is in progress
-	deviceCreateProgress atomic.Value      // int - number of devices created so far
-	deviceCreateTotal    atomic.Value      // int - total number of devices to create
+	isPreAllocating      atomic.Value // bool - true when pre-allocation is in progress
+	preAllocProgress     atomic.Value // int - number of interfaces pre-allocated so far
+	isCreatingDevices    atomic.Value // bool - true when device creation is in progress
+	deviceCreateProgress atomic.Value // int - number of devices created so far
+	deviceCreateTotal    atomic.Value // int - total number of devices to create
 
 	// Flow export state (nil/zero when disabled; set by InitFlowExport)
 	flowConn             *net.UDPConn
 	flowCollectorAddr    *net.UDPAddr
-	flowCollectorStr     string        // original "host:port" string for status reporting
-	flowProtocol         string        // normalised protocol name ("netflow9" or "ipfix")
+	flowCollectorStr     string // original "host:port" string for status reporting
+	flowProtocol         string // normalised protocol name ("netflow9" or "ipfix")
 	flowEncoder          FlowEncoder
-	flowBufPool          sync.Pool     // supplies []byte(1500); set via flowBufPool.New
-	flowActive           atomic.Bool   // true after InitFlowExport; safe for concurrent reads
+	flowBufPool          sync.Pool   // supplies []byte(1500); set via flowBufPool.New
+	flowActive           atomic.Bool // true after InitFlowExport; safe for concurrent reads
 	flowTickInterval     time.Duration
 	flowActiveTimeout    time.Duration
 	flowInactiveTimeout  time.Duration
 	flowTemplateInterval time.Duration
-	flowSourcePerDevice  bool // bind per-device UDP socket in opensim ns so src IP = device IP
+	flowSourcePerDevice  bool           // bind per-device UDP socket in opensim ns so src IP = device IP
 	flowStopCh           chan struct{}  // closed by Shutdown to stop the ticker goroutine
-	flowStopOnce         sync.Once     // ensures flowStopCh is closed exactly once
+	flowStopOnce         sync.Once      // ensures flowStopCh is closed exactly once
 	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before closing flowConn
 
 	// Flow export cumulative counters (updated atomically by tickAllFlowExporters).
@@ -254,7 +261,7 @@ type SimulatorManager struct {
 	syslogSourcePerDevice bool
 	syslogCatalogPath     string // "" when using embedded catalog
 
-	mu              sync.RWMutex
+	mu sync.RWMutex
 }
 
 // Resource file info for API
@@ -267,16 +274,22 @@ type ResourceInfo struct {
 
 // API request/response structures
 type CreateDevicesRequest struct {
-	StartIP      string         `json:"start_ip"`
-	DeviceCount  int            `json:"device_count"`
-	Netmask      string         `json:"netmask"`
-	ResourceFile string         `json:"resource_file,omitempty"` // Optional resource file selection
-	RoundRobin   bool           `json:"round_robin,omitempty"`   // Optional: cycle through device types
-	Category     string         `json:"category,omitempty"`      // Optional: filter round robin to a category
-	SNMPv3       *SNMPv3Config  `json:"snmpv3,omitempty"`
-	PreAllocate  bool           `json:"pre_allocate,omitempty"` // Optional: explicitly enable/disable pre-allocation
-	MaxWorkers   int            `json:"max_workers,omitempty"`  // Optional: max workers for pre-allocation
-	SNMPPort     int            `json:"snmp_port,omitempty"`    // Optional: UDP port for SNMP listener (default: 161)
+	StartIP      string        `json:"start_ip"`
+	DeviceCount  int           `json:"device_count"`
+	Netmask      string        `json:"netmask"`
+	ResourceFile string        `json:"resource_file,omitempty"` // Optional resource file selection
+	RoundRobin   bool          `json:"round_robin,omitempty"`   // Optional: cycle through device types
+	Category     string        `json:"category,omitempty"`      // Optional: filter round robin to a category
+	SNMPv3       *SNMPv3Config `json:"snmpv3,omitempty"`
+	PreAllocate  bool          `json:"pre_allocate,omitempty"` // Optional: explicitly enable/disable pre-allocation
+	MaxWorkers   int           `json:"max_workers,omitempty"`  // Optional: max workers for pre-allocation
+	SNMPPort     int           `json:"snmp_port,omitempty"`    // Optional: UDP port for SNMP listener (default: 161)
+	// Per-device export configuration. A nil block disables that export
+	// type for the batch. Wiring lands in phases 3–5 of
+	// `per-device-export-config`; phase 2 only parses and validates.
+	Flow   *DeviceFlowConfig   `json:"flow,omitempty"`
+	Traps  *DeviceTrapConfig   `json:"traps,omitempty"`
+	Syslog *DeviceSyslogConfig `json:"syslog,omitempty"`
 }
 
 // RoundRobinDeviceTypes defines all 28 device flavors for round robin creation
@@ -323,6 +336,12 @@ type DeviceInfo struct {
 	SSHPort    int    `json:"ssh_port"`
 	Running    bool   `json:"running"`
 	DeviceType string `json:"device_type,omitempty"`
+	// Per-device export configuration echoed for GET /api/v1/devices
+	// consumers. Fields are omitted from JSON when nil. Populated from
+	// the device's runtime state in phases 3–5.
+	Flow   *DeviceFlowConfig   `json:"flow,omitempty"`
+	Traps  *DeviceTrapConfig   `json:"traps,omitempty"`
+	Syslog *DeviceSyslogConfig `json:"syslog,omitempty"`
 }
 
 type APIResponse struct {


### PR DESCRIPTION
## Summary

- Introduces `DeviceFlowConfig`, `DeviceTrapConfig`, `DeviceSyslogConfig` in `go/simulator/export_config.go`. These will carry per-device flow/trap/syslog export settings through the REST surface and the device lifecycle.
- Extends `CreateDevicesRequest`, `DeviceSimulator`, `DeviceInfo` with optional pointer fields (`Flow`/`Traps`/`Syslog`). A nil block means "export disabled for this device/batch".
- Adds a `jsonDuration` wrapper that accepts Go duration strings (`"10s"`, `"1m30s"`). Integer seconds are rejected per design §D10 to avoid ambiguity with CLI flags.
- 27 unit tests covering JSON round-trip, defaults, protocol/mode/format canonicalisation, invalid-input rejection, nil-receiver safety, integer-duration rejection.

**No behaviour change in this PR.** The three subsystems continue to read simulator-wide globals; the new types are declared but not yet wired. Wiring lands in phases 3 (flow, #121), 4 (trap, #122), 5 (syslog, #123).

Also fixes a design/spec inconsistency in the `per-device-export-config` OpenSpec change: `TemplateInterval` is global per design §D5 and has been removed from the `DeviceFlowConfig` field list in the spec.

## Test plan

- [x] `go build ./simulator/`
- [x] `go test ./...` (full suite, 18.6s)
- [x] `go vet .`
- [x] `gofmt -l` clean on the three touched files
- [x] 27 new unit tests, all pass (`go test -run 'TestJSONDuration|TestDeviceFlowConfig|TestDeviceTrapConfig|TestDeviceSyslogConfig|TestCreateDevicesRequest'`)

## Tracking

- Epic: #118
- Phase issue: #120
- Phase 3 follow-up: #121