### PR TITLE
feat(export)!: refactor syslog export to per-device configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,11 +111,12 @@ The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-s
 - Optional top-level `snmpTrapEnterprise` field (string, dotted OID) per entry. When set, the encoder emits an additional `snmpTrapEnterprise.0` varbind (OID `1.3.6.1.6.3.1.1.4.3.0`) after the two mandatory ones — useful for v1↔v2c cross-compatibility on collectors that expect the enterprise OID per SNMPv2-MIB §10. Catalog-loader rejects reserved OIDs (`sysUpTime.0`, `snmpTrapOID.0`, `snmpTrapEnterprise.0`) as enterprise values. Omit the field to keep the backward-compatible 2-varbind prefix.
 
 **Trap operational notes:**
-- INFORM mode (`-trap-mode inform`) requires `-trap-source-per-device=true` (the default) so the per-device UDP socket can demux acks without a global request-id table. Startup fails with a clear error if the operator explicitly sets the flag false.
+- INFORM mode (`-trap-mode inform`) requires `-trap-source-per-device=true` (the default) so the per-device UDP socket can demux acks without a global request-id table. Enforced at device-attach time (phase 4 moved it out of startup).
 - Pending-inform map is bounded at 100 per device with oldest-drop overflow policy (exposed as `informsDropped` in `GET /api/v1/traps/status`).
 - Retransmissions consume global-cap tokens (design decision to prevent retry-storm amplification when the collector is unreachable).
 - Collector-side `rp_filter` may need relaxing (`net.ipv4.conf.*.rp_filter=0` or `2`) to accept UDP/162 with 10.42.0.0/16 source IPs — same caveat already documented for flow export.
 - Per-device UDP source binding reuses the same `setupVethPair` + `FORWARD -i veth-sim-host -j ACCEPT` iptables rule that flow export already relies on. No new netns / iptables surface.
+- **`StopTrapExport` is shutdown-only** (phase-5 review D1). It is not safe to race concurrent device creation: `startDeviceTrapExporter` captures scheduler / pool / encoder pointers under a short RLock and uses them outside that lock, so a concurrent Stop can leave orphan exporters or closed sockets. Today it is only called from the process-exit signal handler. Do not introduce a runtime "restart trap subsystem" control path without first tightening the attach-path lock discipline.
 
 **Trap HTTP endpoints:**
 - `GET /api/v1/traps/status` — JSON with `enabled`, `mode`, `sent`, INFORM counters (`informs_pending`, `informs_acked`, `informs_failed`, `informs_dropped` when mode=inform), `rate_limiter_tokens_available` (when `-trap-global-cap` is set), `devices_exporting`.
@@ -194,11 +195,12 @@ In every branch the result is run through `sanitiseHostname`: spaces become hyph
   Out-of-range integers or unknown names are rejected at catalog load.
 
 **Syslog operational notes:**
-- Only one format on the wire at a time — `-syslog-format 5424` (default) or `3164`. Mixed formats on one socket break auto-detecting parsers downstream; operators select one per deployment.
+- The format is per-device post-phase-5 — each device's `syslogConfig.Format` sets its own wire format. The shared-socket pool is keyed by `(collector, format)` so 5424 and 3164 streams never interleave on the same socket.
 - Per-device UDP source binding reuses the same `setupVethPair` + `FORWARD -i veth-sim-host -j ACCEPT` rule shared by flow / trap. No new netns / iptables surface.
-- Per-device bind failure is **non-fatal** for syslog (unlike INFORM): exporter logs a warning and falls back to the shared socket. When the primary per-device write fails but the shared fallback succeeds, the primary failure is logged and stats count the send as successful.
+- Per-device bind failure is **non-fatal** for syslog (unlike INFORM): exporter logs a warning and falls back to the shared socket. When the primary per-device write fails but the shared fallback succeeds, the primary failure is logged and stats count the send as successful. If **both** per-device bind and shared-pool open fail, the attach is rejected so `ListDevices` doesn't show a ghost entry.
 - The collector-side `rp_filter` caveat is the same as flow / trap — accept UDP from device IPs with `net.ipv4.conf.*.rp_filter=0` or `2`.
 - On-demand HTTP fires **bypass the global rate limiter** (test-harness use case; scheduler-driven traffic still honours `-syslog-global-cap`).
+- **`StopSyslogExport` is shutdown-only** (phase-5 review D1). Same constraint as trap: `startDeviceSyslogExporter` uses captured pointers outside the short RLock. Only called from the process-exit path today. Tightening is a pre-requisite for any runtime "restart" control plane.
 
 **Syslog HTTP endpoints:**
 - `GET /api/v1/syslog/status` — JSON with `enabled`, `format` (`5424` or `3164`), `collector`, `sent`, `send_failures`, `rate_limiter_tokens_available` (when `-syslog-global-cap` is set), `devices_exporting`.

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -306,12 +306,19 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 				}
 			}
 
-			// Initialize UDP syslog exporter if syslog export is enabled.
-			// Per-device bind failure is non-fatal (no ack path that requires
-			// symmetric source IPs); exporter falls back to the shared socket
-			// with an in-function warning log.
-			if sm.syslogActive.Load() {
-				sm.startDeviceSyslogExporter(device)
+			// Initialize UDP syslog exporter if this device has syslog
+			// config (set by applyExportSeed). Per-device bind failure
+			// is non-fatal for syslog — exporter falls back to the
+			// shared-pool socket with an in-function warning log. Other
+			// errors (bad format, unresolvable collector) nil the config
+			// so ListDevices doesn't show a ghost entry.
+			if device.syslogConfig != nil {
+				if err := sm.startDeviceSyslogExporter(device); err != nil {
+					log.Printf("syslog export: skipping device %s: %v", device.IP, err)
+					device.mu.Lock()
+					device.syslogConfig = nil
+					device.mu.Unlock()
+				}
 			}
 
 			// Cache the dynamic values using atomic for lock-free access
@@ -574,9 +581,14 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 		}
 	}
 
-	// Initialize UDP syslog exporter if syslog export is enabled.
-	if sm.syslogActive.Load() {
-		sm.startDeviceSyslogExporter(device)
+	// Initialize UDP syslog exporter if this device has syslog config.
+	if device.syslogConfig != nil {
+		if err := sm.startDeviceSyslogExporter(device); err != nil {
+			log.Printf("syslog export: skipping device %s: %v", device.IP, err)
+			device.mu.Lock()
+			device.syslogConfig = nil
+			device.mu.Unlock()
+		}
 	}
 
 	// Cache the dynamic values using atomic for lock-free access
@@ -731,16 +743,26 @@ func (d *DeviceSimulator) Stop() error {
 			manager.persistTrapCounters(d.trapExporter)
 		}
 		_ = d.trapExporter.Close()
-		if manager != nil && manager.trapScheduler != nil {
-			manager.trapScheduler.Deregister(d.IP)
+		// Snapshot the scheduler under manager.mu so the nil-check and
+		// the Deregister call can't split across a concurrent Stop*Export
+		// that nils the field (phase-5 review D3).
+		if sched := getTrapScheduler(manager); sched != nil {
+			sched.Deregister(d.IP)
 		}
 		d.trapExporter = nil
 	}
 
 	if d.syslogExporter != nil {
+		// Persist counters into the simulator-wide per-(collector,
+		// format) aggregate so /syslog/status reports monotonic totals
+		// across device churn. sync.Once-gated so it's single-shot even
+		// if StopSyslogExport also persists the same exporter.
+		if manager != nil {
+			manager.persistSyslogCounters(d.syslogExporter)
+		}
 		_ = d.syslogExporter.Close()
-		if manager != nil && manager.syslogScheduler != nil {
-			manager.syslogScheduler.Deregister(d.IP)
+		if sched := getSyslogScheduler(manager); sched != nil {
+			sched.Deregister(d.IP)
 		}
 		d.syslogExporter = nil
 	}
@@ -798,6 +820,10 @@ func (d *DeviceSimulator) stopListenersOnly() {
 		d.trapExporter = nil
 	}
 	if d.syslogExporter != nil {
+		// Persist counters before Close (sync.Once-gated).
+		if manager != nil {
+			manager.persistSyslogCounters(d.syslogExporter)
+		}
 		_ = d.syslogExporter.Close()
 		d.syslogExporter = nil
 	}

--- a/go/simulator/export_attach_test.go
+++ b/go/simulator/export_attach_test.go
@@ -1,0 +1,382 @@
+/*
+ * © 2025 Labmonkeys Space
+ * Apache-2.0 — see LICENSE.
+ *
+ * Integration-style tests that exercise the REAL
+ * `startDeviceTrapExporter` / `startDeviceSyslogExporter` attach paths
+ * end-to-end (review decision D3 from phase-4 trap-refactor review).
+ *
+ * The existing `startTrapForTest` / `startSyslogForTest` helpers
+ * construct exporters directly and bypass the attach logic — useful
+ * for happy-path behaviour but leaves the shared-pool wiring,
+ * first-attach log, scheduler register, and per-device-interval
+ * warning uncovered. These tests close that gap.
+ */
+
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// setupTestDeviceForAttach returns a DeviceSimulator initialised enough
+// for `startDeviceTrapExporter` / `startDeviceSyslogExporter` to run
+// end-to-end. Registers the device in `sm.devices` and
+// `sm.deviceTypesByIP`. Does NOT start any exporter; the caller wires
+// `trapConfig` / `syslogConfig` and then invokes the attach method.
+func setupTestDeviceForAttach(t *testing.T, sm *SimulatorManager, id string, ip net.IP) *DeviceSimulator {
+	t.Helper()
+	device := &DeviceSimulator{
+		ID:      id,
+		IP:      ip,
+		sysName: "test-host-" + id,
+	}
+	sm.mu.Lock()
+	sm.devices[id] = device
+	sm.deviceIPs[ip.String()] = struct{}{}
+	sm.deviceTypesByIP[ip.String()] = "cisco_ios" // arbitrary but valid slug
+	sm.mu.Unlock()
+	return device
+}
+
+// TestStartDeviceTrapExporter_FullAttachPath exercises the real attach
+// path: device config set, startDeviceTrapExporter called, scheduler
+// registered, status endpoint reflects the new collector.
+func TestStartDeviceTrapExporter_FullAttachPath(t *testing.T) {
+	sm := newTestSimulatorManager()
+	if err := sm.StartTrapSubsystem(TrapSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopTrapExport)
+
+	device := setupTestDeviceForAttach(t, sm, "dev-trap-1", net.IPv4(127, 0, 0, 2))
+	device.trapConfig = &DeviceTrapConfig{
+		Collector:     "127.0.0.1:16201",
+		Mode:          "trap",
+		Community:     "public",
+		Interval:      jsonDuration(time.Second),
+		InformTimeout: jsonDuration(200 * time.Millisecond),
+	}
+
+	if err := sm.startDeviceTrapExporter(device); err != nil {
+		t.Fatalf("startDeviceTrapExporter: %v", err)
+	}
+
+	device.mu.RLock()
+	exp := device.trapExporter
+	device.mu.RUnlock()
+	if exp == nil {
+		t.Fatal("device.trapExporter = nil after attach")
+	}
+	if got := exp.CollectorString(); got != "127.0.0.1:16201" {
+		t.Errorf("CollectorString = %q, want %q", got, "127.0.0.1:16201")
+	}
+	if exp.Mode() != TrapModeTrap {
+		t.Errorf("Mode = %v, want TrapModeTrap", exp.Mode())
+	}
+
+	st := sm.GetTrapStatus()
+	if !st.SubsystemActive {
+		t.Error("SubsystemActive = false after attach")
+	}
+	if len(st.Collectors) != 1 {
+		t.Fatalf("Collectors length = %d, want 1: %+v", len(st.Collectors), st.Collectors)
+	}
+	if st.Collectors[0].Collector != "127.0.0.1:16201" {
+		t.Errorf("Collector in status = %q", st.Collectors[0].Collector)
+	}
+	if st.Collectors[0].Devices != 1 {
+		t.Errorf("Devices in status = %d, want 1", st.Collectors[0].Devices)
+	}
+}
+
+// TestStartDeviceSyslogExporter_FullAttachPath exercises the real
+// syslog attach path end-to-end.
+func TestStartDeviceSyslogExporter_FullAttachPath(t *testing.T) {
+	sm := newTestSyslogManager()
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopSyslogExport)
+
+	device := setupTestDeviceForAttach(t, sm, "dev-syslog-1", net.IPv4(127, 0, 0, 3))
+	device.syslogConfig = &DeviceSyslogConfig{
+		Collector: "127.0.0.1:16514",
+		Format:    "5424",
+		Interval:  jsonDuration(time.Second),
+	}
+
+	if err := sm.startDeviceSyslogExporter(device); err != nil {
+		t.Fatalf("startDeviceSyslogExporter: %v", err)
+	}
+
+	device.mu.RLock()
+	exp := device.syslogExporter
+	device.mu.RUnlock()
+	if exp == nil {
+		t.Fatal("device.syslogExporter = nil after attach")
+	}
+	if got := exp.CollectorString(); got != "127.0.0.1:16514" {
+		t.Errorf("CollectorString = %q, want %q", got, "127.0.0.1:16514")
+	}
+	if got := exp.Format(); got != SyslogFormat5424 {
+		t.Errorf("Format = %q, want 5424", got)
+	}
+
+	st := sm.GetSyslogStatus()
+	if !st.SubsystemActive {
+		t.Error("SubsystemActive = false after attach")
+	}
+	if len(st.Collectors) != 1 {
+		t.Fatalf("Collectors length = %d, want 1: %+v", len(st.Collectors), st.Collectors)
+	}
+	c := st.Collectors[0]
+	if c.Collector != "127.0.0.1:16514" || c.Format != "5424" || c.Devices != 1 {
+		t.Errorf("Collector record = %+v", c)
+	}
+}
+
+// TestStartDeviceSyslogExporter_MonotonicCountersAcrossDeletion asserts
+// that persistSyslogCounters folds deleted devices' counters into the
+// status aggregate — mirror of the trap D1.b pattern.
+func TestStartDeviceSyslogExporter_MonotonicCountersAcrossDeletion(t *testing.T) {
+	sm := newTestSyslogManager()
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopSyslogExport)
+
+	device := setupTestDeviceForAttach(t, sm, "dev-syslog-mono", net.IPv4(127, 0, 0, 4))
+	device.syslogConfig = &DeviceSyslogConfig{
+		Collector: "127.0.0.1:16515",
+		Format:    "5424",
+	}
+	if err := sm.startDeviceSyslogExporter(device); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate some sends directly into the exporter stats.
+	device.syslogExporter.stats.Sent.Add(7)
+	device.syslogExporter.stats.SendFailures.Add(2)
+
+	// Persist and close (mirrors device.Stop).
+	sm.persistSyslogCounters(device.syslogExporter)
+	_ = device.syslogExporter.Close()
+	device.mu.Lock()
+	device.syslogExporter = nil
+	device.mu.Unlock()
+
+	// Remove the device from sm.devices so Collectors is computed from
+	// the aggregate alone.
+	sm.mu.Lock()
+	delete(sm.devices, device.ID)
+	sm.mu.Unlock()
+
+	st := sm.GetSyslogStatus()
+	if len(st.Collectors) != 1 {
+		t.Fatalf("Collectors = %+v, want one record from the persisted aggregate", st.Collectors)
+	}
+	c := st.Collectors[0]
+	if c.Sent != 7 || c.SendFailures != 2 || c.Devices != 0 {
+		t.Errorf("persisted counters = %+v, want Sent=7 SendFailures=2 Devices=0", c)
+	}
+	// Phase-5 review P16: the top-level DevicesExporting should be 0
+	// once no live exporters remain, even though the aggregate is
+	// populated — it counts live exporters only.
+	if st.DevicesExporting != 0 {
+		t.Errorf("DevicesExporting = %d, want 0 after device deletion", st.DevicesExporting)
+	}
+	if !st.SubsystemActive {
+		t.Error("SubsystemActive should still be true until StopSyslogExport runs")
+	}
+}
+
+// TestStartSyslogSubsystem_PostStopShape asserts the observable shape
+// after Start → Stop: SubsystemActive=false and Collectors=empty. The
+// post-Stop state and the never-started state are distinguishable only
+// by SubsystemActive. Phase-5 review P15 gap (comment + test).
+func TestStartSyslogSubsystem_PostStopShape(t *testing.T) {
+	sm := newTestSyslogManager()
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st := sm.GetSyslogStatus()
+	if !st.SubsystemActive {
+		t.Fatal("SubsystemActive should be true after Start")
+	}
+
+	sm.StopSyslogExport()
+
+	st = sm.GetSyslogStatus()
+	if st.SubsystemActive {
+		t.Error("SubsystemActive should be false after Stop")
+	}
+	if len(st.Collectors) != 0 {
+		t.Errorf("Collectors = %+v, want empty after Stop", st.Collectors)
+	}
+	if st.CatalogsByType != nil {
+		t.Errorf("CatalogsByType = %+v, want nil after Stop", st.CatalogsByType)
+	}
+}
+
+// TestDeviceStop_PersistsSyslogCountersViaRealLifecycle drives
+// `device.Stop()` end-to-end (rather than calling persistSyslogCounters
+// manually) so a future refactor that drops the persist call from Stop
+// regresses this test. Phase-5 review D2 upgrade.
+func TestDeviceStop_PersistsSyslogCountersViaRealLifecycle(t *testing.T) {
+	sm := newTestSyslogManager()
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopSyslogExport)
+
+	// Install sm as the package-level `manager` so device.Stop can
+	// reach persistSyslogCounters.
+	withManager(t, sm)
+
+	device := setupTestDeviceForAttach(t, sm, "dev-stop-syslog", net.IPv4(127, 0, 0, 11))
+	device.syslogConfig = &DeviceSyslogConfig{
+		Collector: "127.0.0.1:16611",
+		Format:    "5424",
+	}
+	if err := sm.startDeviceSyslogExporter(device); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject counter values that the Stop path must preserve.
+	device.syslogExporter.stats.Sent.Add(11)
+	device.syslogExporter.stats.SendFailures.Add(3)
+
+	// `Stop()` early-returns unless d.running is true — mimic a live
+	// device. All servers are nil-guarded, so the bare device stops
+	// cleanly.
+	device.running = true
+	if err := device.Stop(); err != nil {
+		t.Fatalf("device.Stop: %v", err)
+	}
+	if device.syslogExporter != nil {
+		t.Error("device.syslogExporter should be nil after Stop")
+	}
+	if device.running {
+		t.Error("device.running should be false after Stop")
+	}
+
+	// Remove from sm.devices so the aggregate is the sole counter
+	// source in the status view.
+	sm.mu.Lock()
+	delete(sm.devices, device.ID)
+	sm.mu.Unlock()
+
+	st := sm.GetSyslogStatus()
+	if len(st.Collectors) != 1 {
+		t.Fatalf("Collectors = %+v, want one record persisted by device.Stop", st.Collectors)
+	}
+	c := st.Collectors[0]
+	if c.Sent != 11 || c.SendFailures != 3 {
+		t.Errorf("persisted counters = %+v, want Sent=11 SendFailures=3", c)
+	}
+	if c.Devices != 0 {
+		t.Errorf("Devices = %d, want 0 after deletion", c.Devices)
+	}
+}
+
+// TestDeviceStop_PersistsTrapCountersViaRealLifecycle — symmetric trap
+// variant so a future refactor dropping persistTrapCounters from
+// device.Stop regresses a test.
+func TestDeviceStop_PersistsTrapCountersViaRealLifecycle(t *testing.T) {
+	sm := newTestSimulatorManager()
+	if err := sm.StartTrapSubsystem(TrapSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopTrapExport)
+
+	withManager(t, sm)
+
+	device := setupTestDeviceForAttach(t, sm, "dev-stop-trap", net.IPv4(127, 0, 0, 12))
+	device.trapConfig = &DeviceTrapConfig{
+		Collector:     "127.0.0.1:16612",
+		Mode:          "trap",
+		Community:     "public",
+		Interval:      jsonDuration(time.Second),
+		InformTimeout: jsonDuration(200 * time.Millisecond),
+	}
+	if err := sm.startDeviceTrapExporter(device); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject counter values that the Stop path must preserve.
+	device.trapExporter.Stats().Sent.Add(13)
+	device.trapExporter.Stats().InformsAcked.Add(5)
+	device.trapExporter.Stats().InformsFailed.Add(2)
+
+	device.running = true
+	if err := device.Stop(); err != nil {
+		t.Fatalf("device.Stop: %v", err)
+	}
+	if device.trapExporter != nil {
+		t.Error("device.trapExporter should be nil after Stop")
+	}
+
+	sm.mu.Lock()
+	delete(sm.devices, device.ID)
+	sm.mu.Unlock()
+
+	st := sm.GetTrapStatus()
+	if len(st.Collectors) != 1 {
+		t.Fatalf("Collectors = %+v, want one record persisted by device.Stop", st.Collectors)
+	}
+	c := st.Collectors[0]
+	if c.Sent != 13 {
+		t.Errorf("persisted Sent = %d, want 13", c.Sent)
+	}
+	// InformsAcked/Failed are TRAP-mode zero (mode=trap), so they should
+	// NOT be folded per the mode check in persistTrapCounters. Verify.
+	if c.InformsAcked != 0 || c.InformsFailed != 0 {
+		t.Errorf("INFORM counters should be 0 for trap-mode aggregate: %+v", c)
+	}
+}
+
+// TestStartTrapSubsystem_PostStopShape — symmetric test on the trap
+// side so the two subsystems stay in lock-step.
+func TestStartTrapSubsystem_PostStopShape(t *testing.T) {
+	sm := newTestSimulatorManager()
+	if err := sm.StartTrapSubsystem(TrapSubsystemConfig{
+		MeanSchedulerInterval: time.Second,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !sm.GetTrapStatus().SubsystemActive {
+		t.Fatal("SubsystemActive should be true after Start")
+	}
+
+	sm.StopTrapExport()
+
+	st := sm.GetTrapStatus()
+	if st.SubsystemActive {
+		t.Error("SubsystemActive should be false after Stop")
+	}
+	if len(st.Collectors) != 0 {
+		t.Errorf("Collectors = %+v, want empty after Stop", st.Collectors)
+	}
+	if st.CatalogsByType != nil {
+		t.Errorf("CatalogsByType = %+v, want nil after Stop", st.CatalogsByType)
+	}
+}

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -264,24 +264,35 @@ func main() {
 		}
 	}
 
-	// Enable UDP syslog export if a collector address was provided.
-	// Must run before device creation so per-device SyslogExporters are
-	// wired during startup.
+	// Start the UDP syslog subsystem unconditionally so REST-created
+	// devices can opt in to syslog even when no CLI seed is provided.
+	// Phase 5 of per-device-export-config: simulator-wide knobs
+	// (catalog, global cap, per-device-source, scheduler mean interval)
+	// live on the manager; per-device knobs (collector, format,
+	// interval) live on each DeviceSyslogConfig.
+	if err := manager.StartSyslogSubsystem(SyslogSubsystemConfig{
+		CatalogPath:           *syslogCatalog,
+		GlobalCap:             *syslogGlobalCap,
+		SourcePerDevice:       *syslogSourcePerDevice,
+		MeanSchedulerInterval: *syslogInterval,
+	}); err != nil {
+		log.Fatalf("Failed to initialize syslog subsystem: %v", err)
+	}
+
+	// Build the CLI-seed syslog config for the auto-start batch. Mirrors
+	// the flow-seed and trap-seed patterns. `DeviceSyslogConfig.Validate`
+	// canonicalises Format via ParseSyslogFormat, so a malformed
+	// -syslog-format surfaces here.
+	var syslogSeed *DeviceSyslogConfig
 	if *syslogCollector != "" {
-		format, err := ParseSyslogFormat(*syslogFormat)
-		if err != nil {
-			log.Fatalf("Failed to initialize syslog export: %v", err)
+		syslogSeed = &DeviceSyslogConfig{
+			Collector: *syslogCollector,
+			Format:    *syslogFormat,
+			Interval:  jsonDuration(*syslogInterval),
 		}
-		cfg := SyslogConfig{
-			Collector:       *syslogCollector,
-			Format:          format,
-			Interval:        *syslogInterval,
-			GlobalCap:       *syslogGlobalCap,
-			CatalogPath:     *syslogCatalog,
-			SourcePerDevice: *syslogSourcePerDevice,
-		}
-		if err := manager.StartSyslogExport(cfg); err != nil {
-			log.Fatalf("Failed to initialize syslog export: %v", err)
+		syslogSeed.ApplyDefaults()
+		if err := syslogSeed.Validate(); err != nil {
+			log.Fatalf("syslog export: invalid -syslog-* CLI seed: %v", err)
 		}
 	}
 
@@ -338,7 +349,7 @@ func main() {
 					*snmpv3EngineID, *snmpv3AuthProto, *snmpv3PrivProto)
 			}
 
-			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort, &ExportSeed{Flow: flowSeed, Traps: trapSeed})
+			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort, &ExportSeed{Flow: flowSeed, Traps: trapSeed, Syslog: syslogSeed})
 			if err != nil {
 				log.Printf("Failed to auto-create devices: %v", err)
 			} else {

--- a/go/simulator/syslog_api_test.go
+++ b/go/simulator/syslog_api_test.go
@@ -17,127 +17,107 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Config validation
+// Subsystem validation
 // ---------------------------------------------------------------------------
 
-func TestStartSyslogExport_RejectsEmptyCollector(t *testing.T) {
+// TestStartSyslogSubsystem_RejectsNegativeGlobalCap asserts the subsystem-level
+// guard. Per-device-config validation lives in DeviceSyslogConfig.Validate
+// and is covered in export_config_test.go.
+func TestStartSyslogSubsystem_RejectsNegativeGlobalCap(t *testing.T) {
 	sm := newTestSyslogManager()
-	err := sm.StartSyslogExport(SyslogConfig{Interval: time.Second})
-	if err == nil || !strings.Contains(err.Error(), "-syslog-collector") {
-		t.Fatalf("want empty-collector error, got %v", err)
-	}
-	if sm.syslogActive.Load() {
-		t.Error("syslogActive should remain false after failed StartSyslogExport")
-	}
-}
-
-func TestStartSyslogExport_RejectsNonPositiveInterval(t *testing.T) {
-	sm := newTestSyslogManager()
-	err := sm.StartSyslogExport(SyslogConfig{
-		Collector: "127.0.0.1:16500",
-		Interval:  0,
-	})
-	if err == nil || !strings.Contains(err.Error(), "-syslog-interval") {
-		t.Fatalf("want interval error, got %v", err)
+	err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{GlobalCap: -1})
+	if err == nil || !strings.Contains(err.Error(), "global-cap") {
+		t.Fatalf("want global-cap error, got %v", err)
 	}
 }
 
-func TestStartSyslogExport_RejectsNegativeCap(t *testing.T) {
+// TestStartSyslogSubsystem_DoubleStartRejected confirms idempotency: a
+// second Start without StopSyslogExport in between returns an error
+// instead of silently replacing the scheduler.
+func TestStartSyslogSubsystem_DoubleStartRejected(t *testing.T) {
 	sm := newTestSyslogManager()
-	err := sm.StartSyslogExport(SyslogConfig{
-		Collector: "127.0.0.1:16501",
-		Interval:  time.Second,
-		GlobalCap: -1,
-	})
-	if err == nil || !strings.Contains(err.Error(), "-syslog-global-cap") {
-		t.Fatalf("want cap error, got %v", err)
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{MeanSchedulerInterval: time.Second}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopSyslogExport)
+
+	err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{MeanSchedulerInterval: time.Second})
+	if err == nil || !strings.Contains(err.Error(), "already started") {
+		t.Fatalf("want already-started error, got %v", err)
 	}
 }
 
-func TestStartSyslogExport_RejectsUnresolvableCollector(t *testing.T) {
+// TestStartDeviceSyslogExporter_RejectsBadFormat asserts per-device
+// validation at attach-time: a malformed Format in DeviceSyslogConfig
+// fails before any socket is opened.
+func TestStartDeviceSyslogExporter_RejectsBadFormat(t *testing.T) {
 	sm := newTestSyslogManager()
-	err := sm.StartSyslogExport(SyslogConfig{
-		Collector: "host-does-not-resolve.invalid:514",
-		Interval:  time.Second,
-	})
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Second,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopSyslogExport)
+
+	device := &DeviceSimulator{
+		ID: "test-device",
+		IP: net.IPv4(127, 0, 0, 1),
+		syslogConfig: &DeviceSyslogConfig{
+			Collector: "127.0.0.1:16500",
+			Format:    "notAFormat",
+			Interval:  jsonDuration(time.Second),
+		},
+	}
+	err := sm.startDeviceSyslogExporter(device)
 	if err == nil {
 		t.Fatal("want error, got nil")
 	}
-	if !strings.Contains(err.Error(), "invalid collector address") && !strings.Contains(err.Error(), "no such host") {
-		t.Errorf("error %q: want mention of invalid collector", err)
+	if !strings.Contains(err.Error(), "format") {
+		t.Errorf("error should mention format: %v", err)
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Lifecycle happy path
-// ---------------------------------------------------------------------------
-
-func TestStartStopSyslogExport_HappyPath(t *testing.T) {
-	sm := newTestSyslogManager()
-	collector, collectorAddr := newLocalUDPCollector(t)
-	_ = collector // collector is cleaned up by t.Cleanup
-
-	err := sm.StartSyslogExport(SyslogConfig{
-		Collector:       collectorAddr.String(),
-		Format:          SyslogFormat5424,
-		Interval:        time.Second,
-		SourcePerDevice: false, // tests run without netns
-	})
-	if err != nil {
-		t.Fatalf("StartSyslogExport: %v", err)
-	}
-	if !sm.syslogActive.Load() {
-		t.Fatal("syslogActive should be true after successful Start")
-	}
-	if sm.syslogCatalog == nil || len(sm.syslogCatalog.Entries) != 6 {
-		t.Errorf("embedded catalog not loaded: %v", sm.syslogCatalog)
-	}
-
-	// Idempotency: second Start without Stop should fail.
-	if err := sm.StartSyslogExport(SyslogConfig{
-		Collector: collectorAddr.String(),
-		Interval:  time.Second,
-	}); err == nil {
-		t.Error("second Start should refuse without a Stop")
-	}
-
-	sm.StopSyslogExport()
-	if sm.syslogActive.Load() {
-		t.Error("syslogActive should be false after Stop")
-	}
-	// Stop is idempotent.
-	sm.StopSyslogExport()
 }
 
 // ---------------------------------------------------------------------------
 // GetSyslogStatus
 // ---------------------------------------------------------------------------
 
+// TestGetSyslogStatus_Disabled asserts the "feature off" shape after
+// phase 5: an empty Collectors array and no catalogs_by_type.
 func TestGetSyslogStatus_Disabled(t *testing.T) {
 	sm := newTestSyslogManager()
 	st := sm.GetSyslogStatus()
-	if st.Enabled {
-		t.Error("Enabled should be false when feature not started")
+	if len(st.Collectors) != 0 {
+		t.Errorf("Collectors = %v, want empty when subsystem not started", st.Collectors)
 	}
-	if st.Format != "" || st.Collector != "" {
-		t.Errorf("Format/Collector should be empty when disabled: %+v", st)
+	if st.DevicesExporting != 0 {
+		t.Errorf("DevicesExporting = %d, want 0", st.DevicesExporting)
+	}
+	if st.CatalogsByType != nil {
+		t.Errorf("CatalogsByType = %v, want nil when subsystem not started", st.CatalogsByType)
 	}
 }
 
+// TestGetSyslogStatus_EnabledShape asserts Collectors is populated with
+// the device's (collector, format) tuple once a device is attached.
 func TestGetSyslogStatus_EnabledShape(t *testing.T) {
 	sm, _, _ := startSyslogForTest(t, SyslogFormat3164)
 	st := sm.GetSyslogStatus()
-	if !st.Enabled {
-		t.Fatal("Enabled should be true")
+	if len(st.Collectors) != 1 {
+		t.Fatalf("Collectors length = %d, want 1: %+v", len(st.Collectors), st.Collectors)
 	}
-	if st.Format != "3164" {
-		t.Errorf("Format: got %q, want 3164", st.Format)
+	c := st.Collectors[0]
+	if c.Format != "3164" {
+		t.Errorf("Format = %q, want 3164", c.Format)
 	}
-	if st.Collector == "" {
+	if c.Devices != 1 {
+		t.Errorf("Devices = %d, want 1", c.Devices)
+	}
+	if c.Collector == "" {
 		t.Error("Collector should be populated")
 	}
 	if st.DevicesExporting != 1 {
-		t.Errorf("DevicesExporting: got %d, want 1 (test fixture has one device)", st.DevicesExporting)
+		t.Errorf("DevicesExporting: got %d, want 1", st.DevicesExporting)
 	}
 }
 
@@ -164,11 +144,11 @@ func TestFireSyslogOnDevice_HappyPath(t *testing.T) {
 	if !strings.Contains(wire, "LINKDOWN") {
 		t.Errorf("wire missing MsgID: %q", wire)
 	}
-	// Spec Requirement "On-demand HTTP syslog endpoint" scenario "Valid
-	// request returns 202" says "AND the sent counter SHALL increment
-	// by 1". Verify via the status endpoint.
-	if got := sm.GetSyslogStatus().Sent; got != 1 {
-		t.Errorf("SyslogStatus.Sent after one Fire: got %d, want 1", got)
+	// Spec: sent counter increments by 1 — verified via the status
+	// endpoint's per-collector aggregate.
+	st := sm.GetSyslogStatus()
+	if len(st.Collectors) == 0 || st.Collectors[0].Sent != 1 {
+		t.Errorf("SyslogStatus.Collectors[0].Sent after one Fire: got %+v, want 1", st.Collectors)
 	}
 }
 
@@ -255,8 +235,8 @@ func TestSyslogHTTP_StatusEndpointDisabled(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode body: %v — raw=%q", err, rr.Body.String())
 	}
-	if body.Enabled {
-		t.Errorf("Enabled: got %v, want false when feature disabled", body.Enabled)
+	if len(body.Collectors) != 0 {
+		t.Errorf("Collectors: got %v, want empty when feature disabled", body.Collectors)
 	}
 }
 
@@ -275,7 +255,7 @@ func TestSyslogHTTP_StatusEndpointEnabled(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if !body.Enabled || body.Format != "5424" || body.DevicesExporting != 1 {
+	if len(body.Collectors) != 1 || body.Collectors[0].Format != "5424" || body.DevicesExporting != 1 {
 		t.Errorf("enabled status unexpected: %+v", body)
 	}
 }
@@ -389,55 +369,66 @@ func newTestSyslogManager() *SimulatorManager {
 		deviceIPs:        make(map[string]struct{}),
 		resourcesCache:   make(map[string]*DeviceResources),
 		tunInterfacePool: make(map[string]*TunInterface),
+		deviceTypesByIP:  make(map[string]string),
 	}
 }
 
-// startSyslogForTest stands up a SimulatorManager with syslog export
-// active, registers one fake device with a SyslogExporter writing via a
-// shared socket (no netns). Returns the manager, the collector socket (for
-// reading emitted datagrams), and the fake device. Registers t.Cleanup.
+// startSyslogForTest stands up a SimulatorManager with the syslog
+// subsystem running and registers one fake device with a
+// SyslogExporter writing via a shared socket (no netns). Returns the
+// manager, the collector socket (for reading emitted datagrams), and
+// the fake device. Registers t.Cleanup.
 func startSyslogForTest(t *testing.T, format SyslogFormat) (*SimulatorManager, *net.UDPConn, *DeviceSimulator) {
 	t.Helper()
 	sm := newTestSyslogManager()
 	collector, collectorAddr := newLocalUDPCollector(t)
 
-	err := sm.StartSyslogExport(SyslogConfig{
-		Collector: collectorAddr.String(),
-		Format:    format,
-		// One hour, not ten seconds: the scheduler's Poisson draw has an
-		// unbounded tail, and at 10s the ~1% of runs with a sub-second
-		// tail draw made `TestFireSyslogOnDevice_OverridesApplied` read
-		// the scheduled datagram instead of the explicit-fire one.
-		Interval:        time.Hour,
-		SourcePerDevice: false, // no netns available in unit tests
-	})
-	if err != nil {
-		t.Fatalf("StartSyslogExport: %v", err)
+	// One hour, not ten seconds: the scheduler's Poisson draw has an
+	// unbounded tail, and at 10s the ~1% of runs with a sub-second tail
+	// draw made `TestFireSyslogOnDevice_OverridesApplied` read the
+	// scheduled datagram instead of the explicit-fire one.
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatalf("StartSyslogSubsystem: %v", err)
 	}
 
-	// Build a fake device with a SyslogExporter that writes via the
-	// manager's shared socket (SharedConn). This mirrors what
-	// startDeviceSyslogExporter does but without touching netns.
+	// Build a fake device with a SyslogExporter that writes via a
+	// dedicated shared socket (not the manager's pool, so the test
+	// owns its lifetime). Mirrors what startDeviceSyslogExporter does
+	// but without touching netns.
+	sharedConn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		t.Fatalf("open shared udp: %v", err)
+	}
+	t.Cleanup(func() { _ = sharedConn.Close() })
+
+	encoder, err := sm.syslogEncoderFor(format)
+	if err != nil {
+		t.Fatalf("encoder: %v", err)
+	}
+
 	device := &DeviceSimulator{
 		ID:      "test-device",
 		IP:      net.IPv4(127, 0, 0, 1),
 		sysName: "test-host",
 	}
 	exp := NewSyslogExporter(SyslogExporterOptions{
-		DeviceIP:   device.IP,
-		Encoder:    sm.syslogEncoder,
-		Collector:  sm.syslogCollectorAddr,
-		SharedConn: sm.syslogConn,
-		SysName:    device.sysName,
-		IfIndexFn:  func() int { return 3 },
-		IfNameFn:   func(i int) string { return "GigabitEthernet0/3" },
+		DeviceIP:     device.IP,
+		Encoder:      encoder,
+		Collector:    collectorAddr,
+		CollectorStr: collectorAddr.String(),
+		Format:       format,
+		SharedConn:   sharedConn,
+		SysName:      device.sysName,
+		IfIndexFn:    func() int { return 3 },
+		IfNameFn:     func(i int) string { return "GigabitEthernet0/3" },
 	})
 	device.syslogExporter = exp
 	sm.devices[device.ID] = device
 	sm.deviceIPs[device.IP.String()] = struct{}{}
-	if sm.syslogScheduler != nil {
-		sm.syslogScheduler.Register(device.IP, exp)
-	}
+	sm.syslogScheduler.Register(device.IP, exp)
 
 	t.Cleanup(func() {
 		sm.StopSyslogExport()

--- a/go/simulator/syslog_exporter.go
+++ b/go/simulator/syslog_exporter.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -54,9 +55,22 @@ type SyslogStats struct {
 // been bound inside the device's network namespace. Close releases the
 // socket and marks the exporter as closing (subsequent Fire calls no-op).
 type SyslogExporter struct {
-	deviceIP  net.IP
-	encoder   SyslogEncoder
-	collector *net.UDPAddr
+	deviceIP     net.IP
+	encoder      SyslogEncoder
+	collector    *net.UDPAddr
+	collectorStr string       // canonical "host:port" for status aggregation keying
+	format       SyslogFormat // wire format this exporter is emitting
+
+	// firstWriteErr gates at most one log line per exporter on a failed
+	// write (review fix pattern from trap phase 4 P8).
+	firstWriteErr sync.Once
+
+	// countersPersisted ensures SimulatorManager.persistSyslogCounters adds
+	// this exporter's counters into the simulator-wide aggregate at most
+	// once. Both device.Stop / stopListenersOnly and StopSyslogExport can
+	// invoke persistence; the sync.Once makes it race-free without
+	// per-callsite locking.
+	countersPersisted sync.Once
 
 	// conn is the per-device UDP socket. Nil when per-device binding was
 	// disabled or failed and the fallback shared socket is used. Stored as
@@ -97,11 +111,13 @@ type SyslogExporter struct {
 
 // SyslogExporterOptions bundles per-device exporter configuration.
 type SyslogExporterOptions struct {
-	DeviceIP   net.IP
-	Encoder    SyslogEncoder
-	Collector  *net.UDPAddr
-	SharedConn *net.UDPConn // fallback; may be nil
-	SysName    string       // device's sysName.0 value — empty falls back to DeviceIP at encode time
+	DeviceIP     net.IP
+	Encoder      SyslogEncoder
+	Collector    *net.UDPAddr
+	CollectorStr string       // canonical "host:port"; used for status aggregation key
+	Format       SyslogFormat // wire format; used for status aggregation key
+	SharedConn   *net.UDPConn // fallback; may be nil
+	SysName      string       // device's sysName.0 value — empty falls back to DeviceIP at encode time
 	// Class 1 device-context fields. Constant for the device's lifetime;
 	// consumed by `{{.Model}}` / `{{.Serial}}` / `{{.ChassisID}}` in the
 	// unified template vocabulary.
@@ -138,19 +154,44 @@ func NewSyslogExporter(opts SyslogExporterOptions) *SyslogExporter {
 		opts.IfNameFn = func(int) string { return "" }
 	}
 	return &SyslogExporter{
-		deviceIP:   append(net.IP(nil), opts.DeviceIP...),
-		encoder:    opts.Encoder,
-		collector:  opts.Collector,
-		sharedConn: opts.SharedConn,
-		sysName:    opts.SysName,
-		model:      opts.Model,
-		serial:     opts.Serial,
-		chassisID:  opts.ChassisID,
-		ifIndexFn:  opts.IfIndexFn,
-		ifNameFn:   opts.IfNameFn,
-		startTime:  time.Now(),
-		stats:      &SyslogStats{},
+		deviceIP:     append(net.IP(nil), opts.DeviceIP...),
+		encoder:      opts.Encoder,
+		collector:    opts.Collector,
+		collectorStr: opts.CollectorStr,
+		format:       opts.Format,
+		sharedConn:   opts.SharedConn,
+		sysName:      opts.SysName,
+		model:        opts.Model,
+		serial:       opts.Serial,
+		chassisID:    opts.ChassisID,
+		ifIndexFn:    opts.IfIndexFn,
+		ifNameFn:     opts.IfNameFn,
+		startTime:    time.Now(),
+		stats:        &SyslogStats{},
 	}
+}
+
+// CollectorString returns the canonical "host:port" string identifying
+// this exporter's destination. Used as the (collector, format) key for
+// the shared-socket pool and the status-endpoint aggregate.
+func (e *SyslogExporter) CollectorString() string { return e.collectorStr }
+
+// Format returns the exporter's wire format (5424 or 3164). Used as the
+// (collector, format) key for the status-endpoint aggregate.
+func (e *SyslogExporter) Format() SyslogFormat { return e.format }
+
+// logFirstWriteErr emits at most one log line per exporter on a failed
+// write. Gated by e.firstWriteErr so a down/misconfigured collector
+// doesn't flood logs at fire cadence × device count (mirror of
+// TrapExporter.logFirstWriteErr from trap phase 4 P8).
+func (e *SyslogExporter) logFirstWriteErr(err error) {
+	if e == nil || err == nil {
+		return
+	}
+	e.firstWriteErr.Do(func() {
+		log.Printf("syslog export: device %s write to %s failed: %v (further errors suppressed for this exporter)",
+			e.deviceIP, e.collectorStr, err)
+	})
 }
 
 // SetConn installs the per-device UDP socket. Must be called before the
@@ -260,8 +301,10 @@ func (e *SyslogExporter) writeDatagram(pdu []byte) error {
 	}
 	if e.sharedConn == nil {
 		if primaryErr != nil {
+			e.logFirstWriteErr(primaryErr)
 			return primaryErr
 		}
+		e.logFirstWriteErr(errNoSyslogSocket)
 		return errNoSyslogSocket
 	}
 	_, err := e.sharedConn.WriteToUDP(pdu, e.collector)
@@ -275,10 +318,14 @@ func (e *SyslogExporter) writeDatagram(pdu []byte) error {
 		return nil
 	}
 	sharedErr := fmt.Errorf("shared socket: %w", err)
+	var finalErr error
 	if primaryErr != nil {
-		return errors.Join(primaryErr, sharedErr)
+		finalErr = errors.Join(primaryErr, sharedErr)
+	} else {
+		finalErr = sharedErr
 	}
-	return sharedErr
+	e.logFirstWriteErr(finalErr)
+	return finalErr
 }
 
 // uptimeHundredths returns device uptime in 1/100-second ticks, matching

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -15,11 +15,12 @@
 
 // SimulatorManager-level UDP syslog export lifecycle.
 //
-// Parses the SyslogConfig surfaced by CLI flags, loads the catalog (embedded
-// or file override), creates the shared SyslogScheduler + SyslogEncoder, and
-// starts the scheduler goroutine. Wires per-device SyslogExporters into
-// device startup/teardown (see device.go) and exposes GetSyslogStatus +
-// FireSyslogOnDevice for the HTTP API.
+// `StartSyslogSubsystem` loads the catalog (embedded or file override), creates
+// the shared SyslogScheduler and optional rate limiter, and starts the
+// scheduler goroutine. Per-device SyslogExporters are wired in from device
+// startup/teardown (see device.go) against each device's `DeviceSyslogConfig`.
+// GetSyslogStatus exposes the aggregated per-(collector, format) counters to
+// the HTTP API.
 
 package main
 
@@ -31,33 +32,57 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
 )
 
-// SyslogConfig bundles CLI-derived configuration for the syslog subsystem.
-// Empty Collector disables the feature.
-type SyslogConfig struct {
-	Collector       string
-	Format          SyslogFormat
-	Interval        time.Duration
-	GlobalCap       int // 0 = unlimited
-	CatalogPath     string
-	SourcePerDevice bool
+// SyslogStatus is the JSON body returned by GET /api/v1/syslog/status.
+//
+// Shape matches TrapStatus: per-device-export-config phase 5 returns an
+// array-of-collectors aggregated across devices. Legacy scalar fields
+// (enabled/format/collector/sent/send_failures) retired. Use
+// `SubsystemActive` to distinguish "never started" from "started with
+// zero devices"; `len(collectors) == 0` no longer implies feature off.
+//
+// `CatalogsByType` and `RateLimiterTokensAvailable` remain top-level.
+type SyslogStatus struct {
+	SubsystemActive            bool                         `json:"subsystem_active"`
+	Collectors                 []SyslogCollectorStatus      `json:"collectors"`
+	DevicesExporting           int                          `json:"devices_exporting"`
+	RateLimiterTokensAvailable int                          `json:"rate_limiter_tokens_available,omitempty"`
+	CatalogsByType             map[string]CatalogSourceInfo `json:"catalogs_by_type,omitempty"`
 }
 
-// SyslogStatus is the JSON body returned by GET /api/v1/syslog/status. Field
-// shape matches spec Requirement "Syslog status HTTP endpoint".
-type SyslogStatus struct {
-	Enabled                    bool                         `json:"enabled"`
-	Format                     string                       `json:"format,omitempty"`
-	Collector                  string                       `json:"collector,omitempty"`
-	Sent                       uint64                       `json:"sent"`
-	SendFailures               uint64                       `json:"send_failures"`
-	RateLimiterTokensAvailable int                          `json:"rate_limiter_tokens_available,omitempty"`
-	DevicesExporting           int                          `json:"devices_exporting"`
-	CatalogsByType             map[string]CatalogSourceInfo `json:"catalogs_by_type,omitempty"`
+// SyslogCollectorStatus is one aggregate record in SyslogStatus.Collectors.
+// Devices with the same (collector, format) tuple collapse into one record;
+// counters are cumulative since simulator start (monotonic — persisted
+// counters from deleted devices are merged at read time).
+type SyslogCollectorStatus struct {
+	Collector    string `json:"collector"`
+	Format       string `json:"format"`
+	Devices      int    `json:"devices"`
+	Sent         uint64 `json:"sent"`
+	SendFailures uint64 `json:"send_failures"`
+}
+
+// syslogConnKey identifies a (collector, format) tuple for the shared-socket
+// pool and the monotonic counter aggregate. Format is included because the
+// encoder is per-format — one socket per format-collector pair isolates
+// wire-format interleave on a shared socket.
+type syslogConnKey struct {
+	collector string
+	format    SyslogFormat
+}
+
+// syslogCollectorAggregate holds monotonic counters for a (collector, format)
+// tuple that survive device deletion. Mirror of flowCollectorAggregate /
+// trapCollectorAggregate.
+type syslogCollectorAggregate struct {
+	sent         atomic.Uint64
+	sendFailures atomic.Uint64
 }
 
 // Sentinel errors returned by FireSyslogOnDevice for HTTP status mapping.
@@ -130,46 +155,46 @@ func sortedSyslogEntryNames(cat *SyslogCatalog) []string {
 	return out
 }
 
-// StartSyslogExport validates cfg, loads the catalog, creates the shared
-// scheduler, and starts the scheduler goroutine. Partial state on failure
-// is unwound before returning.
+// SyslogSubsystemConfig bundles the simulator-wide knobs still owned by the
+// manager after the per-device-export-config refactor. Per-device knobs
+// (collector / format / interval) live on each `DeviceSyslogConfig`.
+type SyslogSubsystemConfig struct {
+	CatalogPath     string
+	GlobalCap       int  // 0 = unlimited
+	SourcePerDevice bool // bind per-device UDP socket in opensim ns
+	// MeanSchedulerInterval seeds the scheduler's Poisson draw when no
+	// device-specific intervals are known. Individual devices still
+	// register with their own per-device interval on the heap.
+	MeanSchedulerInterval time.Duration
+}
+
+// StartSyslogSubsystem loads the catalog, creates the shared scheduler
+// and optional rate limiter, and starts the scheduler goroutine. The
+// subsystem is always-on after this runs — per-device attach via
+// `startDeviceSyslogExporter` later wires individual exporters in.
 //
-// Preconditions:
-//   - Called after manager construction, before any device creation that
-//     should participate in syslog export.
-func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
-	if sm.syslogActive.Load() {
-		return fmt.Errorf("syslog export: already active; Shutdown before re-initializing")
-	}
-	if cfg.Collector == "" {
-		return fmt.Errorf("syslog export: -syslog-collector required to enable feature")
-	}
-	if cfg.Interval <= 0 {
-		return fmt.Errorf("syslog export: -syslog-interval must be positive, got %s", cfg.Interval)
-	}
-	// Mirror NewSyslogScheduler's own floor: sub-millisecond intervals
-	// busy-loop the scheduler when no global cap is set. Catch it here with
-	// a clean startup error rather than let the scheduler constructor panic.
-	if cfg.Interval < time.Millisecond {
-		return fmt.Errorf("syslog export: -syslog-interval must be >= 1ms, got %s", cfg.Interval)
+// Replaces pre-phase-5 `StartSyslogExport`: the per-device collector /
+// format / interval settings are now on each `DeviceSyslogConfig`. The
+// manager no longer holds those values simulator-wide.
+func (sm *SimulatorManager) StartSyslogSubsystem(cfg SyslogSubsystemConfig) error {
+	if sm.syslogScheduler != nil {
+		return fmt.Errorf("syslog export: subsystem already started")
 	}
 	if cfg.GlobalCap < 0 {
 		return fmt.Errorf("syslog export: -syslog-global-cap must be non-negative, got %d", cfg.GlobalCap)
 	}
-	if cfg.Format == "" {
-		cfg.Format = SyslogFormat5424
+	if cfg.MeanSchedulerInterval <= 0 {
+		log.Printf("syslog export: MeanSchedulerInterval <= 0, defaulting to 10s (phase-5 review P12)")
+		cfg.MeanSchedulerInterval = 10 * time.Second
 	}
-	encoder, err := NewSyslogEncoder(cfg.Format)
-	if err != nil {
-		return fmt.Errorf("syslog export: %w", err)
-	}
-
-	addr, err := net.ResolveUDPAddr("udp4", cfg.Collector)
-	if err != nil {
-		return fmt.Errorf("syslog export: invalid collector address %q: %w", cfg.Collector, err)
+	// Mirror the scheduler's sub-millisecond floor — sub-ms intervals
+	// busy-loop when no global cap is set.
+	if cfg.MeanSchedulerInterval < time.Millisecond {
+		return fmt.Errorf("syslog export: MeanSchedulerInterval must be >= 1ms, got %s", cfg.MeanSchedulerInterval)
 	}
 
 	var catalog *SyslogCatalog
+	var err error
 	if cfg.CatalogPath == "" {
 		catalog, err = LoadEmbeddedSyslogCatalog()
 	} else {
@@ -179,7 +204,6 @@ func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
 		return err
 	}
 
-	// Per-device-type overlay scan. Skipped when `-syslog-catalog` is set.
 	catalogsByType := map[string]*SyslogCatalog{
 		universalCatalogKey: catalog,
 	}
@@ -193,12 +217,6 @@ func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
 		}
 	}
 
-	// Shared fallback socket: used when per-device binding is off or fails.
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
-	if err != nil {
-		return fmt.Errorf("syslog export: failed to open shared UDP socket: %w", err)
-	}
-
 	var limiter *rate.Limiter
 	if cfg.GlobalCap > 0 {
 		limiter = rate.NewLimiter(rate.Limit(cfg.GlobalCap), cfg.GlobalCap)
@@ -206,7 +224,7 @@ func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
 
 	scheduler := NewSyslogScheduler(SyslogSchedulerOptions{
 		CatalogFor:         func(ip net.IP) *SyslogCatalog { return sm.SyslogCatalogFor(ip.String()) },
-		MeanInterval:       cfg.Interval,
+		MeanInterval:       cfg.MeanSchedulerInterval,
 		GlobalCapPerSecond: cfg.GlobalCap,
 	})
 
@@ -214,18 +232,12 @@ func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
 	sm.syslogCatalog = catalog
 	sm.syslogCatalogsByType = catalogsByType
 	sm.syslogScheduler = scheduler
-	sm.syslogEncoder = encoder
+	sm.syslogEncodersByFmt = map[SyslogFormat]SyslogEncoder{}
 	sm.syslogLimiter = limiter
-	sm.syslogConn = conn
-	sm.syslogCollectorAddr = addr
-	sm.syslogCollectorStr = cfg.Collector
-	sm.syslogFormat = cfg.Format
-	sm.syslogInterval = cfg.Interval
 	sm.syslogGlobalCap = cfg.GlobalCap
 	sm.syslogSourcePerDevice = cfg.SourcePerDevice
 	sm.syslogCatalogPath = cfg.CatalogPath
 	sm.mu.Unlock()
-	sm.syslogActive.Store(true)
 
 	capStr := "unlimited"
 	if cfg.GlobalCap > 0 {
@@ -235,28 +247,137 @@ func (sm *SimulatorManager) StartSyslogExport(cfg SyslogConfig) error {
 	if cfg.CatalogPath != "" {
 		catStr = cfg.CatalogPath
 	}
-	log.Printf("Syslog export: %s → %s (format=%s, interval=%s, cap=%s, catalog=%s, per-device-source=%v)",
-		conn.LocalAddr(), cfg.Collector, cfg.Format, cfg.Interval, capStr, catStr, cfg.SourcePerDevice)
+	log.Printf("Syslog subsystem: ready (cap=%s, catalog=%s, per-device-source=%v) — awaiting per-device config",
+		capStr, catStr, cfg.SourcePerDevice)
 
 	go scheduler.Run(context.Background())
 
 	return nil
 }
 
-// StopSyslogExport stops the scheduler, closes the shared socket, and closes
-// every device's SyslogExporter. Safe to call when syslog export is inactive
-// (no-op).
-func (sm *SimulatorManager) StopSyslogExport() {
-	if !sm.syslogActive.Load() {
+// syslogEncoderFor returns the shared encoder for a given wire format.
+// Lazily constructs and caches so StartSyslogSubsystem doesn't need to
+// know which formats will be used at boot. Safe for concurrent use.
+func (sm *SimulatorManager) syslogEncoderFor(format SyslogFormat) (SyslogEncoder, error) {
+	sm.mu.RLock()
+	if enc, ok := sm.syslogEncodersByFmt[format]; ok {
+		sm.mu.RUnlock()
+		return enc, nil
+	}
+	sm.mu.RUnlock()
+	enc, err := NewSyslogEncoder(format)
+	if err != nil {
+		return nil, err
+	}
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	// Double-check after re-acquiring the write lock in case another
+	// goroutine raced us.
+	if existing, ok := sm.syslogEncodersByFmt[format]; ok {
+		return existing, nil
+	}
+	sm.syslogEncodersByFmt[format] = enc
+	return enc, nil
+}
+
+// syslogConnFor returns the shared-pool UDP socket for a (collector, format)
+// tuple. First caller for a key opens the socket; subsequent callers reuse
+// it. Returns nil if the socket can't be opened. Safe for concurrent use.
+func (sm *SimulatorManager) syslogConnFor(key syslogConnKey) *net.UDPConn {
+	if cached, ok := sm.syslogConns.Load(key); ok {
+		return cached.(*net.UDPConn)
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		log.Printf("syslog export: failed to open shared socket for %s (format=%s): %v",
+			key.collector, key.format, err)
+		return nil
+	}
+	actual, loaded := sm.syslogConns.LoadOrStore(key, conn)
+	if loaded {
+		_ = conn.Close()
+		return actual.(*net.UDPConn)
+	}
+	return conn
+}
+
+// closeSyslogConnPool closes every pooled shared socket and removes its
+// map entry so a subsequent `syslogConnFor` after `StartSyslogSubsystem`
+// cannot return a closed *net.UDPConn.
+func (sm *SimulatorManager) closeSyslogConnPool() {
+	sm.syslogConns.Range(func(k, v interface{}) bool {
+		if conn, ok := v.(*net.UDPConn); ok {
+			_ = conn.Close()
+		}
+		sm.syslogConns.Delete(k)
+		return true
+	})
+}
+
+// getSyslogScheduler returns the manager's syslog scheduler pointer
+// under sm.mu.RLock so callers cannot race a concurrent
+// StopSyslogExport that nils the field (phase-5 review D3 fix). Safe
+// with nil manager.
+func getSyslogScheduler(sm *SimulatorManager) *SyslogScheduler {
+	if sm == nil {
+		return nil
+	}
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.syslogScheduler
+}
+
+// persistSyslogCounters snapshots a SyslogExporter's cumulative counters
+// into the simulator-wide per-(collector, format) aggregate so
+// /syslog/status reports monotonic totals across DEVICE CHURN WITHIN
+// ONE SUBSYSTEM LIFECYCLE (create/delete a device — counters persist).
+// A Stop→Start cycle resets sm.syslogAggregates and starts from zero by
+// design (phase-5 review P2 scope clarification).
+//
+// Idempotent per exporter via countersPersisted sync.Once, so
+// concurrent Stop paths cannot double-count. Safe to call with nil
+// exporter.
+func (sm *SimulatorManager) persistSyslogCounters(fe *SyslogExporter) {
+	if fe == nil {
 		return
 	}
-	sm.syslogActive.Store(false)
+	collector := fe.CollectorString()
+	if collector == "" {
+		return
+	}
+	fe.countersPersisted.Do(func() {
+		key := syslogConnKey{collector: collector, format: fe.Format()}
+		v, _ := sm.syslogAggregates.LoadOrStore(key, &syslogCollectorAggregate{})
+		agg := v.(*syslogCollectorAggregate)
+		stats := fe.Stats()
+		agg.sent.Add(stats.Sent.Load())
+		agg.sendFailures.Add(stats.SendFailures.Load())
+	})
+}
 
-	// Snapshot per-device exporters under each device's own mutex so we
-	// don't race `startDeviceSyslogExporter` (which writes under d.mu) or
-	// direct reads from `GetSyslogStatus` / `FireSyslogOnDevice`.
+// StopSyslogExport stops the scheduler, closes every pooled shared socket,
+// and closes every device's SyslogExporter. Safe to call when the subsystem
+// was never started (no-op).
+//
+// CONSTRAINT — process-shutdown only (phase-5 review D1):
+// StopSyslogExport is NOT safe to race concurrent device creation. See
+// the equivalent note on StopTrapExport. Today it is only called from
+// the process-exit signal handler (Shutdown). Do not introduce a
+// runtime "restart syslog subsystem" path without first tightening the
+// attach-path lock discipline (deferred D1 follow-up in the
+// per-device-export-config change).
+func (sm *SimulatorManager) StopSyslogExport() {
 	sm.mu.RLock()
 	scheduler := sm.syslogScheduler
+	sm.mu.RUnlock()
+
+	if scheduler == nil {
+		return // subsystem never started
+	}
+
+	// Snapshot per-device exporters under each device's own mutex so we
+	// don't race `startDeviceSyslogExporter` (which writes under d.mu).
+	sm.mu.RLock()
 	type devExp struct {
 		d   *DeviceSimulator
 		exp *SyslogExporter
@@ -271,87 +392,153 @@ func (sm *SimulatorManager) StopSyslogExport() {
 			captured = append(captured, devExp{d: d, exp: exp})
 		}
 	}
-	conn := sm.syslogConn
 	sm.mu.RUnlock()
 
-	if scheduler != nil {
-		scheduler.Stop()
-	}
+	scheduler.Stop()
 	for _, ce := range captured {
+		sm.persistSyslogCounters(ce.exp)
 		_ = ce.exp.Close()
 	}
-	if conn != nil {
-		_ = conn.Close()
-	}
+	sm.closeSyslogConnPool()
 
 	sm.mu.Lock()
 	sm.syslogScheduler = nil
-	sm.syslogConn = nil
-	// Clear per-type catalog state so a subsequent StartSyslogExport
-	// rebuilds it from scratch rather than inheriting stale overlays.
 	sm.syslogCatalog = nil
 	sm.syslogCatalogsByType = nil
 	sm.syslogCatalogPath = ""
+	sm.syslogEncodersByFmt = nil
+	// Reset monotonic counter aggregates + first-attach log so a
+	// subsequent StartSyslogSubsystem starts from zero and logs the
+	// first attach again. atomic.Bool Store is race-free against
+	// concurrent CAS readers — replaces the earlier sync.Once{}
+	// reassignment which was a data race with the Do() call in
+	// startDeviceSyslogExporter (phase-5 review P3).
+	sm.syslogAggregates = sync.Map{}
+	sm.syslogFirstAttachLog.Store(false)
+	sm.syslogIntervalWarned.Store(false)
+	// Reset subsystem-scalar state so a subsequent StartSyslogSubsystem
+	// starts from a clean slate (phase-5 review P-E1).
+	sm.syslogLimiter = nil
+	sm.syslogGlobalCap = 0
+	sm.syslogSourcePerDevice = false
 	sm.mu.Unlock()
 }
 
-// startDeviceSyslogExporter creates a SyslogExporter for the device, opens a
-// per-device UDP socket when enabled, and registers the exporter with the
-// scheduler. Called from device creation sites in device.go (mirrors the
-// trap-export hook).
+// startDeviceSyslogExporter creates a SyslogExporter for a device that
+// already has `device.syslogConfig` populated. Opens a per-device UDP
+// socket when `-syslog-source-per-device=true`, falls back to the
+// shared-pool socket keyed by (collector, format) otherwise. Registers
+// the exporter with the central scheduler.
 //
-// Unlike the trap counterpart, per-device bind failure is never fatal for
-// syslog — there is no ack path that requires symmetric source IPs. On bind
-// failure we log a warning and fall back to the shared socket. Every error
-// scenario inside this function is handled internally (logged + degraded),
-// so the function has no error return; the trap-style signature was trimmed
-// after a review noted the call-site `err != nil` log branches were dead.
-func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) {
-	if !sm.syslogActive.Load() || device == nil {
-		return
+// Per-device bind failure is NEVER fatal for syslog — the device falls
+// back to the shared socket and a warning is logged (preserves the
+// existing syslog bind-failure semantic per spec). Other error paths —
+// subsystem not started, bad format, unresolvable collector — return an
+// error so the caller can clear `device.syslogConfig` and skip the
+// device cleanly.
+//
+// Must be called only after `StartSyslogSubsystem` — caller enforces.
+func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) error {
+	if device == nil || device.syslogConfig == nil {
+		return nil
 	}
-	// `device.sysName` is written once at device construction and never
-	// mutated (the simulator doesn't expose sysName-set via the admin API),
-	// so reading it here without holding `device.mu` is safe. Capture it
-	// into the exporter options as a plain string; subsequent runtime
-	// changes to `device.sysName` — if ever introduced — would not be
-	// reflected in emitted syslog messages until the exporter is rebuilt.
+	cfg := device.syslogConfig
+
+	format, err := ParseSyslogFormat(cfg.Format)
+	if err != nil {
+		return fmt.Errorf("syslog export: parse format: %w", err)
+	}
+
 	sm.mu.RLock()
-	deviceIPStr := device.IP.String()
-	opts := SyslogExporterOptions{
-		DeviceIP:   device.IP,
-		Encoder:    sm.syslogEncoder,
-		Collector:  sm.syslogCollectorAddr,
-		SharedConn: sm.syslogConn,
-		SysName:    device.sysName,
-		Model:      modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr]),
-		Serial:     synthSerial(device.IP),
-		ChassisID:  synthChassisID(device.IP),
-		IfIndexFn:  deviceIfIndexFn(device),
-		IfNameFn:   deviceIfNameFn(device),
-	}
 	sourcePerDevice := sm.syslogSourcePerDevice
 	scheduler := sm.syslogScheduler
+	deviceIPStr := device.IP.String()
+	modelLabel := modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr])
 	sm.mu.RUnlock()
 
-	exporter := NewSyslogExporter(opts)
+	if scheduler == nil {
+		return fmt.Errorf("syslog export: subsystem not started; call StartSyslogSubsystem first")
+	}
 
+	encoder, err := sm.syslogEncoderFor(format)
+	if err != nil {
+		return fmt.Errorf("syslog export: encoder: %w", err)
+	}
+
+	collectorAddr, err := net.ResolveUDPAddr("udp4", cfg.Collector)
+	if err != nil {
+		return fmt.Errorf("syslog export: resolve collector %q: %w", cfg.Collector, err)
+	}
+	canonicalCollector := collectorAddr.String()
+
+	// Open per-device socket first (when enabled) so we know whether to
+	// wire in the shared-pool fallback; passing SharedConn at
+	// construction avoids an unsynchronised post-hoc field write.
+	var perDeviceConn *net.UDPConn
 	if sourcePerDevice {
-		conn := openSyslogConnForDevice(device)
-		if conn == nil {
-			log.Printf("syslog export: device %s per-device bind failed, falling back to shared socket", device.IP)
-		} else {
-			exporter.SetConn(conn)
+		perDeviceConn = openSyslogConnForDevice(device)
+		if perDeviceConn == nil {
+			log.Printf("syslog export: device %s per-device bind failed, falling back to shared-pool socket", device.IP)
 		}
+	}
+	var sharedConn *net.UDPConn
+	if perDeviceConn == nil {
+		sharedConn = sm.syslogConnFor(syslogConnKey{collector: canonicalCollector, format: format})
+		if sharedConn == nil {
+			// Both per-device bind and shared-pool open failed — refuse
+			// the attach so the caller clears device.syslogConfig.
+			// Constructing an exporter with nil sockets would silently
+			// drop every fire via errNoSyslogSocket (phase-5 review P10).
+			return fmt.Errorf("syslog export: no UDP socket available for device %s → %s", device.IP, canonicalCollector)
+		}
+	}
+
+	opts := SyslogExporterOptions{
+		DeviceIP:     device.IP,
+		Encoder:      encoder,
+		Collector:    collectorAddr,
+		CollectorStr: canonicalCollector,
+		Format:       format,
+		SharedConn:   sharedConn,
+		SysName:      device.sysName,
+		Model:        modelLabel,
+		Serial:       synthSerial(device.IP),
+		ChassisID:    synthChassisID(device.IP),
+		IfIndexFn:    deviceIfIndexFn(device),
+		IfNameFn:     deviceIfNameFn(device),
+	}
+
+	exporter := NewSyslogExporter(opts)
+	if perDeviceConn != nil {
+		exporter.SetConn(perDeviceConn)
 	}
 
 	device.mu.Lock()
 	device.syslogExporter = exporter
 	device.mu.Unlock()
 
-	if scheduler != nil {
-		scheduler.Register(device.IP, exporter)
+	// Per-device Interval is stored on cfg but not honored by the
+	// scheduler today — the scheduler draws Poisson fires from its
+	// simulator-wide MeanInterval (design debt, same pattern as trap
+	// Interval and flow TickInterval). Warn ONCE per subsystem
+	// lifecycle — per-device logging floods at fleet scale (phase-5
+	// review P13).
+	if time.Duration(cfg.Interval) != 0 && time.Duration(cfg.Interval) != scheduler.MeanInterval() {
+		if sm.syslogIntervalWarned.CompareAndSwap(false, true) {
+			log.Printf("syslog export: device %s configured interval=%s but the scheduler runs at mean=%s; per-device intervals are not yet honored (further divergences suppressed this lifecycle)",
+				device.IP, time.Duration(cfg.Interval), scheduler.MeanInterval())
+		}
 	}
+
+	scheduler.Register(device.IP, exporter)
+
+	// CAS-gated first-attach log; race-free vs. StopSyslogExport's
+	// reset to false (phase-5 review P3).
+	if sm.syslogFirstAttachLog.CompareAndSwap(false, true) {
+		log.Printf("syslog export: active; first device %s → %s (format=%s)",
+			device.IP, canonicalCollector, format)
+	}
+	return nil
 }
 
 // deviceIfNameFn returns the ifName for a given ifIndex on the device.
@@ -399,20 +586,27 @@ func lookupIfDescr(device *DeviceSimulator, ifIndex int) string {
 	return s
 }
 
-// GetSyslogStatus returns a JSON-serializable snapshot of the syslog export
-// state. Exposed via GET /api/v1/syslog/status.
+// GetSyslogStatus returns a JSON-serializable snapshot of the syslog
+// export state. Exposed via GET /api/v1/syslog/status.
+//
+// Shape matches GetFlowStatus / GetTrapStatus: live per-device exporters
+// aggregated by (collector, format); counters from deleted devices
+// persisted in sm.syslogAggregates are folded in so totals remain
+// monotonic within the current subsystem lifecycle.
+//
+// `SubsystemActive` is the authoritative "is the feature live?" signal —
+// true when StartSyslogSubsystem has run and StopSyslogExport has not.
+// `len(Collectors) == 0` is NOT sufficient on its own: it also occurs
+// when the subsystem is running but no device has opted in, or after a
+// Stop (which clears the catalog + aggregate maps). After Stop, this
+// function returns `{SubsystemActive: false, Collectors: [], …}`.
 func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
-	if !sm.syslogActive.Load() {
-		return SyslogStatus{Enabled: false}
-	}
+	agg := make(map[syslogConnKey]*SyslogCollectorStatus)
 
 	sm.mu.RLock()
-	status := SyslogStatus{
-		Enabled:   true,
-		Format:    string(sm.syslogFormat),
-		Collector: sm.syslogCollectorStr,
-	}
 	limiter := sm.syslogLimiter
+	status := SyslogStatus{SubsystemActive: sm.syslogScheduler != nil}
+
 	if len(sm.syslogCatalogsByType) > 0 {
 		status.CatalogsByType = make(map[string]CatalogSourceInfo, len(sm.syslogCatalogsByType))
 		for slug, cat := range sm.syslogCatalogsByType {
@@ -423,30 +617,69 @@ func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
 		}
 	}
 
-	var sent, failures uint64
-	devicesExporting := 0
 	for _, d := range sm.devices {
 		// Snapshot the exporter pointer under d.mu so a concurrent Stop
-		// path (which nils it under d.mu.Lock) can't race this read.
+		// path can't race this read.
 		d.mu.RLock()
 		exp := d.syslogExporter
 		d.mu.RUnlock()
 		if exp == nil {
 			continue
 		}
-		devicesExporting++
+		key := syslogConnKey{collector: exp.CollectorString(), format: exp.Format()}
+		rec, ok := agg[key]
+		if !ok {
+			rec = &SyslogCollectorStatus{
+				Collector: exp.CollectorString(),
+				Format:    string(exp.Format()),
+			}
+			agg[key] = rec
+		}
+		rec.Devices++
 		st := exp.Stats()
-		sent += st.Sent.Load()
-		failures += st.SendFailures.Load()
+		rec.Sent += st.Sent.Load()
+		rec.SendFailures += st.SendFailures.Load()
 	}
+
 	var tokens int
 	if limiter != nil {
 		tokens = int(limiter.Tokens())
 	}
 	sm.mu.RUnlock()
 
-	status.Sent = sent
-	status.SendFailures = failures
+	// Fold persisted counters for tuples whose devices have since been
+	// deleted. A tuple with no live exporters still surfaces so operators
+	// keep seeing cumulative totals.
+	sm.syslogAggregates.Range(func(k, v interface{}) bool {
+		key := k.(syslogConnKey)
+		pers := v.(*syslogCollectorAggregate)
+		rec, ok := agg[key]
+		if !ok {
+			rec = &SyslogCollectorStatus{
+				Collector: key.collector,
+				Format:    string(key.format),
+			}
+			agg[key] = rec
+		}
+		rec.Sent += pers.sent.Load()
+		rec.SendFailures += pers.sendFailures.Load()
+		return true
+	})
+
+	collectors := make([]SyslogCollectorStatus, 0, len(agg))
+	devicesExporting := 0
+	for _, rec := range agg {
+		collectors = append(collectors, *rec)
+		devicesExporting += rec.Devices
+	}
+	sort.Slice(collectors, func(i, j int) bool {
+		if collectors[i].Collector != collectors[j].Collector {
+			return collectors[i].Collector < collectors[j].Collector
+		}
+		return collectors[i].Format < collectors[j].Format
+	})
+
+	status.Collectors = collectors
 	status.DevicesExporting = devicesExporting
 	if limiter != nil {
 		status.RateLimiterTokensAvailable = tokens
@@ -465,7 +698,10 @@ func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
 //   - ErrSyslogDeviceNotFound → 404
 //   - ErrSyslogEntryNotFound  → 400
 func (sm *SimulatorManager) FireSyslogOnDevice(ip, entryName string, overrides map[string]string) error {
-	if !sm.syslogActive.Load() {
+	sm.mu.RLock()
+	schedulerStarted := sm.syslogScheduler != nil
+	sm.mu.RUnlock()
+	if !schedulerStarted {
 		return ErrSyslogExportDisabled
 	}
 	device := sm.FindDeviceByIP(ip)
@@ -512,4 +748,3 @@ func (sm *SimulatorManager) SyslogCatalogFor(ip string) *SyslogCatalog {
 	cat, _ := sm.syslogCatalogWithLabelFor(ip)
 	return cat
 }
-

--- a/go/simulator/syslog_scheduler.go
+++ b/go/simulator/syslog_scheduler.go
@@ -82,6 +82,11 @@ func (h *syslogHeap) Pop() interface{} {
 	return e
 }
 
+// MeanInterval returns the simulator-wide mean firing interval. Exposed
+// for per-device-attach divergence warnings — per-device intervals are
+// stored on DeviceSyslogConfig but not yet honored by the scheduler.
+func (s *SyslogScheduler) MeanInterval() time.Duration { return s.meanInterval }
+
 // SyslogScheduler coordinates per-device syslog firing with a single
 // goroutine and a global token-bucket rate limiter. All fields are private;
 // callers interact via Register / Deregister / Run / Stop.

--- a/go/simulator/trap_exporter.go
+++ b/go/simulator/trap_exporter.go
@@ -270,7 +270,7 @@ func (e *TrapExporter) Mode() TrapMode { return e.mode }
 // WriteTo. Gated by fe.firstWriteErr so a down/misconfigured collector
 // doesn't flood logs at fire cadence × device count.
 func (e *TrapExporter) logFirstWriteErr(err error) {
-	if e == nil {
+	if e == nil || err == nil {
 		return
 	}
 	e.firstWriteErr.Do(func() {

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -57,13 +57,15 @@ func ParseTrapMode(s string) (TrapMode, error) {
 // TrapStatus is the JSON body returned by GET /api/v1/traps/status.
 //
 // BREAKING (per-device-export-config phase 4): the response is now an
-// array-of-collectors aggregated across devices. Callers detect
-// "feature off" via `len(collectors) == 0`. Legacy scalar fields
-// (enabled/mode/collector/community/sent/informs_*) retired.
+// array-of-collectors aggregated across devices. Legacy scalar fields
+// (enabled/mode/collector/community/sent/informs_*) retired. Use
+// `SubsystemActive` to distinguish "never started" from "started with
+// zero devices"; `len(collectors) == 0` no longer implies feature off.
 //
 // CatalogsByType surfaces the per-device-type overlay map — unchanged
 // from phase-4-prior behaviour.
 type TrapStatus struct {
+	SubsystemActive            bool                         `json:"subsystem_active"`
 	Collectors                 []TrapCollectorStatus        `json:"collectors"`
 	DevicesExporting           int                          `json:"devices_exporting"`
 	RateLimiterTokensAvailable int                          `json:"rate_limiter_tokens_available,omitempty"`
@@ -140,6 +142,7 @@ func (sm *SimulatorManager) StartTrapSubsystem(cfg TrapSubsystemConfig) error {
 		return fmt.Errorf("trap export: -trap-global-cap must be non-negative, got %d", cfg.GlobalCap)
 	}
 	if cfg.MeanSchedulerInterval <= 0 {
+		log.Printf("trap export: MeanSchedulerInterval <= 0, defaulting to 30s (phase-5 review P12)")
 		cfg.MeanSchedulerInterval = 30 * time.Second
 	}
 
@@ -240,10 +243,24 @@ func (sm *SimulatorManager) closeTrapConnPool() {
 	})
 }
 
+// getTrapScheduler returns the manager's trap scheduler pointer under
+// sm.mu.RLock so callers cannot race a concurrent StopTrapExport that
+// nils the field (phase-5 review D3 fix). Safe with nil manager.
+func getTrapScheduler(sm *SimulatorManager) *TrapScheduler {
+	if sm == nil {
+		return nil
+	}
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.trapScheduler
+}
+
 // persistTrapCounters snapshots a TrapExporter's cumulative counters
 // into the simulator-wide per-(collector, mode) aggregate so
-// /traps/status reports monotonic totals even as devices come and go
-// (review decision D1.b applied to trap subsystem). Called from the
+// /traps/status reports monotonic totals across DEVICE CHURN WITHIN
+// ONE SUBSYSTEM LIFECYCLE (review decision D1.b applied to trap). A
+// Stop→Start cycle resets sm.trapAggregates and starts from zero by
+// design (phase-5 review P2 scope clarification). Called from the
 // device lifecycle immediately before `TrapExporter.Close()`. Safe to
 // call with nil exporter; idempotent per exporter (countersPersisted
 // sync.Once) so concurrent Stop paths cannot double-count.
@@ -273,6 +290,17 @@ func (sm *SimulatorManager) persistTrapCounters(fe *TrapExporter) {
 // StopTrapExport stops the scheduler, closes every pooled shared
 // socket, and closes every device's TrapExporter. Safe to call when
 // the subsystem was never started (no-op).
+//
+// CONSTRAINT — process-shutdown only (phase-5 review D1):
+// StopTrapExport is NOT safe to race concurrent device creation.
+// `startDeviceTrapExporter` captures scheduler / pool / encoder
+// pointers under a short RLock and uses them outside that lock; a
+// concurrent StopTrapExport can leave orphan exporters or closed
+// sockets in that window. Today StopTrapExport is only called from
+// the process-exit signal handler (Shutdown), so no live attach can
+// race it. Do not introduce a runtime "restart trap subsystem" path
+// without first tightening the attach-path lock discipline (see the
+// deferred D1 follow-up in the per-device-export-config change).
 func (sm *SimulatorManager) StopTrapExport() {
 	sm.mu.RLock()
 	scheduler := sm.trapScheduler
@@ -314,8 +342,17 @@ func (sm *SimulatorManager) StopTrapExport() {
 	// from the previous lifecycle (review fix P2).
 	sm.trapAggregates = sync.Map{}
 	// Reset the first-attach log gate so the "trap export active" line
-	// fires again on the next Start→first-device cycle (review fix P9).
-	sm.trapFirstAttachLog = sync.Once{}
+	// fires again on the next Start→first-device cycle. atomic.Bool
+	// Store is race-free against concurrent CAS readers — replaces the
+	// earlier sync.Once{} reassignment which was a data race with the
+	// Do() call in startDeviceTrapExporter (phase-5 review P3).
+	sm.trapFirstAttachLog.Store(false)
+	sm.trapIntervalWarned.Store(false)
+	// Reset subsystem-scalar state so a subsequent StartTrapSubsystem
+	// starts from a clean slate (phase-5 review P-E1).
+	sm.trapLimiter = nil
+	sm.trapGlobalCap = 0
+	sm.trapSourcePerDevice = false
 	sm.mu.Unlock()
 }
 
@@ -417,19 +454,27 @@ func (sm *SimulatorManager) startDeviceTrapExporter(device *DeviceSimulator) err
 	// Per-device Interval is stored on cfg but not honored by the
 	// scheduler today — the scheduler draws Poisson fires from its
 	// simulator-wide MeanInterval (design debt, same pattern as flow's
-	// TickInterval). Warn once per device at attach so operators
-	// aren't silently surprised.
+	// TickInterval). Warn ONCE per subsystem lifecycle at the first
+	// divergent attach — per-device logging floods at fleet scale
+	// (phase-5 review P13).
 	if time.Duration(cfg.Interval) != 0 && time.Duration(cfg.Interval) != scheduler.MeanInterval() {
-		log.Printf("trap export: device %s configured interval=%s but the scheduler runs at mean=%s; per-device intervals are not yet honored",
-			device.IP, time.Duration(cfg.Interval), scheduler.MeanInterval())
+		if sm.trapIntervalWarned.CompareAndSwap(false, true) {
+			log.Printf("trap export: device %s configured interval=%s but the scheduler runs at mean=%s; per-device intervals are not yet honored (further divergences suppressed this lifecycle)",
+				device.IP, time.Duration(cfg.Interval), scheduler.MeanInterval())
+		}
 	}
 
 	scheduler.Register(device.IP, exporter)
 
-	sm.trapFirstAttachLog.Do(func() {
+	// CAS-gated first-attach log; race-free vs. StopTrapExport's reset
+	// to false (phase-5 review P3). If the per-device Interval diverges
+	// from the scheduler mean, warn once per subsystem lifecycle instead
+	// of per-device — 30k near-identical lines at scale was noisy
+	// (phase-5 review P13).
+	if sm.trapFirstAttachLog.CompareAndSwap(false, true) {
 		log.Printf("trap export: active; first device %s → %s (mode=%s)",
 			device.IP, canonicalCollector, cfg.Mode)
-	})
+	}
 	return nil
 }
 
@@ -468,7 +513,7 @@ func (sm *SimulatorManager) GetTrapStatus() TrapStatus {
 
 	sm.mu.RLock()
 	limiter := sm.trapLimiter
-	status := TrapStatus{}
+	status := TrapStatus{SubsystemActive: sm.trapScheduler != nil}
 
 	if len(sm.trapCatalogsByType) > 0 {
 		status.CatalogsByType = make(map[string]CatalogSourceInfo, len(sm.trapCatalogsByType))

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -238,28 +238,29 @@ type SimulatorManager struct {
 	trapScheduler       *TrapScheduler
 	trapEncoder         TrapEncoder
 	trapLimiter         *rate.Limiter // shared global cap (nil = unlimited)
-	trapConns           sync.Map      // key: string collector, value: *net.UDPConn (shared-socket fallback pool, TRAP mode only)
-	trapAggregates      sync.Map      // key: trapAggKey, value: *trapCollectorAggregate — monotonic counters surviving device delete
-	trapFirstAttachLog  sync.Once     // emits a single "trap export active" line on first per-device attach
+	trapConns           sync.Map    // key: string collector, value: *net.UDPConn (shared-socket fallback pool, TRAP mode only)
+	trapAggregates      sync.Map    // key: trapAggKey, value: *trapCollectorAggregate — monotonic counters surviving device delete
+	trapFirstAttachLog  atomic.Bool // CAS-gated so the "trap export active" line fires once per lifecycle; race-free reset on Stop
+	trapIntervalWarned  atomic.Bool // CAS-gated divergence warning — one line per lifecycle, not per device (phase-5 review P13)
 	trapGlobalCap       int
 	trapSourcePerDevice bool
 	trapCatalogPath     string // "" when using embedded catalog
 
-	// UDP syslog export state (nil/zero when disabled; set by StartSyslogExport).
-	// See syslog_manager.go for lifecycle and syslog_exporter.go for per-device state.
+	// UDP syslog export state. Per the per-device-export-config refactor,
+	// each device owns its own collector/format/interval on `syslogConfig`.
+	// The manager retains subsystem-level concerns: catalog, scheduler,
+	// shared limiter, and shared-socket pool for the fallback path.
 	//
 	// syslogCatalogsByType mirrors trapCatalogsByType for the syslog side.
-	syslogActive          atomic.Bool
 	syslogCatalog         *SyslogCatalog
 	syslogCatalogsByType  map[string]*SyslogCatalog
 	syslogScheduler       *SyslogScheduler
-	syslogEncoder         SyslogEncoder
-	syslogLimiter         *rate.Limiter // independent of trap's limiter (design.md §D9)
-	syslogConn            *net.UDPConn  // shared fallback when per-device bind disabled or fails
-	syslogCollectorAddr   *net.UDPAddr
-	syslogCollectorStr    string
-	syslogFormat          SyslogFormat
-	syslogInterval        time.Duration
+	syslogEncodersByFmt   map[SyslogFormat]SyslogEncoder // one encoder per format; lazily populated
+	syslogLimiter         *rate.Limiter                  // independent of trap's limiter (design.md §D9)
+	syslogConns           sync.Map                       // key: syslogConnKey, value: *net.UDPConn (shared-socket fallback pool)
+	syslogAggregates      sync.Map                       // key: syslogConnKey, value: *syslogCollectorAggregate — monotonic counters surviving device delete
+	syslogFirstAttachLog  atomic.Bool                    // CAS-gated so the "syslog export active" line fires once per lifecycle; race-free reset on Stop
+	syslogIntervalWarned  atomic.Bool                    // CAS-gated divergence warning — one line per lifecycle, not per device (phase-5 review P13)
 	syslogGlobalCap       int
 	syslogSourcePerDevice bool
 	syslogCatalogPath     string // "" when using embedded catalog


### PR DESCRIPTION
## Summary

Phase 5 of the per-device-export-config refactor, symmetric to phase 3 flow (#90) and phase 4 trap (#129). Each `DeviceSimulator` now owns its syslog `collector` / `format` / `interval` on `DeviceSyslogConfig`; the manager retains only subsystem-level concerns (catalog, scheduler, shared limiter, shared-socket pool, per-format encoder cache).

- `StartSyslogSubsystem(SyslogSubsystemConfig)` replaces `StartSyslogExport(SyslogConfig)`. Subsystem-level knobs only; called unconditionally at boot so REST-created devices can opt in via `POST /api/v1/devices` without a CLI seed.
- CLI `-syslog-*` flags build a `DeviceSyslogConfig` seed carried on `ExportSeed.Syslog`, mirroring the flow / trap seed pattern.
- `startDeviceSyslogExporter` reads `device.syslogConfig`, selects the cached encoder for the device's wire format, and resolves the shared-pool fallback socket at construction time. Attach fails (clearing the device's `syslogConfig`) when both per-device bind AND shared-pool open fail.
- `GetSyslogStatus` returns `{"subsystem_active", "collectors": [...], "devices_exporting", ...}` aggregated by `(collector, format)`. Monotonic counters survive device deletion via `sm.syslogAggregates`.
- Shared-socket pool keyed by `(collector, format)` — 5424 and 3164 streams never interleave on the same socket.
- Phase-4 review deferred items landed here symmetrically:
  - **D1** — `SubsystemActive bool` field added to both `TrapStatus` and `SyslogStatus`.
  - **D3** — new `export_attach_test.go` exercises the real `startDeviceTrapExporter` / `startDeviceSyslogExporter` attach paths + `device.Stop()` persist-before-close lifecycle for both subsystems.

### Pre-PR review fixes

`/bmad-code-review` (Blind Hunter + Edge Case Hunter, no-spec mode) surfaced 10 actionable findings; all 10 applied. Summary in commit body (P1 → P16 + P-E1). Three further deferred items from this review landed as follow-ups in the same PR:

- **D1** — documented `Stop{Trap,Syslog}Export` is process-shutdown-only in godoc, `CLAUDE.md`, and the openspec design doc. Runtime restart would race attach paths; tightening is a pre-requisite.
- **D2** — added `TestDeviceStop_Persists*CountersViaRealLifecycle` tests that drive `device.Stop()` through the real sequence (rather than calling `persistCounters` manually).
- **D3** — `device.Stop()` now reads the scheduler pointers via `getTrapScheduler` / `getSyslogScheduler` helpers that take `sm.mu.RLock` so the nil-check and Deregister can't split across a concurrent Stop.

### BREAKING CHANGE

`GET /api/v1/syslog/status` response shape changed to the array-of-collectors form (matches flow + trap). Clients detect "feature off" via `subsystem_active == false` (preferred) or `len(collectors) == 0`. Legacy scalar fields (`enabled` / `format` / `collector` / `sent` / `send_failures`) retired.

`SyslogConfig` and `StartSyslogExport` Go API retired; use `SyslogSubsystemConfig` + `StartSyslogSubsystem` + per-device `DeviceSyslogConfig`. CLI flag surface is unchanged.

`TrapStatus` additionally gained `subsystem_active` — additive, not breaking.

## Test plan

- [x] `go vet ./simulator/` clean
- [x] `go test ./simulator/` — full suite green (17.1s)
- [x] `go test ./simulator/ -race -run 'Trap|Syslog|Flow'` — race-detector clean (17.0s)
- [ ] Manual smoke: boot with `-syslog-collector -syslog-format 3164`, confirm `/api/v1/syslog/status` returns the new shape with `subsystem_active=true` and the device's collector record
- [ ] Manual smoke: boot without `-syslog-collector`, confirm `POST /api/v1/devices` with a per-device `syslog` block attaches an exporter (always-on subsystem)
- [ ] Manual smoke: create devices with two different collectors at two different formats — `/api/v1/syslog/status` shows 3 collector rows (a:514/5424, a:514/3164, b:514/5424)
- [ ] DCO sign-off added before merge