### PR TITLE
feat(export)!: per-device flow export configuration (phase 3 of 8)

### DIFF
--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -36,12 +36,15 @@ func makeDeviceID(ip net.IP, typeSlug string) string {
 	return fmt.Sprintf("%s-%s", typeSlug, ip.String())
 }
 
-func (sm *SimulatorManager) CreateDevices(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, roundRobin bool, category string, snmpPort int) error {
-	return sm.CreateDevicesWithOptions(startIP, count, netmask, resourceFile, v3Config, true, 0, roundRobin, category, snmpPort)
+func (sm *SimulatorManager) CreateDevices(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, roundRobin bool, category string, snmpPort int, seed *ExportSeed) error {
+	return sm.CreateDevicesWithOptions(startIP, count, netmask, resourceFile, v3Config, true, 0, roundRobin, category, snmpPort, seed)
 }
 
-// CreateDevicesWithOptions creates devices with optional pre-allocation control
-func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, preAllocate bool, maxWorkers int, roundRobin bool, category string, snmpPort int) error {
+// CreateDevicesWithOptions creates devices with optional pre-allocation control.
+// `seed`, when non-nil, populates every created device's `flowConfig` /
+// `trapConfig` / `syslogConfig` pointer fields with a copy of the seed's
+// non-nil blocks (per-device-export-config phase 3).
+func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, netmask string, resourceFile string, v3Config *SNMPv3Config, preAllocate bool, maxWorkers int, roundRobin bool, category string, snmpPort int, seed *ExportSeed) error {
 	if snmpPort == 0 {
 		snmpPort = DEFAULT_SNMP_PORT
 	}
@@ -162,7 +165,7 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 
 	if sm.tunPoolSize > 0 {
 		// Pre-allocation was done - create devices in parallel
-		sm.createDevicesParallel(count, netmask, resourceFile, resources, v3Config, &successCount, roundRobin, roundRobinResources, roundRobinResourceFiles, snmpPort)
+		sm.createDevicesParallel(count, netmask, resourceFile, resources, v3Config, &successCount, roundRobin, roundRobinResources, roundRobinResourceFiles, snmpPort, seed)
 	} else {
 		// No pre-allocation - create devices sequentially (original logic)
 		for i := 0; i < count; i++ {
@@ -263,13 +266,18 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			device.metricsCycler.InitGPUMetrics(int64(i), profile.GPU)
 			device.metricsCycler.InitIfCounters(deviceResources, int64(i)^0x4843_0000)
 
-			// Initialize flow exporter if flow export is enabled.
-			if sm.flowActive.Load() {
+			// Apply the batch-level export seed to this device (phase 3).
+			// A nil seed or nil block means "no export of this type for this
+			// device"; a non-nil block is copied so subsequent mutations
+			// don't leak across devices.
+			applyExportSeed(device, seed)
+
+			// Initialize flow exporter if this device has flow config.
+			if device.flowConfig != nil {
 				flowProfile := GetFlowProfile(deviceResourceFile)
-				device.flowExporter = NewFlowExporter(device, flowProfile,
-					sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
-				sm.openFlowConnForDevice(device)
-				sm.registerSFlowCounterSources(device)
+				if err := sm.attachFlowExporter(device, flowProfile); err != nil {
+					log.Printf("flow export: skipping device %s: %v", device.IP, err)
+				}
 			}
 
 			// Register device type BEFORE starting exporters. startDevice*Exporter
@@ -380,8 +388,10 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 	return nil
 }
 
-// createDevicesParallel creates devices in parallel when pre-allocation was done
-func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, successCount *int, roundRobin bool, roundRobinResources []*DeviceResources, roundRobinResourceFiles []string, snmpPort int) {
+// createDevicesParallel creates devices in parallel when pre-allocation was done.
+// `seed` is propagated verbatim to every worker; each worker passes it into
+// `createSingleDevice` which copies per-device.
+func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, successCount *int, roundRobin bool, roundRobinResources []*DeviceResources, roundRobinResourceFiles []string, snmpPort int, seed *ExportSeed) {
 	// Worker pool for parallel device creation
 	sem := make(chan struct{}, sm.maxWorkers) // Limit concurrent workers
 	var wg sync.WaitGroup
@@ -441,7 +451,7 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 			defer func() { <-sem }()
 
 			// Create device in parallel
-			if sm.createSingleDevice(deviceIndex, ip, devID, netmask, devResourceFile, devResources, v3Config, snmpPort) {
+			if sm.createSingleDevice(deviceIndex, ip, devID, netmask, devResourceFile, devResources, v3Config, snmpPort, seed) {
 				mu.Lock()
 				(*successCount)++
 				progress := *successCount
@@ -465,8 +475,9 @@ func (sm *SimulatorManager) createDevicesParallel(count int, netmask string, res
 	log.Printf("Parallel creation rate: %.2f devices/second", float64(*successCount)/parallelElapsed.Seconds())
 }
 
-// createSingleDevice creates a single device - used by parallel device creation
-func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP, deviceID string, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, snmpPort int) bool {
+// createSingleDevice creates a single device - used by parallel device creation.
+// `seed` propagates the batch-level export configuration (phase 3).
+func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP, deviceID string, netmask string, resourceFile string, resources *DeviceResources, v3Config *SNMPv3Config, snmpPort int, seed *ExportSeed) bool {
 	// Check if we have a pre-allocated interface for this IP
 	var tunIface *TunInterface
 
@@ -524,13 +535,17 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	device.metricsCycler.InitGPUMetrics(int64(deviceIndex), profile.GPU)
 	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex)^0x4843_0000)
 
-	// Initialize flow exporter if flow export is enabled.
-	if sm.flowActive.Load() {
+	// Apply the batch-level export seed (phase 3). Parallel workers see
+	// the same seed pointer; each device gets its own copy via
+	// applyExportSeed so downstream mutations don't race.
+	applyExportSeed(device, seed)
+
+	// Initialize flow exporter if this device has flow config.
+	if device.flowConfig != nil {
 		flowProfile := GetFlowProfile(resourceFile)
-		device.flowExporter = NewFlowExporter(device, flowProfile,
-			sm.flowActiveTimeout, sm.flowInactiveTimeout, sm.flowTemplateInterval)
-		sm.openFlowConnForDevice(device)
-		sm.registerSFlowCounterSources(device)
+		if err := sm.attachFlowExporter(device, flowProfile); err != nil {
+			log.Printf("flow export: skipping device %s: %v", device.IP, err)
+		}
 	}
 
 	// Register device type BEFORE starting exporters so scheduler fires

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -277,6 +277,9 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 				flowProfile := GetFlowProfile(deviceResourceFile)
 				if err := sm.attachFlowExporter(device, flowProfile); err != nil {
 					log.Printf("flow export: skipping device %s: %v", device.IP, err)
+					// Nil out flowConfig so ListDevices doesn't show
+					// config that has no live exporter (review fix P5).
+					device.flowConfig = nil
 				}
 			}
 
@@ -545,6 +548,9 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 		flowProfile := GetFlowProfile(resourceFile)
 		if err := sm.attachFlowExporter(device, flowProfile); err != nil {
 			log.Printf("flow export: skipping device %s: %v", device.IP, err)
+			// Nil out flowConfig so ListDevices doesn't show config
+			// that has no live exporter (review fix P5).
+			device.flowConfig = nil
 		}
 	}
 
@@ -699,6 +705,13 @@ func (d *DeviceSimulator) Stop() error {
 	}
 
 	if d.flowExporter != nil {
+		// Persist cumulative counters into the simulator-wide
+		// per-collector aggregate (review decision D1.b) BEFORE closing
+		// the exporter so /flows/status reports monotonic totals. The
+		// outer `if !d.running` guard above makes this single-shot.
+		if manager != nil {
+			manager.persistFlowCounters(d.flowExporter)
+		}
 		d.flowExporter.Close() //nolint:errcheck
 	}
 
@@ -755,6 +768,11 @@ func (d *DeviceSimulator) stopListenersOnly() {
 		d.apiServer.Stop()
 	}
 	if d.flowExporter != nil {
+		// Persist counters before Close (review decision D1.b). The
+		// `if !d.running` early-return above makes this single-shot.
+		if manager != nil {
+			manager.persistFlowCounters(d.flowExporter)
+		}
 		d.flowExporter.Close() //nolint:errcheck
 	}
 	if d.trapExporter != nil {

--- a/go/simulator/export_config.go
+++ b/go/simulator/export_config.go
@@ -331,6 +331,29 @@ func isASCII(s string) bool {
 	return true
 }
 
+// applyExportSeed copies a batch-level ExportSeed onto a newly-constructed
+// device. Each non-nil block in the seed is copied so every device in the
+// batch gets its own pointer; downstream mutations don't leak across
+// devices in the fleet. Safe to call with a nil seed (no-op) or nil
+// blocks (partial seed).
+func applyExportSeed(device *DeviceSimulator, seed *ExportSeed) {
+	if device == nil || seed == nil {
+		return
+	}
+	if seed.Flow != nil {
+		f := *seed.Flow
+		device.flowConfig = &f
+	}
+	if seed.Traps != nil {
+		t := *seed.Traps
+		device.trapConfig = &t
+	}
+	if seed.Syslog != nil {
+		s := *seed.Syslog
+		device.syslogConfig = &s
+	}
+}
+
 // Compile-time safety: ensure jsonDuration satisfies the json
 // (Un)Marshaler interfaces. Catches accidental signature drift.
 var (

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -105,10 +105,17 @@ type FlowExporter struct {
 	encoder       FlowEncoder
 
 	// Per-exporter cumulative counters. Summed at status-endpoint read
-	// time to produce FlowStatus.Collectors aggregates.
+	// time and persisted into the simulator-wide per-collector aggregate
+	// when the device is deleted, so /api/v1/flows/status exposes
+	// monotonic totals even as devices come and go.
 	statPackets atomic.Uint64
 	statBytes   atomic.Uint64
 	statRecords atomic.Uint64
+
+	// firstWriteErr ensures we log at most one write-failure message per
+	// exporter; silent swallowing of WriteTo errors was an observability
+	// hole flagged in the phase 3 review (P6).
+	firstWriteErr sync.Once
 
 	// conn is the per-device UDP socket (nil = use shared pool). atomic.Pointer
 	// so Tick (ticker goroutine) and Close (device-shutdown paths) can read and
@@ -166,6 +173,19 @@ func (fe *FlowExporter) Close() error {
 		return nil
 	}
 	return conn.Close()
+}
+
+// logFirstWriteErr emits at most one log line per exporter on a failed
+// WriteTo. Gated by fe.firstWriteErr so a down/misconfigured collector
+// doesn't flood logs at tick cadence × device count.
+func (fe *FlowExporter) logFirstWriteErr(err error) {
+	if fe == nil {
+		return
+	}
+	fe.firstWriteErr.Do(func() {
+		log.Printf("flow export: device %s write to %s failed: %v (further errors suppressed for this exporter)",
+			domainIDtoIP(fe.domainID), fe.collectorStr, err)
+	})
 }
 
 // Tick is called by the shared SimulatorManager ticker goroutine on every
@@ -271,7 +291,9 @@ func (fe *FlowExporter) Tick(now time.Time, sharedConn *net.UDPConn, bufPool *sy
 			break
 		}
 
-		writeConn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
+		if _, err := writeConn.WriteTo(buf[:n], collectorAddr); err != nil {
+			fe.logFirstWriteErr(err)
+		}
 		stats.PacketsSent++
 		stats.BytesSent += uint64(n)
 		stats.RecordsSent += uint64(len(batch))
@@ -321,7 +343,9 @@ func (fe *FlowExporter) Tick(now time.Time, sharedConn *net.UDPConn, bufPool *sy
 			if err != nil || n == 0 {
 				break
 			}
-			writeConn.WriteTo(buf[:n], collectorAddr) //nolint:errcheck
+			if _, err := writeConn.WriteTo(buf[:n], collectorAddr); err != nil {
+				fe.logFirstWriteErr(err)
+			}
 			stats.PacketsSent++
 			stats.BytesSent += uint64(n)
 			fe.seqNo++
@@ -415,7 +439,10 @@ func (sm *SimulatorManager) flowConnFor(key flowConnKey) *net.UDPConn {
 }
 
 // closeFlowConnPool closes every pooled shared socket. Called from
-// Shutdown after the ticker goroutine has exited.
+// Shutdown after the ticker goroutine has exited. Does NOT reassign
+// `sm.flowConns` — the manager is being torn down, the map value goes
+// out of scope with it, and reassigning a concurrent sync.Map field is
+// racy by itself.
 func (sm *SimulatorManager) closeFlowConnPool() {
 	sm.flowConns.Range(func(_, v interface{}) bool {
 		if conn, ok := v.(*net.UDPConn); ok {
@@ -423,7 +450,35 @@ func (sm *SimulatorManager) closeFlowConnPool() {
 		}
 		return true
 	})
-	sm.flowConns = sync.Map{}
+}
+
+// flowCollectorAggregate holds monotonic counters for a
+// (collector, protocol) tuple that survive device deletion. Written
+// by `persistFlowCounters` on device Stop; read by `GetFlowStatus` and
+// merged with live-exporter counters to produce cumulative totals.
+type flowCollectorAggregate struct {
+	packets atomic.Uint64
+	bytes   atomic.Uint64
+	records atomic.Uint64
+}
+
+// persistFlowCounters snapshots a FlowExporter's cumulative counters
+// into the simulator-wide per-collector aggregate so /flows/status
+// reports monotonic totals even as devices come and go (review
+// decision D1.b). Called from the device lifecycle immediately before
+// `FlowExporter.Close()`. Safe to call with nil exporter; idempotent
+// only in the sense that calling it twice will DOUBLE the persisted
+// counters — callers MUST invoke it at most once per exporter.
+func (sm *SimulatorManager) persistFlowCounters(fe *FlowExporter) {
+	if fe == nil || fe.collectorStr == "" {
+		return
+	}
+	key := flowConnKey{collector: fe.collectorStr, protocol: fe.protocol}
+	v, _ := sm.flowAggregates.LoadOrStore(key, &flowCollectorAggregate{})
+	agg := v.(*flowCollectorAggregate)
+	agg.packets.Add(fe.statPackets.Load())
+	agg.bytes.Add(fe.statBytes.Load())
+	agg.records.Add(fe.statRecords.Load())
 }
 
 // buildFlowEncoder returns the encoder + canonical protocol name for a
@@ -453,6 +508,12 @@ func buildFlowEncoder(protocol string) (FlowEncoder, string, error) {
 // sources if the device is exporting sFlow. On failure, logs and leaves
 // `device.flowExporter == nil` so the device participates in the
 // simulator but without flow export.
+//
+// The collector string stored on the exporter is the canonicalised form
+// returned by `net.ResolveUDPAddr` so that devices configured with
+// equivalent-but-different-spelling collectors (e.g. "localhost:2055"
+// vs "127.0.0.1:2055") aggregate into one pool entry and one
+// FlowCollectorStatus row (review fix P1).
 func (sm *SimulatorManager) attachFlowExporter(device *DeviceSimulator, flowProfile *FlowProfile) error {
 	cfg := device.flowConfig
 	if cfg == nil {
@@ -466,13 +527,28 @@ func (sm *SimulatorManager) attachFlowExporter(device *DeviceSimulator, flowProf
 	if err != nil {
 		return fmt.Errorf("resolve collector %q: %w", cfg.Collector, err)
 	}
+	canonicalCollector := collectorAddr.String()
+
+	// Per-device TickInterval is stored on cfg but not honored by the
+	// single global ticker (design debt documented in the change). Warn
+	// once per device at attach so operators aren't silently surprised
+	// when they set a distinct value (review fix P2).
+	if time.Duration(cfg.TickInterval) != 0 && time.Duration(cfg.TickInterval) != sm.flowTickInterval {
+		log.Printf("flow export: device %s configured tick_interval=%s but the simulator-wide ticker runs at %s; per-device tick rates are not yet honored",
+			device.IP, time.Duration(cfg.TickInterval), sm.flowTickInterval)
+	}
+
 	device.flowExporter = NewFlowExporter(device, flowProfile,
 		time.Duration(cfg.ActiveTimeout),
 		time.Duration(cfg.InactiveTimeout),
 		sm.flowTemplateInterval,
-		cfg.Collector, collectorAddr, canonical, encoder)
+		canonicalCollector, collectorAddr, canonical, encoder)
 	sm.openFlowConnForDevice(device)
 	sm.registerSFlowCounterSources(device)
+	sm.flowFirstAttachLog.Do(func() {
+		log.Printf("flow export: active; first device %s → %s (protocol=%s)",
+			device.IP, canonicalCollector, canonical)
+	})
 	return nil
 }
 
@@ -586,17 +662,17 @@ func (sm *SimulatorManager) tickAllFlowExporters(now time.Time) {
 
 // GetFlowStatus returns the aggregated flow-export snapshot. Devices
 // sharing the same (collector, protocol) tuple collapse into one record
-// in the `Collectors` array; counters are cumulative since each
-// exporter's construction.
+// in the `Collectors` array. Counters are MONOTONIC since simulator
+// start: live exporters' per-tick counters are summed with the
+// per-collector aggregates persisted when earlier devices were deleted
+// (review decision D1.b), so Prometheus-style consumers never see
+// counter resets mid-run.
 //
 // BREAKING (per-device-export-config phase 3): returns the new
 // array-of-collectors shape. The legacy scalar fields are retired;
 // callers detect "feature off" via `len(collectors) == 0`.
 func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
-	type aggKey struct {
-		collector, protocol string
-	}
-	agg := make(map[aggKey]*FlowCollectorStatus)
+	agg := make(map[flowConnKey]*FlowCollectorStatus)
 
 	sm.mu.RLock()
 	for _, d := range sm.devices {
@@ -604,7 +680,7 @@ func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
 		if fe == nil {
 			continue
 		}
-		k := aggKey{fe.collectorStr, fe.protocol}
+		k := flowConnKey{collector: fe.collectorStr, protocol: fe.protocol}
 		rec, ok := agg[k]
 		if !ok {
 			rec = &FlowCollectorStatus{
@@ -619,6 +695,27 @@ func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
 		rec.SentRecords += fe.statRecords.Load()
 	}
 	sm.mu.RUnlock()
+
+	// Fold persisted counters for tuples whose devices have since been
+	// deleted (or that have a live device AND historical deletions).
+	// A tuple with no live exporters still shows up in the output with
+	// Devices=0 so the monotonic totals remain visible.
+	sm.flowAggregates.Range(func(k, v interface{}) bool {
+		key := k.(flowConnKey)
+		pers := v.(*flowCollectorAggregate)
+		rec, ok := agg[key]
+		if !ok {
+			rec = &FlowCollectorStatus{
+				Collector: key.collector,
+				Protocol:  key.protocol,
+			}
+			agg[key] = rec
+		}
+		rec.SentPackets += pers.packets.Load()
+		rec.SentBytes += pers.bytes.Load()
+		rec.SentRecords += pers.records.Load()
+		return true
+	})
 
 	collectors := make([]FlowCollectorStatus, 0, len(agg))
 	totalDevices := 0

--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -76,17 +76,41 @@ type FlowTickStats struct {
 // flowSourcePerDevice is enabled) lets each exporter send UDP packets with
 // a source IP matching the simulated device, so collectors like OpenNMS
 // Telemetryd can attribute flows to the correct node. When conn is nil,
-// Tick falls back to the shared SimulatorManager socket.
+// Tick falls back to the shared-socket pool (one entry per (collector,
+// protocol) tuple) via `SimulatorManager.flowConnFor`.
+//
+// As of the per-device-export-config refactor, the exporter owns its
+// protocol / encoder / collector address and cumulative stat counters
+// instead of pulling them from the manager at tick time. That keeps
+// heterogeneous fleets coherent: devices pointing at different collectors
+// or using different protocols tick independently through the same
+// goroutine.
 type FlowExporter struct {
 	cache            *FlowCache
 	profile          *FlowProfile
 	rng              *rand.Rand
 	seqNo            uint32
-	domainID         uint32        // device IPv4 as uint32 (RFC 7011 §3.1)
-	startTime        time.Time     // reference point for SysUptime
-	lastTempl        time.Time     // last template transmission time
+	domainID         uint32    // device IPv4 as uint32 (RFC 7011 §3.1)
+	startTime        time.Time // reference point for SysUptime
+	lastTempl        time.Time // last template transmission time
 	templateInterval time.Duration
-	// conn is the per-device UDP socket (nil = use shared conn). atomic.Pointer
+
+	// Per-device wire configuration (owned by the exporter, not the manager).
+	// collectorStr keeps the human-readable "host:port" for status reporting;
+	// collectorAddr is the resolved *net.UDPAddr used for WriteTo. protocol
+	// is the canonicalised name ("netflow9" / "ipfix" / "netflow5" / "sflow").
+	collectorStr  string
+	collectorAddr *net.UDPAddr
+	protocol      string
+	encoder       FlowEncoder
+
+	// Per-exporter cumulative counters. Summed at status-endpoint read
+	// time to produce FlowStatus.Collectors aggregates.
+	statPackets atomic.Uint64
+	statBytes   atomic.Uint64
+	statRecords atomic.Uint64
+
+	// conn is the per-device UDP socket (nil = use shared pool). atomic.Pointer
 	// so Tick (ticker goroutine) and Close (device-shutdown paths) can read and
 	// clear it without racing. Callers must use Load/Store/Swap — never touch
 	// the field by address.
@@ -101,7 +125,16 @@ type FlowExporter struct {
 // NewFlowExporter creates a FlowExporter for device, using profile to drive
 // synthetic flow generation. The RNG is seeded from the device's domainID so
 // each device produces distinct but deterministic traffic patterns.
-func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeout, inactiveTimeout, templateInterval time.Duration) *FlowExporter {
+//
+// collectorStr is the "host:port" the device exports to; collectorAddr is the
+// resolved form (the caller must pre-resolve so construction is cheap);
+// protocol is the canonical protocol name; encoder is the matching encoder
+// instance. Callers typically use `SimulatorManager.attachFlowExporter`
+// rather than calling this constructor directly.
+func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile,
+	activeTimeout, inactiveTimeout, templateInterval time.Duration,
+	collectorStr string, collectorAddr *net.UDPAddr,
+	protocol string, encoder FlowEncoder) *FlowExporter {
 	var domainID uint32
 	if ip4 := device.IP.To4(); ip4 != nil {
 		domainID = binary.BigEndian.Uint32(ip4)
@@ -113,6 +146,10 @@ func NewFlowExporter(device *DeviceSimulator, profile *FlowProfile, activeTimeou
 		domainID:         domainID,
 		startTime:        time.Now(),
 		templateInterval: templateInterval,
+		collectorStr:     collectorStr,
+		collectorAddr:    collectorAddr,
+		protocol:         protocol,
+		encoder:          encoder,
 	}
 }
 
@@ -133,29 +170,34 @@ func (fe *FlowExporter) Close() error {
 
 // Tick is called by the shared SimulatorManager ticker goroutine on every
 // flowTickInterval. It replenishes the flow cache to ConcurrentFlows, expires
-// aged records, and emits one or more UDP datagrams to collectorAddr.
+// aged records, and emits one or more UDP datagrams to `fe.collectorAddr`
+// using `fe.encoder`.
 //
 // When fe.conn is non-nil (per-device mode) it is used for the WriteTo; the
-// passed-in conn is the shared fallback used when the per-device socket
-// could not be opened or per-device mode is disabled.
+// passed-in sharedConn is the shared-pool fallback (keyed by collector +
+// protocol) used when the per-device socket could not be opened or
+// per-device mode is disabled. sharedConn may be nil when the pool
+// could not open a socket for this exporter's (collector, protocol) tuple.
 //
 // bufPool must supply []byte slices of at least 1500 bytes.
 // Write errors are ignored (best-effort delivery; collector may be down).
 // The returned FlowTickStats are summed by tickAllFlowExporters into the
-// cumulative atomic counters on SimulatorManager.
-func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPConn, collectorAddr *net.UDPAddr, bufPool *sync.Pool) FlowTickStats {
+// per-exporter atomic counters and aggregated at status-endpoint read time.
+func (fe *FlowExporter) Tick(now time.Time, sharedConn *net.UDPConn, bufPool *sync.Pool) FlowTickStats {
 	uptimeMs := uint32(now.Sub(fe.startTime).Milliseconds())
 	deviceIP := domainIDtoIP(fe.domainID)
+	encoder := fe.encoder
+	collectorAddr := fe.collectorAddr
 
 	// Prefer the per-device socket (source IP = device IP) when set; fall back
-	// to the shared SimulatorManager socket so callers that don't use
-	// per-device binding (tests, ns-disabled deployments) still work.
+	// to the shared-pool socket so callers that don't use per-device binding
+	// (tests, ns-disabled deployments) still work.
 	// atomic Load pairs with Swap in Close — Tick never observes a torn pointer.
 	writeConn := fe.conn.Load()
 	if writeConn == nil {
-		writeConn = conn
+		writeConn = sharedConn
 	}
-	if writeConn == nil {
+	if writeConn == nil || collectorAddr == nil || encoder == nil {
 		return FlowTickStats{}
 	}
 
@@ -292,18 +334,19 @@ func (fe *FlowExporter) Tick(now time.Time, encoder FlowEncoder, conn *net.UDPCo
 // SetFlowSourcePerDevice toggles per-device UDP source IP binding. When true,
 // each device opens its own UDP socket inside the opensim namespace bound to
 // the device's IP, so collectors see per-device exporter IPs rather than the
-// container host IP. Must be called before InitFlowExport.
+// container host IP. Read at per-device attach time; call before the
+// first call to `CreateDevices` that carries a flow seed.
 func (sm *SimulatorManager) SetFlowSourcePerDevice(enabled bool) {
 	sm.flowSourcePerDevice = enabled
 }
 
 // registerSFlowCounterSources wires per-device CounterSource instances onto
-// the FlowExporter, but only when the active protocol is sFlow. Under
+// the FlowExporter, but only when the device's protocol is sFlow. Under
 // NetFlow/IPFIX/NF5 the sources are never consulted, so skipping registration
 // avoids per-device allocations for the 30,000+ device workloads this
 // simulator is built for.
 func (sm *SimulatorManager) registerSFlowCounterSources(device *DeviceSimulator) {
-	if sm.flowProtocol != "sflow" || device.flowExporter == nil {
+	if device.flowExporter == nil || device.flowExporter.protocol != "sflow" {
 		return
 	}
 	var sources []CounterSource
@@ -321,14 +364,14 @@ func (sm *SimulatorManager) registerSFlowCounterSources(device *DeviceSimulator)
 
 // openFlowConnForDevice opens a per-device UDP socket bound to the device's
 // IP (ephemeral source port) and assigns it to device.flowExporter.conn.
-// Silently falls through to the shared socket when:
+// Silently falls through to the shared-pool socket when:
 //   - per-device mode is disabled,
 //   - namespace isolation is off (device.netNamespace == nil),
 //   - or the bind fails (typically because the opensim ns has no route to
 //     the collector — see issue #36).
 //
 // Best-effort: a failed per-device bind logs once and the exporter keeps
-// working via the shared socket.
+// working via the shared-pool socket.
 func (sm *SimulatorManager) openFlowConnForDevice(device *DeviceSimulator) {
 	if !sm.flowSourcePerDevice || device.flowExporter == nil {
 		return
@@ -339,7 +382,7 @@ func (sm *SimulatorManager) openFlowConnForDevice(device *DeviceSimulator) {
 	addr := &net.UDPAddr{IP: device.IP, Port: 0}
 	conn, err := device.netNamespace.ListenUDPInNamespace(addr)
 	if err != nil {
-		if sm.flowProtocol == "sflow" {
+		if device.flowExporter.protocol == "sflow" {
 			log.Printf("flow export: device %s per-device bind failed, falling back to shared socket: %v (sFlow agent_address may not match UDP source IP observed by collector)", device.IP, err)
 		} else {
 			log.Printf("flow export: device %s per-device bind failed, falling back to shared socket: %v", device.IP, err)
@@ -350,6 +393,89 @@ func (sm *SimulatorManager) openFlowConnForDevice(device *DeviceSimulator) {
 	device.flowExporter.conn.Store(conn)
 }
 
+// flowConnFor returns the shared-pool UDP socket for a (collector, protocol)
+// tuple. First caller for a key opens the socket; subsequent callers reuse
+// it. Returns nil if the socket can't be opened. Safe for concurrent use.
+func (sm *SimulatorManager) flowConnFor(key flowConnKey) *net.UDPConn {
+	if cached, ok := sm.flowConns.Load(key); ok {
+		return cached.(*net.UDPConn)
+	}
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{})
+	if err != nil {
+		log.Printf("flow export: failed to open shared socket for %s/%s: %v", key.collector, key.protocol, err)
+		return nil
+	}
+	actual, loaded := sm.flowConns.LoadOrStore(key, conn)
+	if loaded {
+		// Another goroutine opened a socket for this key first. Close ours.
+		_ = conn.Close()
+		return actual.(*net.UDPConn)
+	}
+	return conn
+}
+
+// closeFlowConnPool closes every pooled shared socket. Called from
+// Shutdown after the ticker goroutine has exited.
+func (sm *SimulatorManager) closeFlowConnPool() {
+	sm.flowConns.Range(func(_, v interface{}) bool {
+		if conn, ok := v.(*net.UDPConn); ok {
+			_ = conn.Close()
+		}
+		return true
+	})
+	sm.flowConns = sync.Map{}
+}
+
+// buildFlowEncoder returns the encoder + canonical protocol name for a
+// configured protocol string. Caller must have already canonicalised via
+// `DeviceFlowConfig.Validate` — this function is strict and returns an
+// error for anything it doesn't recognise. Centralised so the
+// `attachFlowExporter` path and any future REST-validation path share one
+// source of truth.
+func buildFlowEncoder(protocol string) (FlowEncoder, string, error) {
+	switch strings.ToLower(protocol) {
+	case "netflow9", "nf9", "":
+		return NetFlow9Encoder{}, "netflow9", nil
+	case "ipfix", "ipfix10":
+		return IPFIXEncoder{}, "ipfix", nil
+	case "netflow5", "nf5":
+		return &NetFlow5Encoder{}, "netflow5", nil
+	case "sflow", "sflow5":
+		return SFlowEncoder{}, "sflow", nil
+	default:
+		return nil, "", fmt.Errorf("unknown flow protocol %q (supported: netflow9, ipfix, netflow5, sflow)", protocol)
+	}
+}
+
+// attachFlowExporter constructs and wires a FlowExporter for a device that
+// already has `device.flowConfig` populated. Opens the per-device UDP
+// socket if `flowSourcePerDevice` is enabled; registers sFlow counter
+// sources if the device is exporting sFlow. On failure, logs and leaves
+// `device.flowExporter == nil` so the device participates in the
+// simulator but without flow export.
+func (sm *SimulatorManager) attachFlowExporter(device *DeviceSimulator, flowProfile *FlowProfile) error {
+	cfg := device.flowConfig
+	if cfg == nil {
+		return nil
+	}
+	encoder, canonical, err := buildFlowEncoder(cfg.Protocol)
+	if err != nil {
+		return err
+	}
+	collectorAddr, err := net.ResolveUDPAddr("udp", cfg.Collector)
+	if err != nil {
+		return fmt.Errorf("resolve collector %q: %w", cfg.Collector, err)
+	}
+	device.flowExporter = NewFlowExporter(device, flowProfile,
+		time.Duration(cfg.ActiveTimeout),
+		time.Duration(cfg.InactiveTimeout),
+		sm.flowTemplateInterval,
+		cfg.Collector, collectorAddr, canonical, encoder)
+	sm.openFlowConnForDevice(device)
+	sm.registerSFlowCounterSources(device)
+	return nil
+}
+
 // domainIDtoIP converts a uint32 ObservationDomainID back to a net.IP.
 func domainIDtoIP(id uint32) net.IP {
 	ip := make(net.IP, 4)
@@ -357,71 +483,49 @@ func domainIDtoIP(id uint32) net.IP {
 	return ip
 }
 
-// InitFlowExport opens a shared UDP socket, selects an encoder, and starts the
-// shared ticker goroutine. Call once after NewSimulatorManagerWithOptions.
+// initFlowSubsystem sets up the simulator-wide flow export infrastructure
+// that's always live: the 1500-byte buffer pool, the stop channel, and
+// the ticker goroutine. After this runs, per-device attach via
+// `attachFlowExporter` wires up individual exporters; the ticker walks
+// them on every tick interval and no-ops when the list is empty.
 //
-// collectorAddr is "host:port" (e.g. "192.168.1.100:2055").
-// protocol selects the wire format: "netflow9" (default), "ipfix", or
-// "netflow5". Aliases "nf9", "ipfix10", and "nf5" are also accepted.
-//
-// Call SetFlowSourcePerDevice beforehand to enable per-device source IP binding.
-func (sm *SimulatorManager) InitFlowExport(collectorAddr, protocol string, activeTimeout, inactiveTimeout, templateInterval, tickInterval time.Duration) error {
-	if sm.flowActive.Load() {
-		return fmt.Errorf("flow export: already active; call Shutdown() before re-initializing")
-	}
-
-	addr, err := net.ResolveUDPAddr("udp4", collectorAddr)
-	if err != nil {
-		return fmt.Errorf("flow export: invalid collector address %q: %w", collectorAddr, err)
-	}
-
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
-	if err != nil {
-		return fmt.Errorf("flow export: failed to open UDP socket: %w", err)
-	}
-
-	var enc FlowEncoder
-	var canonicalProtocol string
-	switch strings.ToLower(protocol) {
-	case "netflow9", "nf9", "":
-		enc = NetFlow9Encoder{}
-		canonicalProtocol = "netflow9"
-	case "ipfix", "ipfix10":
-		enc = IPFIXEncoder{}
-		canonicalProtocol = "ipfix"
-	case "netflow5", "nf5":
-		enc = &NetFlow5Encoder{}
-		canonicalProtocol = "netflow5"
-	case "sflow", "sflow5":
-		enc = SFlowEncoder{}
-		canonicalProtocol = "sflow"
-	default:
-		conn.Close()
-		return fmt.Errorf("flow export: unknown protocol %q (supported: netflow9, ipfix, netflow5, sflow)", protocol)
-	}
-
-	sm.flowConn = conn
-	sm.flowCollectorAddr = addr
-	sm.flowCollectorStr = collectorAddr
-	sm.flowProtocol = canonicalProtocol
-	sm.flowEncoder = enc
-	sm.flowActiveTimeout = activeTimeout
-	sm.flowInactiveTimeout = inactiveTimeout
-	sm.flowTemplateInterval = templateInterval
-	sm.flowTickInterval = tickInterval
+// Called unconditionally from `NewSimulatorManagerWithOptions` (design
+// §D9: always-on scheduler). The simulator-wide tick / template interval
+// defaults are set here; operators override them via SetFlowTickInterval
+// / SetFlowTemplateInterval before creating devices. Safe to call once.
+func (sm *SimulatorManager) initFlowSubsystem() {
 	sm.flowBufPool.New = func() interface{} {
 		buf := make([]byte, 1500)
 		return buf
 	}
 	sm.flowStopCh = make(chan struct{})
 	sm.flowStopOnce = sync.Once{}
-	sm.flowActive.Store(true)
-
-	log.Printf("Flow export: %s → %s (protocol: %s, tick: %s, active-timeout: %s)",
-		conn.LocalAddr(), collectorAddr, protocol, tickInterval, activeTimeout)
-
+	if sm.flowTickInterval == 0 {
+		sm.flowTickInterval = defaultFlowTickInterval
+	}
+	if sm.flowTemplateInterval == 0 {
+		sm.flowTemplateInterval = 60 * time.Second
+	}
 	sm.startFlowTicker()
-	return nil
+}
+
+// SetFlowTickInterval overrides the simulator-wide flow ticker cadence.
+// Call before device creation. Per-device `TickInterval` fields are
+// stored on DeviceFlowConfig but not yet honored (design debt documented
+// in the per-device-export-config change).
+func (sm *SimulatorManager) SetFlowTickInterval(d time.Duration) {
+	if d > 0 {
+		sm.flowTickInterval = d
+	}
+}
+
+// SetFlowTemplateInterval overrides the simulator-wide template refresh
+// interval (applies to NetFlow v9 / IPFIX). Call before device creation.
+// `template_interval` is global per design §D5.
+func (sm *SimulatorManager) SetFlowTemplateInterval(d time.Duration) {
+	if d > 0 {
+		sm.flowTemplateInterval = d
+	}
 }
 
 // startFlowTicker launches a single background goroutine that calls Tick on
@@ -445,8 +549,10 @@ func (sm *SimulatorManager) startFlowTicker() {
 }
 
 // tickAllFlowExporters calls Tick on every device that has a FlowExporter.
-// It takes a read lock to snapshot the device list, then releases it before
-// calling Tick to avoid holding the lock during I/O.
+// Each exporter supplies its own encoder / collectorAddr; the manager
+// supplies the shared-pool fallback socket (looked up by the exporter's
+// (collector, protocol) key). Stats are accumulated per-exporter and
+// aggregated at status-endpoint read time.
 func (sm *SimulatorManager) tickAllFlowExporters(now time.Time) {
 	sm.mu.RLock()
 	exporters := make([]*FlowExporter, 0, len(sm.devices))
@@ -455,52 +561,71 @@ func (sm *SimulatorManager) tickAllFlowExporters(now time.Time) {
 			exporters = append(exporters, d.flowExporter)
 		}
 	}
-	// Snapshot shared transport fields under the lock to avoid racing with Shutdown.
-	conn := sm.flowConn
-	collectorAddr := sm.flowCollectorAddr
-	encoder := sm.flowEncoder
 	sm.mu.RUnlock()
 
-	if conn == nil {
-		return // flow export was shut down between tick and snapshot
-	}
-
-	var totalPackets, totalBytes, totalRecords uint64
 	var lastTemplMs int64
 	for _, fe := range exporters {
-		s := fe.Tick(now, encoder, conn, collectorAddr, &sm.flowBufPool)
-		totalPackets += s.PacketsSent
-		totalBytes += s.BytesSent
-		totalRecords += s.RecordsSent
+		var sharedConn *net.UDPConn
+		if fe.conn.Load() == nil {
+			sharedConn = sm.flowConnFor(flowConnKey{collector: fe.collectorStr, protocol: fe.protocol})
+		}
+		s := fe.Tick(now, sharedConn, &sm.flowBufPool)
+		if s.PacketsSent > 0 {
+			fe.statPackets.Add(s.PacketsSent)
+			fe.statBytes.Add(s.BytesSent)
+			fe.statRecords.Add(s.RecordsSent)
+		}
 		if s.LastTemplateMs > lastTemplMs {
 			lastTemplMs = s.LastTemplateMs
 		}
-	}
-	if totalPackets > 0 {
-		sm.flowStatPackets.Add(totalPackets)
-		sm.flowStatBytes.Add(totalBytes)
-		sm.flowStatRecords.Add(totalRecords)
 	}
 	if lastTemplMs > 0 {
 		sm.flowStatLastTmpl.Store(lastTemplMs)
 	}
 }
 
-// GetFlowStatus returns a snapshot of the current flow export state and
-// cumulative counters. Returns {Enabled: false} when flow export is off.
+// GetFlowStatus returns the aggregated flow-export snapshot. Devices
+// sharing the same (collector, protocol) tuple collapse into one record
+// in the `Collectors` array; counters are cumulative since each
+// exporter's construction.
+//
+// BREAKING (per-device-export-config phase 3): returns the new
+// array-of-collectors shape. The legacy scalar fields are retired;
+// callers detect "feature off" via `len(collectors) == 0`.
 func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
-	if !sm.flowActive.Load() {
-		return FlowStatus{Enabled: false}
+	type aggKey struct {
+		collector, protocol string
 	}
+	agg := make(map[aggKey]*FlowCollectorStatus)
 
 	sm.mu.RLock()
-	devicesExporting := 0
 	for _, d := range sm.devices {
-		if d.flowExporter != nil {
-			devicesExporting++
+		fe := d.flowExporter
+		if fe == nil {
+			continue
 		}
+		k := aggKey{fe.collectorStr, fe.protocol}
+		rec, ok := agg[k]
+		if !ok {
+			rec = &FlowCollectorStatus{
+				Collector: fe.collectorStr,
+				Protocol:  fe.protocol,
+			}
+			agg[k] = rec
+		}
+		rec.Devices++
+		rec.SentPackets += fe.statPackets.Load()
+		rec.SentBytes += fe.statBytes.Load()
+		rec.SentRecords += fe.statRecords.Load()
 	}
 	sm.mu.RUnlock()
+
+	collectors := make([]FlowCollectorStatus, 0, len(agg))
+	totalDevices := 0
+	for _, rec := range agg {
+		collectors = append(collectors, *rec)
+		totalDevices += rec.Devices
+	}
 
 	var lastTemplate string
 	if ms := sm.flowStatLastTmpl.Load(); ms > 0 {
@@ -508,13 +633,8 @@ func (sm *SimulatorManager) GetFlowStatus() FlowStatus {
 	}
 
 	return FlowStatus{
-		Enabled:            true,
-		Protocol:           sm.flowProtocol,
-		Collector:          sm.flowCollectorStr,
-		TotalFlowsExported: sm.flowStatRecords.Load(),
-		TotalPacketsSent:   sm.flowStatPackets.Load(),
-		TotalBytesSent:     sm.flowStatBytes.Load(),
-		DevicesExporting:   devicesExporting,
-		LastTemplateSend:   lastTemplate,
+		Collectors:       collectors,
+		DevicesExporting: totalDevices,
+		LastTemplateSend: lastTemplate,
 	}
 }

--- a/go/simulator/flow_exporter_test.go
+++ b/go/simulator/flow_exporter_test.go
@@ -26,6 +26,31 @@ import (
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+// newTestFlowExporter wraps the production NewFlowExporter with dummy
+// collector/encoder/protocol defaults so pre-phase-3 test call sites keep
+// working after the constructor signature grew. Tests that exercise
+// specific wire formats mutate `fe.encoder` / `fe.collectorAddr` via
+// `tickWithEncoder` below.
+func newTestFlowExporter(device *DeviceSimulator, profile *FlowProfile,
+	activeTimeout, inactiveTimeout, templateInterval time.Duration) *FlowExporter {
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	return NewFlowExporter(device, profile,
+		activeTimeout, inactiveTimeout, templateInterval,
+		"127.0.0.1:0", addr, "netflow9", NetFlow9Encoder{})
+}
+
+// tickWithEncoder emulates the pre-phase-3 Tick signature for existing
+// tests. The new FlowExporter.Tick reads encoder + collectorAddr from
+// the exporter itself; this shim overwrites those fields on the fly so
+// tests that construct ad-hoc listeners and pick specific encoders don't
+// need per-test rewiring. Production code never calls this.
+func tickWithEncoder(fe *FlowExporter, now time.Time, enc FlowEncoder,
+	conn *net.UDPConn, addr *net.UDPAddr, pool *sync.Pool) FlowTickStats {
+	fe.encoder = enc
+	fe.collectorAddr = addr
+	return fe.Tick(now, conn, pool)
+}
+
 // testUDPListener opens an ephemeral loopback UDP socket, returning the
 // listener and a channel that delivers raw packet bytes as they arrive.
 // The goroutine exits when the listener is closed.
@@ -87,7 +112,7 @@ func receivePacket(ch <-chan []byte) []byte {
 
 func TestNewFlowExporter_DomainID(t *testing.T) {
 	device := testDevice("10.0.0.1")
-	fe := NewFlowExporter(device, flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
+	fe := newTestFlowExporter(device, flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
 
 	// domainID must be the device IPv4 encoded as big-endian uint32.
 	if fe.domainID != 0x0A000001 {
@@ -102,8 +127,8 @@ func TestNewFlowExporter_DomainID(t *testing.T) {
 }
 
 func TestNewFlowExporter_DifferentDevicesDifferentDomainIDs(t *testing.T) {
-	feA := NewFlowExporter(testDevice("10.0.0.1"), flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
-	feB := NewFlowExporter(testDevice("10.0.0.2"), flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
+	feA := newTestFlowExporter(testDevice("10.0.0.1"), flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
+	feB := newTestFlowExporter(testDevice("10.0.0.2"), flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
 
 	if feA.domainID == feB.domainID {
 		t.Errorf("expected different domainIDs for different devices, both got %08x", feA.domainID)
@@ -115,7 +140,7 @@ func TestDomainIDtoIP_RoundTrip(t *testing.T) {
 	for _, c := range cases {
 		original := net.ParseIP(c).To4()
 		device := &DeviceSimulator{IP: original}
-		fe := NewFlowExporter(device, flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
+		fe := newTestFlowExporter(device, flowProfileEdgeRouter, time.Second, time.Second, time.Minute)
 		recovered := domainIDtoIP(fe.domainID)
 		if !recovered.Equal(original) {
 			t.Errorf("%s: domainIDtoIP(%08x) = %v, want %v", c, fe.domainID, recovered, original)
@@ -137,10 +162,10 @@ func TestFlowExporter_Tick_TemplateOnFirstCall(t *testing.T) {
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
 	// Large timeouts so nothing expires during the test.
-	fe := NewFlowExporter(testDevice("10.1.2.3"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.1.2.3"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 10*time.Minute)
 
-	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
 
 	pkt := receivePacket(ch)
 	if pkt == nil {
@@ -173,17 +198,17 @@ func TestFlowExporter_Tick_NoSendWhenIdle(t *testing.T) {
 
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
-	fe := NewFlowExporter(testDevice("10.1.2.4"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.1.2.4"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 10*time.Minute)
 
 	now := time.Now()
 
 	// First Tick sends template (seqNo=0).
-	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
 	receivePacket(ch) // drain
 
 	// Second Tick immediately after — no flows expired, template fresh.
-	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
 
 	pkt := receivePacket(ch)
 	if pkt != nil {
@@ -204,25 +229,25 @@ func TestFlowExporter_Tick_SendsFlowsWhenExpired(t *testing.T) {
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
 	// Very short timeouts so manually-inserted flows are expired immediately.
-	fe := NewFlowExporter(testDevice("10.1.2.5"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.1.2.5"), flowProfileEdgeRouter,
 		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
 
 	// Insert 3 flows directly into the cache, timestamped far in the past.
 	past := time.Now().Add(-1 * time.Hour)
 	for i := 0; i < 3; i++ {
 		fe.cache.Add(FlowRecord{
-			SrcIP:   net.ParseIP("10.0.0.1").To4(),
-			DstIP:   net.ParseIP("10.0.0.2").To4(),
-			NextHop: net.IPv4(0, 0, 0, 0).To4(),
-			SrcPort: uint16(1000 + i),
-			DstPort: 443,
+			SrcIP:    net.ParseIP("10.0.0.1").To4(),
+			DstIP:    net.ParseIP("10.0.0.2").To4(),
+			NextHop:  net.IPv4(0, 0, 0, 0).To4(),
+			SrcPort:  uint16(1000 + i),
+			DstPort:  443,
 			Protocol: 6,
-			Bytes:   1024,
-			Packets: 10,
+			Bytes:    1024,
+			Packets:  10,
 		}, past)
 	}
 
-	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
 
 	pkt := receivePacket(ch)
 	if pkt == nil {
@@ -245,20 +270,20 @@ func TestFlowExporter_Tick_TemplateRetransmit(t *testing.T) {
 
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
-	fe := NewFlowExporter(testDevice("10.1.2.6"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.1.2.6"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 60*time.Second)
 
 	now := time.Now()
 
 	// First Tick: sends template.
-	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
 	pkt1 := receivePacket(ch)
 	if pkt1 == nil {
 		t.Fatal("expected template on first Tick")
 	}
 
 	// Second Tick: template interval has not elapsed — no send.
-	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
 	if pkt := receivePacket(ch); pkt != nil {
 		t.Error("unexpected packet before template interval elapsed")
 	}
@@ -267,7 +292,7 @@ func TestFlowExporter_Tick_TemplateRetransmit(t *testing.T) {
 	fe.lastTempl = now.Add(-61 * time.Second)
 
 	// Third Tick: template should be retransmitted.
-	fe.Tick(now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, now, NetFlow9Encoder{}, conn, collectorAddr, testPool())
 	pkt3 := receivePacket(ch)
 	if pkt3 == nil {
 		t.Fatal("expected template retransmission after interval elapsed")
@@ -289,10 +314,10 @@ func TestFlowExporter_Tick_IPFIXTemplateOnFirstCall(t *testing.T) {
 
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
-	fe := NewFlowExporter(testDevice("10.2.3.4"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.2.3.4"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 10*time.Minute)
 
-	fe.Tick(time.Now(), IPFIXEncoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), IPFIXEncoder{}, conn, collectorAddr, testPool())
 
 	pkt := receivePacket(ch)
 	if pkt == nil {
@@ -327,16 +352,16 @@ func TestFlowExporter_Tick_IPFIXPagination(t *testing.T) {
 
 	profile := &FlowProfile{
 		TCPWeight: 1.0, UDPWeight: 0, ICMPWeight: 0,
-		DstPorts:        []PortWeight{{443, 1.0}},
-		SrcPortMin:      1024, SrcPortMax: 65535,
-		BytesMin:        100, BytesMax: 200,
-		PktsMin:         1, PktsMax: 2,
-		DurationMinMs:   100, DurationMaxMs: 200,
+		DstPorts:   []PortWeight{{443, 1.0}},
+		SrcPortMin: 1024, SrcPortMax: 65535,
+		BytesMin: 100, BytesMax: 200,
+		PktsMin: 1, PktsMax: 2,
+		DurationMinMs: 100, DurationMaxMs: 200,
 		ConcurrentFlows: 100,
 		MaxFlows:        256,
 	}
 
-	fe := NewFlowExporter(testDevice("10.2.3.5"), profile,
+	fe := newTestFlowExporter(testDevice("10.2.3.5"), profile,
 		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
 
 	// Insert 80 distinct flows all with past timestamps so they expire immediately.
@@ -358,7 +383,7 @@ func TestFlowExporter_Tick_IPFIXPagination(t *testing.T) {
 		t.Fatalf("expected 80 cache entries, got %d", got)
 	}
 
-	fe.Tick(time.Now(), IPFIXEncoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), IPFIXEncoder{}, conn, collectorAddr, testPool())
 
 	// Collect all received packets.
 	var packets [][]byte
@@ -402,16 +427,16 @@ func TestFlowExporter_Tick_Pagination(t *testing.T) {
 	// Use a large MaxFlows to allow many concurrent entries.
 	profile := &FlowProfile{
 		TCPWeight: 1.0, UDPWeight: 0, ICMPWeight: 0,
-		DstPorts:        []PortWeight{{443, 1.0}},
-		SrcPortMin:      1024, SrcPortMax: 65535,
-		BytesMin:        100, BytesMax: 200,
-		PktsMin:         1, PktsMax: 2,
-		DurationMinMs:   100, DurationMaxMs: 200,
+		DstPorts:   []PortWeight{{443, 1.0}},
+		SrcPortMin: 1024, SrcPortMax: 65535,
+		BytesMin: 100, BytesMax: 200,
+		PktsMin: 1, PktsMax: 2,
+		DurationMinMs: 100, DurationMaxMs: 200,
 		ConcurrentFlows: 100,
 		MaxFlows:        256,
 	}
 
-	fe := NewFlowExporter(testDevice("10.1.2.7"), profile,
+	fe := newTestFlowExporter(testDevice("10.1.2.7"), profile,
 		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
 
 	// Insert 80 distinct flows all with past timestamps so they expire immediately.
@@ -433,7 +458,7 @@ func TestFlowExporter_Tick_Pagination(t *testing.T) {
 		t.Fatalf("expected 80 cache entries, got %d", got)
 	}
 
-	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
 
 	// Collect all received packets.
 	var packets [][]byte
@@ -469,7 +494,7 @@ func TestFlowTickStats_Counters(t *testing.T) {
 	defer conn.Close()
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
-	fe := NewFlowExporter(testDevice("10.0.0.3"), flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
+	fe := newTestFlowExporter(testDevice("10.0.0.3"), flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
 
 	// Pre-populate 5 expired records.
 	past := time.Now().Add(-2 * time.Minute)
@@ -486,7 +511,7 @@ func TestFlowTickStats_Counters(t *testing.T) {
 		}, past)
 	}
 
-	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	stats := tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
 	// Drain sent packets so the listener goroutine can exit cleanly.
 	receivePacket(ch)
 
@@ -514,81 +539,85 @@ func TestFlowTickStats_NoRecordsNoTemplate(t *testing.T) {
 	defer conn.Close()
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
-	fe := NewFlowExporter(testDevice("10.0.0.4"), flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Minute)
+	fe := newTestFlowExporter(testDevice("10.0.0.4"), flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Minute)
 
 	// Advance past the first (seqNo==0) template send so the next call has no template due.
-	fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
 	// Second tick with empty cache and no template interval elapsed → zero stats.
-	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
+	stats := tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, conn, collectorAddr, testPool())
 
 	if stats.PacketsSent != 0 || stats.BytesSent != 0 || stats.RecordsSent != 0 || stats.LastTemplateMs != 0 {
 		t.Errorf("expected zero stats on idle tick, got %+v", stats)
 	}
 }
 
-// TestGetFlowStatus_Disabled verifies that GetFlowStatus returns {Enabled:false}
-// when flow export has not been initialised.
-func TestGetFlowStatus_Disabled(t *testing.T) {
+// TestGetFlowStatus_NoExportingDevices verifies that GetFlowStatus returns
+// an empty Collectors array when no device has a FlowExporter attached.
+// Under the per-device-export-config model "feature off" is expressed as
+// `len(collectors) == 0`.
+func TestGetFlowStatus_NoExportingDevices(t *testing.T) {
 	sm := &SimulatorManager{devices: make(map[string]*DeviceSimulator)}
 	status := sm.GetFlowStatus()
-	if status.Enabled {
-		t.Error("expected Enabled=false when flow export is off")
+	if len(status.Collectors) != 0 {
+		t.Errorf("expected empty Collectors, got %+v", status.Collectors)
 	}
-	if status.Protocol != "" || status.Collector != "" {
-		t.Errorf("expected empty Protocol/Collector when disabled, got %+v", status)
+	if status.DevicesExporting != 0 {
+		t.Errorf("DevicesExporting = %d, want 0", status.DevicesExporting)
 	}
 }
 
-// TestGetFlowStatus_Enabled verifies that GetFlowStatus reflects the values set
-// by InitFlowExport and the cumulative counters updated by tickAllFlowExporters.
-func TestGetFlowStatus_Enabled(t *testing.T) {
-	ln, ch := testUDPListener(t)
-	defer ln.Close()
+// TestGetFlowStatus_AggregatesAcrossDevices verifies that GetFlowStatus
+// aggregates per-device counters by (collector, protocol) tuple. Two
+// devices pointing at the same collector/protocol collapse into one
+// record; one device on a distinct collector yields a second record.
+func TestGetFlowStatus_AggregatesAcrossDevices(t *testing.T) {
+	sm := &SimulatorManager{devices: make(map[string]*DeviceSimulator)}
 
-	collectorStr := ln.LocalAddr().String()
-	sm := NewSimulatorManagerWithOptions(false)
-	err := sm.InitFlowExport(collectorStr, "netflow9", 30*time.Second, 15*time.Second, 60*time.Second, 100*time.Millisecond)
-	if err != nil {
-		t.Fatalf("InitFlowExport: %v", err)
+	mkExporter := func(ip, collector, protocol string, encoder FlowEncoder,
+		packets, bytesSent, records uint64) *DeviceSimulator {
+		d := testDevice(ip)
+		addr, _ := net.ResolveUDPAddr("udp", collector)
+		fe := NewFlowExporter(d, flowProfileEdgeRouter,
+			30*time.Second, 15*time.Second, 60*time.Second,
+			collector, addr, protocol, encoder)
+		fe.statPackets.Store(packets)
+		fe.statBytes.Store(bytesSent)
+		fe.statRecords.Store(records)
+		d.flowExporter = fe
+		return d
 	}
-	defer sm.Shutdown()
 
-	// Add a device with a flow exporter.
-	device := testDevice("10.5.0.1")
-	device.flowExporter = NewFlowExporter(device, flowProfileEdgeRouter, 30*time.Second, 15*time.Second, 60*time.Second)
-	sm.mu.Lock()
-	sm.devices["10.5.0.1"] = device
-	sm.mu.Unlock()
+	sm.devices["1"] = mkExporter("10.0.0.1", "a:2055", "netflow9", NetFlow9Encoder{}, 10, 100, 5)
+	sm.devices["2"] = mkExporter("10.0.0.2", "a:2055", "netflow9", NetFlow9Encoder{}, 20, 200, 7)
+	sm.devices["3"] = mkExporter("10.0.0.3", "b:4739", "ipfix", IPFIXEncoder{}, 3, 30, 1)
 
-	// Poll until TotalPacketsSent is updated. receivePacket() synchronises on
-	// UDP arrival, which races the atomic Add in tickAllFlowExporters — use a
-	// short polling loop to fence the counter reliably.
-	deadline := time.Now().Add(2 * time.Second)
-	var status FlowStatus
-	for time.Now().Before(deadline) {
-		receivePacket(ch)
-		status = sm.GetFlowStatus()
-		if status.TotalPacketsSent > 0 {
-			break
+	status := sm.GetFlowStatus()
+
+	if status.DevicesExporting != 3 {
+		t.Errorf("DevicesExporting = %d, want 3", status.DevicesExporting)
+	}
+	if len(status.Collectors) != 2 {
+		t.Fatalf("Collectors = %+v, want 2 records", status.Collectors)
+	}
+	for _, c := range status.Collectors {
+		switch {
+		case c.Collector == "a:2055" && c.Protocol == "netflow9":
+			if c.Devices != 2 {
+				t.Errorf("a:2055/netflow9 Devices = %d, want 2", c.Devices)
+			}
+			if c.SentPackets != 30 || c.SentBytes != 300 || c.SentRecords != 12 {
+				t.Errorf("a:2055/netflow9 counters wrong: %+v", c)
+			}
+		case c.Collector == "b:4739" && c.Protocol == "ipfix":
+			if c.Devices != 1 {
+				t.Errorf("b:4739/ipfix Devices = %d, want 1", c.Devices)
+			}
+			if c.SentPackets != 3 || c.SentBytes != 30 || c.SentRecords != 1 {
+				t.Errorf("b:4739/ipfix counters wrong: %+v", c)
+			}
+		default:
+			t.Errorf("unexpected collector record: %+v", c)
 		}
-	}
-	if !status.Enabled {
-		t.Error("expected Enabled=true after InitFlowExport")
-	}
-	if status.Protocol != "netflow9" {
-		t.Errorf("Protocol = %q, want \"netflow9\"", status.Protocol)
-	}
-	if status.Collector != collectorStr {
-		t.Errorf("Collector = %q, want %q", status.Collector, collectorStr)
-	}
-	if status.DevicesExporting != 1 {
-		t.Errorf("DevicesExporting = %d, want 1", status.DevicesExporting)
-	}
-	if status.TotalPacketsSent == 0 {
-		t.Error("TotalPacketsSent = 0, want >0 after at least one tick")
-	}
-	if status.LastTemplateSend == "" {
-		t.Error("LastTemplateSend is empty, want a non-empty RFC3339 timestamp")
 	}
 }
 
@@ -618,11 +647,11 @@ func TestFlowExporter_Tick_PrefersPerDeviceConn(t *testing.T) {
 	}
 	fallback.Close()
 
-	fe := NewFlowExporter(testDevice("10.9.9.9"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.9.9.9"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 10*time.Minute)
 	fe.conn.Store(perDevice)
 
-	stats := fe.Tick(time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, testPool())
+	stats := tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, testPool())
 
 	pkt := receivePacket(ch)
 	if pkt == nil {
@@ -641,7 +670,7 @@ func TestFlowExporter_Tick_CloseRace(t *testing.T) {
 	defer ln.Close()
 	collectorAddr := ln.LocalAddr().(*net.UDPAddr)
 
-	fe := NewFlowExporter(testDevice("10.9.9.11"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.9.9.11"), flowProfileEdgeRouter,
 		10*time.Minute, 5*time.Minute, 10*time.Minute)
 
 	perDevice, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
@@ -667,7 +696,7 @@ func TestFlowExporter_Tick_CloseRace(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				fe.Tick(time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, pool)
+				tickWithEncoder(fe, time.Now(), NetFlow9Encoder{}, fallback, collectorAddr, pool)
 			}
 		}
 	}()
@@ -685,13 +714,12 @@ func TestFlowExporter_Tick_CloseRace(t *testing.T) {
 	}
 }
 
-// TestInitFlowExport_UnknownProtocol verifies that the default-case error
-// message lists all supported protocols including sflow. This is the
-// assertion point for the spec scenario "Unknown protocol is rejected with
-// updated error message".
-func TestInitFlowExport_UnknownProtocol(t *testing.T) {
-	sm := NewSimulatorManagerWithOptions(false)
-	err := sm.InitFlowExport("127.0.0.1:65530", "nonexistent", time.Second, time.Second, time.Minute, time.Second)
+// TestBuildFlowEncoder_UnknownProtocol verifies that the default-case
+// error message lists all supported protocols including sflow. Ported
+// from the retired InitFlowExport test against the `buildFlowEncoder`
+// helper that replaced it in the per-device-export-config refactor.
+func TestBuildFlowEncoder_UnknownProtocol(t *testing.T) {
+	_, _, err := buildFlowEncoder("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown protocol, got nil")
 	}
@@ -703,21 +731,20 @@ func TestInitFlowExport_UnknownProtocol(t *testing.T) {
 	}
 }
 
-// TestInitFlowExport_SFlowCanonicalized verifies both sflow and sflow5 select
-// the sFlow encoder and canonicalize to "sflow" in GetFlowStatus.
-func TestInitFlowExport_SFlowCanonicalized(t *testing.T) {
+// TestBuildFlowEncoder_SFlowCanonicalized verifies both sflow and sflow5
+// select the sFlow encoder and canonicalize to "sflow". Ported from the
+// retired InitFlowExport-based test; canonicalisation now lives in
+// `buildFlowEncoder`.
+func TestBuildFlowEncoder_SFlowCanonicalized(t *testing.T) {
 	for _, alias := range []string{"sflow", "sflow5", "SFLOW", "SFlow5"} {
-		sm := NewSimulatorManagerWithOptions(false)
-		err := sm.InitFlowExport("127.0.0.1:65531", alias, time.Second, time.Second, time.Minute, time.Hour)
+		_, canonical, err := buildFlowEncoder(alias)
 		if err != nil {
-			t.Errorf("alias %q: InitFlowExport returned error: %v", alias, err)
+			t.Errorf("alias %q: buildFlowEncoder returned error: %v", alias, err)
 			continue
 		}
-		status := sm.GetFlowStatus()
-		if status.Protocol != "sflow" {
-			t.Errorf("alias %q: Protocol = %q, want \"sflow\" (canonical)", alias, status.Protocol)
+		if canonical != "sflow" {
+			t.Errorf("alias %q: canonical = %q, want \"sflow\"", alias, canonical)
 		}
-		_ = sm.Shutdown()
 	}
 }
 
@@ -951,7 +978,7 @@ func TestFlowExporter_Close_Idempotent(t *testing.T) {
 		t.Errorf("Close on nil exporter returned error: %v", err)
 	}
 
-	fe := NewFlowExporter(testDevice("10.9.9.10"), flowProfileEdgeRouter,
+	fe := newTestFlowExporter(testDevice("10.9.9.10"), flowProfileEdgeRouter,
 		time.Second, time.Second, time.Minute)
 	if err := fe.Close(); err != nil {
 		t.Errorf("Close without conn returned error: %v", err)

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -78,6 +78,12 @@ func NewSimulatorManagerWithOptions(useNamespace bool) *SimulatorManager {
 	// Pre-generate shared TLS certificate for all API servers
 	sm.generateSharedTLSCert()
 
+	// Bring up the always-on flow-export infrastructure (buf pool + ticker
+	// goroutine + stop channel). No-op at startup when no device has
+	// flowConfig; per-device attach via attachFlowExporter enables export
+	// later. Phase 3 of per-device-export-config.
+	sm.initFlowSubsystem()
+
 	return sm
 }
 
@@ -211,6 +217,12 @@ func (sm *SimulatorManager) ListDevices() []DeviceInfo {
 		if device.tunIface != nil {
 			info.Interface = device.tunIface.Name
 		}
+		// Echo the per-device export config blocks (phase 3 task 3.9).
+		// Pointer copy so JSON emission sees the resolved config; nil
+		// blocks are omitted via `omitempty` on DeviceInfo.
+		info.Flow = device.flowConfig
+		info.Traps = device.trapConfig
+		info.Syslog = device.syslogConfig
 		devices = append(devices, info)
 	}
 
@@ -324,19 +336,17 @@ func (sm *SimulatorManager) Shutdown() error {
 	log.Println("Shutting down simulator manager...")
 	startTime := time.Now()
 
-	// Stop the flow ticker goroutine and close the shared UDP socket.
-	// flowStopOnce ensures close(flowStopCh) is safe on repeated Shutdown() calls.
-	// flowWg.Wait() ensures the ticker goroutine has exited before we close flowConn,
-	// eliminating the data race between WriteTo and conn.Close()/nil.
-	if sm.flowActive.Load() {
+	// Stop the flow ticker goroutine and close every pooled shared socket.
+	// Per the per-device-export-config refactor the subsystem is always-on
+	// (design §D9); flowStopOnce ensures close(flowStopCh) is idempotent.
+	// flowWg.Wait() guarantees the ticker has exited before we close pooled
+	// sockets so Tick never races WriteTo against Close. Per-device sockets
+	// are closed when each device's flowExporter.Close() runs.
+	if sm.flowStopCh != nil {
 		sm.flowStopOnce.Do(func() { close(sm.flowStopCh) })
 		sm.flowWg.Wait()
-		sm.flowActive.Store(false)
 	}
-	if sm.flowConn != nil {
-		sm.flowConn.Close()
-		sm.flowConn = nil
-	}
+	sm.closeFlowConnPool()
 
 	// Stop the trap subsystem (scheduler goroutine + per-device exporters +
 	// shared fallback socket). Safe to call when trap export was never started.

--- a/go/simulator/netflow5_test.go
+++ b/go/simulator/netflow5_test.go
@@ -345,20 +345,20 @@ func TestNetFlow5IPv4OnlyFiltering(t *testing.T) {
 	buf := make([]byte, 1500)
 
 	v6Src := FlowRecord{
-		SrcIP:    net.ParseIP("2001:db8::1"),
-		DstIP:    net.ParseIP("10.0.0.2").To4(),
-		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
-		SrcPort:  1000, DstPort: 443, Protocol: 6,
+		SrcIP:   net.ParseIP("2001:db8::1"),
+		DstIP:   net.ParseIP("10.0.0.2").To4(),
+		NextHop: net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort: 1000, DstPort: 443, Protocol: 6,
 		Bytes: 100, Packets: 1,
 		StartMs: 500, EndMs: 600,
 		InIface: 1, OutIface: 2, SrcMask: 24, DstMask: 24,
 	}
 	v4 := makeRecord("10.0.0.1", "10.0.0.2", 2000, 443, 6)
 	v6Dst := FlowRecord{
-		SrcIP:    net.ParseIP("10.0.0.1").To4(),
-		DstIP:    net.ParseIP("2001:db8::2"),
-		NextHop:  net.IPv4(0, 0, 0, 0).To4(),
-		SrcPort:  3000, DstPort: 80, Protocol: 6,
+		SrcIP:   net.ParseIP("10.0.0.1").To4(),
+		DstIP:   net.ParseIP("2001:db8::2"),
+		NextHop: net.IPv4(0, 0, 0, 0).To4(),
+		SrcPort: 3000, DstPort: 80, Protocol: 6,
 		Bytes: 200, Packets: 2,
 		StartMs: 700, EndMs: 800,
 		InIface: 1, OutIface: 2, SrcMask: 24, DstMask: 24,
@@ -411,10 +411,10 @@ func TestNetFlow5NextHopCoercion(t *testing.T) {
 	buf := make([]byte, 1500)
 
 	r := FlowRecord{
-		SrcIP:    net.ParseIP("10.0.0.1").To4(),
-		DstIP:    net.ParseIP("10.0.0.2").To4(),
-		NextHop:  net.ParseIP("2001:db8::feed"), // IPv6 nexthop
-		SrcPort:  1000, DstPort: 443, Protocol: 6,
+		SrcIP:   net.ParseIP("10.0.0.1").To4(),
+		DstIP:   net.ParseIP("10.0.0.2").To4(),
+		NextHop: net.ParseIP("2001:db8::feed"), // IPv6 nexthop
+		SrcPort: 1000, DstPort: 443, Protocol: 6,
 		Bytes: 100, Packets: 1,
 		StartMs: 500, EndMs: 600,
 		InIface: 1, OutIface: 2, SrcMask: 24, DstMask: 24,
@@ -666,16 +666,16 @@ func TestNetFlow5Tick_FlowSequenceCumulative(t *testing.T) {
 	// Large MaxFlows so 80 records fit; short timeouts so everything expires.
 	profile := &FlowProfile{
 		TCPWeight: 1.0, UDPWeight: 0, ICMPWeight: 0,
-		DstPorts:        []PortWeight{{443, 1.0}},
-		SrcPortMin:      1024, SrcPortMax: 65535,
-		BytesMin:        100, BytesMax: 200,
-		PktsMin:         1, PktsMax: 2,
-		DurationMinMs:   100, DurationMaxMs: 200,
+		DstPorts:   []PortWeight{{443, 1.0}},
+		SrcPortMin: 1024, SrcPortMax: 65535,
+		BytesMin: 100, BytesMax: 200,
+		PktsMin: 1, PktsMax: 2,
+		DurationMinMs: 100, DurationMaxMs: 200,
 		ConcurrentFlows: 100,
 		MaxFlows:        256,
 	}
 
-	fe := NewFlowExporter(testDevice("10.5.6.7"), profile,
+	fe := newTestFlowExporter(testDevice("10.5.6.7"), profile,
 		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
 
 	// Insert 80 pre-expired IPv4 flows.
@@ -694,7 +694,7 @@ func TestNetFlow5Tick_FlowSequenceCumulative(t *testing.T) {
 	}
 
 	enc := &NetFlow5Encoder{}
-	fe.Tick(time.Now(), enc, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), enc, conn, collectorAddr, testPool())
 
 	// Collect all packets emitted by this single Tick.
 	var packets [][]byte

--- a/go/simulator/sflow_test.go
+++ b/go/simulator/sflow_test.go
@@ -29,13 +29,13 @@ import (
 // wire-compliant XDR without introducing an external dependency.
 
 type sflowDatagramHdr struct {
-	Version     uint32
-	AddrType    uint32
-	AgentIPv4   [4]byte
-	SubAgentID  uint32
-	SequenceNo  uint32
-	Uptime      uint32
-	NumSamples  uint32
+	Version    uint32
+	AddrType   uint32
+	AgentIPv4  [4]byte
+	SubAgentID uint32
+	SequenceNo uint32
+	Uptime     uint32
+	NumSamples uint32
 }
 
 type sflowSampledHeader struct {
@@ -77,10 +77,10 @@ type sflowCountersSample struct {
 }
 
 type sflowSample struct {
-	Type         uint32
-	Length       uint32
-	FlowSample   *sflowFlowSample   // populated when Type == 1
-	CounterSmpl  *sflowCountersSample // populated when Type == 2
+	Type        uint32
+	Length      uint32
+	FlowSample  *sflowFlowSample     // populated when Type == 1
+	CounterSmpl *sflowCountersSample // populated when Type == 2
 }
 
 type sflowDatagram struct {
@@ -641,13 +641,13 @@ func TestSFlowTickSyntheticRate(t *testing.T) {
 		MaxFlows:        256,
 	}
 
-	fe := NewFlowExporter(testDevice("10.9.8.7"), profile,
+	fe := newTestFlowExporter(testDevice("10.9.8.7"), profile,
 		1*time.Millisecond, 1*time.Millisecond, 10*time.Minute)
 
 	// Run two ticks 10ms apart so the inactive timeout fires.
-	fe.Tick(time.Now(), SFlowEncoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), SFlowEncoder{}, conn, collectorAddr, testPool())
 	time.Sleep(15 * time.Millisecond)
-	fe.Tick(time.Now(), SFlowEncoder{}, conn, collectorAddr, testPool())
+	tickWithEncoder(fe, time.Now(), SFlowEncoder{}, conn, collectorAddr, testPool())
 
 	// Drain any datagrams produced. Look for the first one that actually
 	// carries a flow_sample (as opposed to a counter-only tick).

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -103,13 +103,13 @@ func main() {
 		ifFailurePct    = flag.Int("if-failure-pct", 10, "Percentage of interfaces with oper-down (used with -if-scenario 4, 0–100)")
 
 		// Flow export flags
-		flowCollector        = flag.String("flow-collector", "", "NetFlow/IPFIX collector address (host:port, e.g. 192.168.1.100:2055); disables flow export when empty")
-		flowProtocol         = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default), ipfix, netflow5, sflow (alias sflow5). Under netflow5, -flow-template-interval is accepted but has no effect (v5 has no template mechanism). Under sflow, -flow-template-interval is accepted but has no effect (sFlow records are self-describing); flow-samples carry a synthetic sampling_rate of 10 × FlowProfile.ConcurrentFlows — see CLAUDE.md and README.md for caveats")
-		flowActiveSecs       = flag.Int("flow-active-timeout", 30, "Active flow timeout in seconds (default: 30)")
-		flowInactiveSecs     = flag.Int("flow-inactive-timeout", 15, "Inactive flow timeout in seconds (default: 15)")
+		flowCollector            = flag.String("flow-collector", "", "NetFlow/IPFIX collector address (host:port, e.g. 192.168.1.100:2055); disables flow export when empty")
+		flowProtocol             = flag.String("flow-protocol", "netflow9", "Flow export protocol: netflow9 (default), ipfix, netflow5, sflow (alias sflow5). Under netflow5, -flow-template-interval is accepted but has no effect (v5 has no template mechanism). Under sflow, -flow-template-interval is accepted but has no effect (sFlow records are self-describing); flow-samples carry a synthetic sampling_rate of 10 × FlowProfile.ConcurrentFlows — see CLAUDE.md and README.md for caveats")
+		flowActiveSecs           = flag.Int("flow-active-timeout", 30, "Active flow timeout in seconds (default: 30)")
+		flowInactiveSecs         = flag.Int("flow-inactive-timeout", 15, "Inactive flow timeout in seconds (default: 15)")
 		flowTemplateIntervalSecs = flag.Int("flow-template-interval", 60, "Template retransmission interval in seconds (default: 60)")
-		flowTickSecs         = flag.Int("flow-tick-interval", 5, "Flow ticker interval in seconds (default: 5)")
-		flowSourcePerDevice  = flag.Bool("flow-source-per-device", true, "Bind a per-device UDP socket inside the opensim namespace so flow packets use the device's IP as the source address (default: true). Requires the opensim ns to have a route to the collector; set to false to use a single shared socket from the host namespace")
+		flowTickSecs             = flag.Int("flow-tick-interval", 5, "Flow ticker interval in seconds (default: 5)")
+		flowSourcePerDevice      = flag.Bool("flow-source-per-device", true, "Bind a per-device UDP socket inside the opensim namespace so flow packets use the device's IP as the source address (default: true). Requires the opensim ns to have a route to the collector; set to false to use a single shared socket from the host namespace")
 
 		// SNMP trap / INFORM export flags. See CLAUDE.md "SNMP Trap export" for detail.
 		trapCollector       = flag.String("trap-collector", "", "SNMP trap collector address (host:port, e.g. 10.0.0.50:162); enables trap export when non-empty")
@@ -199,19 +199,30 @@ func main() {
 		}
 	}
 
-	// Enable flow export if a collector address was provided.
+	// Configure simulator-wide flow parameters. Per-device fields (collector,
+	// protocol, timeouts) live on DeviceFlowConfig; `tick_interval`,
+	// `template_interval`, and `source_per_device` remain global per
+	// design §D5. Always applied so operators can tune the ticker cadence
+	// even when no CLI-seed flow export is configured.
+	manager.SetFlowSourcePerDevice(*flowSourcePerDevice)
+	manager.SetFlowTickInterval(time.Duration(*flowTickSecs) * time.Second)
+	manager.SetFlowTemplateInterval(time.Duration(*flowTemplateIntervalSecs) * time.Second)
+
+	// Build the CLI-seed flow config for the auto-start batch. Phase 3 of
+	// per-device-export-config: flags seed auto-start devices only;
+	// REST-created devices must opt in via POST /api/v1/devices.
+	var flowSeed *DeviceFlowConfig
 	if *flowCollector != "" {
-		manager.SetFlowSourcePerDevice(*flowSourcePerDevice)
-		err := manager.InitFlowExport(
-			*flowCollector,
-			*flowProtocol,
-			time.Duration(*flowActiveSecs)*time.Second,
-			time.Duration(*flowInactiveSecs)*time.Second,
-			time.Duration(*flowTemplateIntervalSecs)*time.Second,
-			time.Duration(*flowTickSecs)*time.Second,
-		)
-		if err != nil {
-			log.Fatalf("Failed to initialize flow export: %v", err)
+		flowSeed = &DeviceFlowConfig{
+			Collector:       *flowCollector,
+			Protocol:        *flowProtocol,
+			TickInterval:    jsonDuration(time.Duration(*flowTickSecs) * time.Second),
+			ActiveTimeout:   jsonDuration(time.Duration(*flowActiveSecs) * time.Second),
+			InactiveTimeout: jsonDuration(time.Duration(*flowInactiveSecs) * time.Second),
+		}
+		flowSeed.ApplyDefaults()
+		if err := flowSeed.Validate(); err != nil {
+			log.Fatalf("flow export: invalid -flow-* CLI seed: %v", err)
 		}
 	}
 
@@ -313,7 +324,7 @@ func main() {
 					*snmpv3EngineID, *snmpv3AuthProto, *snmpv3PrivProto)
 			}
 
-			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort)
+			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort, &ExportSeed{Flow: flowSeed})
 			if err != nil {
 				log.Printf("Failed to auto-create devices: %v", err)
 			} else {

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -194,28 +194,28 @@ type SimulatorManager struct {
 	deviceCreateProgress atomic.Value // int - number of devices created so far
 	deviceCreateTotal    atomic.Value // int - total number of devices to create
 
-	// Flow export state (nil/zero when disabled; set by InitFlowExport)
-	flowConn             *net.UDPConn
-	flowCollectorAddr    *net.UDPAddr
-	flowCollectorStr     string // original "host:port" string for status reporting
-	flowProtocol         string // normalised protocol name ("netflow9" or "ipfix")
-	flowEncoder          FlowEncoder
-	flowBufPool          sync.Pool   // supplies []byte(1500); set via flowBufPool.New
-	flowActive           atomic.Bool // true after InitFlowExport; safe for concurrent reads
+	// Flow export state. Per the per-device-export-config refactor, each
+	// device owns its collector/protocol/timeouts on its `flowConfig`
+	// field. The manager retains:
+	//   - a pool of shared UDP sockets keyed by (collector, protocol) for
+	//     the fallback path when `flowSourcePerDevice=false`;
+	//   - simulator-wide concerns: buf pool, ticker goroutine, global tick
+	//     interval, global template interval (design §D5), and stat
+	//     counters aggregated across all devices.
+	flowConns            sync.Map // key: flowConnKey, value: *net.UDPConn (shared-socket fallback pool)
+	flowBufPool          sync.Pool
 	flowTickInterval     time.Duration
-	flowActiveTimeout    time.Duration
-	flowInactiveTimeout  time.Duration
 	flowTemplateInterval time.Duration
 	flowSourcePerDevice  bool           // bind per-device UDP socket in opensim ns so src IP = device IP
 	flowStopCh           chan struct{}  // closed by Shutdown to stop the ticker goroutine
 	flowStopOnce         sync.Once      // ensures flowStopCh is closed exactly once
-	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before closing flowConn
+	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before tearing down pool
 
-	// Flow export cumulative counters (updated atomically by tickAllFlowExporters).
-	flowStatPackets  atomic.Uint64 // total UDP datagrams sent since InitFlowExport
-	flowStatBytes    atomic.Uint64 // total bytes written to UDP (headers + records + padding) since InitFlowExport
-	flowStatRecords  atomic.Uint64 // total flow records exported since InitFlowExport
-	flowStatLastTmpl atomic.Int64  // unix milliseconds of the most recent template transmission
+	// Simulator-wide "last template send" stamp — aggregated from
+	// per-exporter ticks and surfaced via GetFlowStatus.
+	// Per-exporter packet/byte/record counters live on the FlowExporter
+	// itself and are aggregated at GetFlowStatus read time.
+	flowStatLastTmpl atomic.Int64 // unix milliseconds of the most recent template transmission
 
 	// SNMP trap export state (nil/zero when disabled; set by StartTrapExport).
 	// See trap_manager.go for lifecycle and trap_exporter.go for per-device state.
@@ -362,13 +362,44 @@ type ManagerStatus struct {
 }
 
 // FlowStatus is the JSON body returned by GET /api/v1/flows/status.
+//
+// BREAKING (per-device-export-config phase 3): the response shape is now
+// an array-of-collectors aggregated across devices. The legacy scalar
+// `enabled`/`protocol`/`collector`/`total_*` fields were removed — clients
+// detect "feature off" via `len(collectors) == 0`.
 type FlowStatus struct {
-	Enabled            bool   `json:"enabled"`
-	Protocol           string `json:"protocol,omitempty"`
-	Collector          string `json:"collector,omitempty"`
-	TotalFlowsExported uint64 `json:"total_flows_exported"`
-	TotalPacketsSent   uint64 `json:"total_packets_sent"`
-	TotalBytesSent     uint64 `json:"total_bytes_sent"`
-	DevicesExporting   int    `json:"devices_exporting"`
-	LastTemplateSend   string `json:"last_template_send,omitempty"`
+	Collectors       []FlowCollectorStatus `json:"collectors"`
+	DevicesExporting int                   `json:"devices_exporting"`
+	LastTemplateSend string                `json:"last_template_send,omitempty"`
+}
+
+// FlowCollectorStatus is one aggregate record in FlowStatus.Collectors.
+// Devices with the same (collector, protocol) tuple collapse into one
+// record; counters are cumulative since simulator start across every
+// device that has ever exported under that tuple.
+type FlowCollectorStatus struct {
+	Collector   string `json:"collector"`
+	Protocol    string `json:"protocol"`
+	Devices     int    `json:"devices"`
+	SentPackets uint64 `json:"sent_packets"`
+	SentBytes   uint64 `json:"sent_bytes"`
+	SentRecords uint64 `json:"sent_records"`
+}
+
+// ExportSeed carries the optional per-device export configs handed to
+// `CreateDevices` / `CreateDevicesWithOptions`. A non-nil field seeds
+// every device in the batch with a copy of the referenced config.
+// nil fields mean "no export of this type for this batch".
+type ExportSeed struct {
+	Flow   *DeviceFlowConfig
+	Traps  *DeviceTrapConfig
+	Syslog *DeviceSyslogConfig
+}
+
+// flowConnKey identifies a shared-socket pool entry. One pooled
+// *net.UDPConn exists per unique (collector, protocol) tuple when
+// `flowSourcePerDevice=false`.
+type flowConnKey struct {
+	collector string
+	protocol  string
 }

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -202,7 +202,12 @@ type SimulatorManager struct {
 	//   - simulator-wide concerns: buf pool, ticker goroutine, global tick
 	//     interval, global template interval (design §D5), and stat
 	//     counters aggregated across all devices.
-	flowConns            sync.Map // key: flowConnKey, value: *net.UDPConn (shared-socket fallback pool)
+	flowConns sync.Map // key: flowConnKey, value: *net.UDPConn (shared-socket fallback pool)
+	// flowAggregates holds monotonic per-(collector,protocol) counters
+	// that survive device deletion (review decision D1.b). Per-exporter
+	// counters are added here on device Stop; GetFlowStatus merges these
+	// with live-exporter counters to emit cumulative totals.
+	flowAggregates       sync.Map // key: flowConnKey, value: *flowCollectorAggregate
 	flowBufPool          sync.Pool
 	flowTickInterval     time.Duration
 	flowTemplateInterval time.Duration
@@ -210,6 +215,7 @@ type SimulatorManager struct {
 	flowStopCh           chan struct{}  // closed by Shutdown to stop the ticker goroutine
 	flowStopOnce         sync.Once      // ensures flowStopCh is closed exactly once
 	flowWg               sync.WaitGroup // tracks the ticker goroutine; Wait before tearing down pool
+	flowFirstAttachLog   sync.Once      // emits a single "flow export active" line on first per-device attach (review fix P4)
 
 	// Simulator-wide "last template send" stamp — aggregated from
 	// per-exporter ticks and surfaced via GetFlowStatus.

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -51,14 +51,48 @@ func createDevicesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Parse and validate per-device export blocks (phase 3 task 3.7).
+	// Each block is optional; missing or nil → export disabled for batch.
+	// Validation failures return 400 with the underlying error so the
+	// operator can see what went wrong. `Traps` and `Syslog` blocks pass
+	// through into the seed but the subsystems themselves still run off
+	// the old globals until phases 4/5 land.
+	seed := &ExportSeed{Flow: req.Flow, Traps: req.Traps, Syslog: req.Syslog}
+	if seed.Flow != nil {
+		seed.Flow.ApplyDefaults()
+		if err := seed.Flow.Validate(); err != nil {
+			sendErrorResponse(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if seed.Traps != nil {
+		seed.Traps.ApplyDefaults()
+		if err := seed.Traps.Validate(); err != nil {
+			sendErrorResponse(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if seed.Syslog != nil {
+		seed.Syslog.ApplyDefaults()
+		if err := seed.Syslog.Validate(); err != nil {
+			sendErrorResponse(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	// Collapse the seed to nil when no block was supplied so CreateDevices
+	// receives the exact "no export" signal rather than an empty shell.
+	if seed.Flow == nil && seed.Traps == nil && seed.Syslog == nil {
+		seed = nil
+	}
+
 	// Use CreateDevicesWithOptions if pre-allocation parameters are specified
 	if req.PreAllocate || req.MaxWorkers > 0 {
 		// If PreAllocate is not explicitly set but MaxWorkers is provided, enable pre-allocation
 		preAllocate := req.PreAllocate || req.MaxWorkers > 0
-		err = manager.CreateDevicesWithOptions(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, preAllocate, req.MaxWorkers, req.RoundRobin, req.Category, snmpPort)
+		err = manager.CreateDevicesWithOptions(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, preAllocate, req.MaxWorkers, req.RoundRobin, req.Category, snmpPort, seed)
 	} else {
 		// Use default behavior (auto pre-allocates for 10+ devices)
-		err = manager.CreateDevices(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, req.RoundRobin, req.Category, snmpPort)
+		err = manager.CreateDevices(req.StartIP, req.DeviceCount, req.Netmask, req.ResourceFile, req.SNMPv3, req.RoundRobin, req.Category, snmpPort, seed)
 	}
 	if err != nil {
 		sendErrorResponse(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Phase 3 of 8 in #118. **BREAKING** change to the flow-export status-endpoint response shape and the CLI-flag seeding semantics.

- `FlowExporter` now owns its collector / protocol / encoder / stat counters, instead of pulling from the manager at tick time. This lets heterogeneous fleets (mixed collectors, mixed protocols) tick through the same goroutine coherently.
- `SimulatorManager` retires `flowActive` + the single-collector globals (\`flowConn\`, \`flowCollectorAddr\`, \`flowCollectorStr\`, \`flowProtocol\`, \`flowEncoder\`, \`flowStat*\`). Replaced with a lazy-open pool of shared sockets keyed by \`(collector, protocol)\` for the \`-flow-source-per-device=false\` fallback path.
- Flow subsystem is now always-on (design §D9): \`initFlowSubsystem\` runs unconditionally from \`NewSimulatorManagerWithOptions\`; the ticker walks an empty list until the first device has \`flowConfig\`.
- \`InitFlowExport\` removed. Replaced by the extracted \`buildFlowEncoder\` helper + simulator-wide setters (\`SetFlowTickInterval\`, \`SetFlowTemplateInterval\`, \`SetFlowSourcePerDevice\`).
- CLI flags seed the \`-auto-start-ip\` batch only (per design §D3); REST-created devices must opt in via the \`flow\` block in \`POST /api/v1/devices\`.
- \`createDevicesHandler\` parses \`flow\` / \`traps\` / \`syslog\` blocks, applies defaults, validates, 400s on bad input, passes via \`ExportSeed\`. Traps / syslog wiring still lives in phases 4 / 5; their blocks flow through but the subsystems themselves are untouched.
- \`ListDevices\` echoes each device's resolved \`flow\` / \`traps\` / \`syslog\` config into \`DeviceInfo\`.

## Breaking changes

### \`GET /api/v1/flows/status\` JSON shape

Before:
\`\`\`json
{ \"enabled\": true, \"protocol\": \"netflow9\", \"collector\": \"...\",
  \"total_flows_exported\": N, \"total_packets_sent\": N,
  \"total_bytes_sent\": N, \"devices_exporting\": N,
  \"last_template_send\": \"...\" }
\`\`\`

After:
\`\`\`json
{ \"collectors\": [ { \"collector\": \"...\", \"protocol\": \"...\",
                    \"devices\": N, \"sent_packets\": N,
                    \"sent_bytes\": N, \"sent_records\": N } ],
  \"devices_exporting\": N, \"last_template_send\": \"...\" }
\`\`\`

\"Feature off\" is now \`len(collectors) == 0\` — no \`enabled\` field. Release-note migration guide lands in phase 7.

### CLI-flag semantics

Previously: \`--flow-collector\` globally enabled flow export; REST-created devices inherited those flags. After phase 3: CLI flags only seed the \`-auto-start-ip\` batch. REST bodies must include a \`flow\` block to opt in.

## Out of scope (intentional)

- Traps and syslog subsystems still use their own \`Xactive\` atomic + single-socket model (phases 4 / 5).
- Per-device \`TickInterval\` on \`DeviceFlowConfig\` is stored but not honored — single global ticker stays. Design debt noted in tasks.md.
- Pool refcount-by-scan at device delete time (shared sockets stay open until shutdown in phase 3; follow-up).
- Integration tests (task 3.10 partial) — pool fd-count semantics, atomic REST batch rejection; follow-up session.

## Test plan

- [x] \`go build ./simulator/\`
- [x] \`go test ./...\` (full suite, ~17s)
- [x] \`go vet .\`
- [x] \`gofmt -l\` clean on touched files
- [x] New: \`TestGetFlowStatus_NoExportingDevices\`, \`TestGetFlowStatus_AggregatesAcrossDevices\`, \`TestBuildFlowEncoder_UnknownProtocol\`, \`TestBuildFlowEncoder_SFlowCanonicalized\`
- [x] \`newTestFlowExporter\` + \`tickWithEncoder\` shims preserve pre-phase-3 wire-format test assertions across \`flow_exporter_test.go\`, \`netflow5_test.go\`, \`sflow_test.go\`

## Tracking

- Epic: #118
- Phase issue: #121
- Parent (phase 2): PR #127 (merged)
- Next: phase 4 (#122 trap refactor), phase 5 (#123 syslog refactor)