### PR TITLE
docs(export): per-device export config — CLAUDE.md, reference, ops, migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,32 +24,35 @@ sudo ./simulator [flags]
 -no-namespace           # Disable network namespace isolation
 
 # Flow export flags (NetFlow v5 / v9 / IPFIX / sFlow v5)
--flow-collector <host:port>       # Enable flow export to this UDP collector
--flow-protocol <proto>            # netflow9 (default) | ipfix | netflow5 | sflow (alias: sflow5)
--flow-tick-interval <duration>    # How often to emit flows (default: 5s)
--flow-active-timeout <duration>   # Active flow expiry timeout (default: 30s)
--flow-inactive-timeout <duration> # Inactive flow expiry timeout (default: 15s)
--flow-template-interval <dur>     # Re-send template every N ticks (default: 10m; ignored under netflow5/sflow)
--flow-source-per-device           # Bind per-device UDP socket so src IP = device IP (default: true)
+# Flags marked [seed] apply ONLY to auto-start devices (-auto-start-ip batch).
+# REST-created devices (POST /api/v1/devices) opt in via a per-device `flow` block.
+# Flags marked [global] retain simulator-wide effect.
+-flow-collector <host:port>       # [seed]   Seed collector for auto-start batch
+-flow-protocol <proto>            # [seed]   netflow9 (default) | ipfix | netflow5 | sflow (alias: sflow5)
+-flow-tick-interval <duration>    # [seed]   How often to emit flows (default: 5s)
+-flow-active-timeout <duration>   # [seed]   Active flow expiry timeout (default: 30s)
+-flow-inactive-timeout <duration> # [seed]   Inactive flow expiry timeout (default: 15s)
+-flow-template-interval <dur>     # [global] Re-send template every N seconds (default: 60s; ignored under netflow5/sflow)
+-flow-source-per-device           # [global] Bind per-device UDP socket so src IP = device IP (default: true)
 
 # SNMP trap / INFORM export flags (SNMPv2c only)
--trap-collector <host:port>       # Enable trap export to this UDP collector (default port 162)
--trap-mode <proto>                # trap (default, fire-and-forget) | inform (acknowledged)
--trap-interval <duration>         # Per-device mean firing interval, Poisson-distributed (default: 30s)
--trap-global-cap <tps>            # Simulator-wide tps ceiling (0 = unlimited)
--trap-catalog <path>              # Override embedded universal 5-trap catalog
--trap-community <string>          # SNMPv2c community (default: public)
--trap-source-per-device           # Source IP = device IP (default: true; REQUIRED in inform mode)
--trap-inform-timeout <duration>   # Per-retry timeout in inform mode (default: 5s)
--trap-inform-retries <int>        # Max retransmissions per inform (default: 2)
+-trap-collector <host:port>       # [seed]   Seed trap collector for auto-start batch (default port 162)
+-trap-mode <proto>                # [seed]   trap (default, fire-and-forget) | inform (acknowledged)
+-trap-interval <duration>         # [seed]   Per-device mean firing interval, Poisson-distributed (default: 30s)
+-trap-global-cap <tps>            # [global] Simulator-wide tps ceiling (0 = unlimited)
+-trap-catalog <path>              # [global] Override embedded universal catalog (5 entries) + per-type overlays — when set, the single file becomes the catalog for every device
+-trap-community <string>          # [seed]   SNMPv2c community (default: public)
+-trap-source-per-device           # [global] Source IP = device IP (default: true; REQUIRED in inform mode)
+-trap-inform-timeout <duration>   # [seed]   Per-retry timeout in inform mode (default: 5s)
+-trap-inform-retries <int>        # [seed]   Max retransmissions per inform (default: 2)
 
 # UDP syslog export flags (RFC 5424 / RFC 3164)
--syslog-collector <host:port>     # Enable UDP syslog export to this collector (default port 514)
--syslog-format <fmt>              # 5424 (default, structured) | 3164 (legacy BSD)
--syslog-interval <duration>       # Per-device mean firing interval, Poisson-distributed (default: 10s)
--syslog-global-cap <rate>         # Simulator-wide rate ceiling (0 = unlimited)
--syslog-catalog <path>            # Override embedded universal 6-entry catalog
--syslog-source-per-device         # Source IP = device IP (default: true; bind failure is non-fatal, falls back to shared socket)
+-syslog-collector <host:port>     # [seed]   Seed collector for auto-start batch (default port 514)
+-syslog-format <fmt>              # [seed]   5424 (default, structured) | 3164 (legacy BSD)
+-syslog-interval <duration>       # [seed]   Per-device mean firing interval, Poisson-distributed (default: 10s)
+-syslog-global-cap <rate>         # [global] Simulator-wide rate ceiling (0 = unlimited)
+-syslog-catalog <path>            # [global] Override embedded universal 6-entry catalog
+-syslog-source-per-device         # [global] Source IP = device IP (default: true; bind failure is non-fatal, falls back to shared socket)
 
 # Tests
 cd go
@@ -82,7 +85,7 @@ go test ./simulator/ -run TestSomething
 
 **Web API:** `web.go` (route setup) + `api.go` (handlers) + `web_routes*.go` (Linux route script generation). Serves device CRUD, CSV export, system stats, flow export status (`GET /api/v1/flows/status`), trap export status (`GET /api/v1/traps/status`), and on-demand trap firing (`POST /api/v1/devices/{ip}/trap`).
 
-**Flow export:** `flow_exporter.go` (FlowExporter, FlowEncoder interface, SimulatorManager integration) + `netflow9.go` (NetFlow9Encoder, RFC 3954) + `ipfix.go` (IPFIXEncoder, RFC 7011) + `netflow5.go` (NetFlow5Encoder, Cisco v5: 24B header, 48B/record, IPv4-only, 30-record datagram cap, no templates) + `sflow.go` (SFlowEncoder, sFlow v5 per sflow_version_5.txt: 28B XDR datagram header, variable-length flow_sample records carrying sampled_header=IPv4+UDP/TCP synthesized from the FlowRecord 5-tuple, no template mechanism). One shared UDP socket and ticker goroutine; per-device FlowExporter owns a FlowCache. Protocols:
+**Flow export (per-device config, phase 3):** `flow_exporter.go` (FlowExporter, FlowEncoder interface, SimulatorManager integration) + `netflow9.go` (NetFlow9Encoder, RFC 3954) + `ipfix.go` (IPFIXEncoder, RFC 7011) + `netflow5.go` (NetFlow5Encoder, Cisco v5: 24B header, 48B/record, IPv4-only, 30-record datagram cap, no templates) + `sflow.go` (SFlowEncoder, sFlow v5 per sflow_version_5.txt: 28B XDR datagram header, variable-length flow_sample records carrying sampled_header=IPv4+UDP/TCP synthesized from the FlowRecord 5-tuple, no template mechanism). Each device owns its collector/protocol/timeouts on `DeviceFlowConfig`; the manager owns a shared-socket pool keyed by `(collector, protocol)` and one ticker goroutine. `FlowStatus` is an array-of-collectors aggregated by `(collector, protocol)`. Protocols:
 
 | Protocol   | Header | Record size    | Template? | Timestamps         | IPv6 records | Notes |
 |------------|--------|----------------|-----------|--------------------|--------------|-------|
@@ -93,7 +96,7 @@ go test ./simulator/ -run TestSomething
 
 The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-size encoders return 0 (NetFlow5/9, IPFIX), variable-length encoders (sFlow) return a worst-case per-record byte bound that `FlowExporter.Tick` uses for MTU-safe pagination.
 
-**SNMP trap export:** `trap_manager.go` (SimulatorManager integration, TrapConfig, `StartTrapExport` / `StopTrapExport`, HTTP handlers' helpers, `TrapStatus`) + `trap_catalog.go` (JSON catalog loader with embedded universal set + weighted-random pick + `text/template`-based varbind resolution) + `trap_v2c.go` (SNMPv2c TRAP [0xA7] and InformRequest [0xA6] PDU encoder, GetResponse [0xA2] ack parser — reuses `snmp_encoding.go` ASN.1 primitives) + `trap_scheduler.go` (single central min-heap scheduler goroutine with Poisson inter-arrival + `golang.org/x/time/rate` global cap) + `trap_exporter.go` (per-device `TrapExporter` with atomic per-device UDP socket, bounded pending-inform map with oldest-drop, reader/retry goroutines in INFORM mode).
+**SNMP trap export (per-device config, phase 4):** `trap_manager.go` (SimulatorManager integration, `TrapSubsystemConfig`, `StartTrapSubsystem` / `StopTrapExport`, HTTP handlers' helpers, `TrapStatus`) + `trap_catalog.go` (JSON catalog loader with embedded universal set + weighted-random pick + `text/template`-based varbind resolution) + `trap_v2c.go` (SNMPv2c TRAP [0xA7] and InformRequest [0xA6] PDU encoder, GetResponse [0xA2] ack parser — reuses `snmp_encoding.go` ASN.1 primitives) + `trap_scheduler.go` (single central min-heap scheduler goroutine with Poisson inter-arrival + `golang.org/x/time/rate` global cap) + `trap_exporter.go` (per-device `TrapExporter` with atomic per-device UDP socket, bounded pending-inform map with oldest-drop, reader/retry goroutines in INFORM mode). Each device owns its collector/mode/community/interval/inform-* settings on `DeviceTrapConfig`; the manager owns a shared-socket pool keyed by collector and a per-(collector, mode) monotonic counter aggregate that survives device deletion. `TrapStatus` is an array-of-collectors aggregated by `(collector, mode)`, with a top-level `subsystem_active` bool for observability.
 
 **Trap catalog:**
 - Default catalog is compiled into the binary from `resources/_common/traps.json` via `embed.FS` — no filesystem dependency for the out-of-box experience.
@@ -119,11 +122,10 @@ The `FlowEncoder` interface has a `MaxRecordSize() int` extension point: fixed-s
 - **`StopTrapExport` is shutdown-only** (phase-5 review D1). It is not safe to race concurrent device creation: `startDeviceTrapExporter` captures scheduler / pool / encoder pointers under a short RLock and uses them outside that lock, so a concurrent Stop can leave orphan exporters or closed sockets. Today it is only called from the process-exit signal handler. Do not introduce a runtime "restart trap subsystem" control path without first tightening the attach-path lock discipline.
 
 **Trap HTTP endpoints:**
-- `GET /api/v1/traps/status` — JSON with `enabled`, `mode`, `sent`, INFORM counters (`informs_pending`, `informs_acked`, `informs_failed`, `informs_dropped` when mode=inform), `rate_limiter_tokens_available` (when `-trap-global-cap` is set), `devices_exporting`.
-- `POST /api/v1/devices/{ip}/trap` — body `{"name":"linkDown","varbindOverrides":{"IfIndex":"3"}}` → `202 Accepted` + `{"requestId": N}`. `400` for unknown catalog entry (response body includes `catalog` — the device's resolved catalog label — and `availableEntries` list so operators can self-service), `404` for unknown device, `503` when trap export is disabled. Fire-and-forget: returns without waiting on INFORM ack.
-- `GET /api/v1/traps/status` additionally reports `catalogs_by_type` when enabled: `{ "cisco_ios": {entries: 11, source: "file:resources/cisco_ios/traps.json"}, "_universal": {entries: 5, source: "embedded"} }`.
+- `GET /api/v1/traps/status` — JSON array-of-collectors: `{subsystem_active, collectors: [{collector, mode, devices, sent, informs_pending?, informs_acked?, informs_failed?, informs_dropped?}], devices_exporting, rate_limiter_tokens_available?, catalogs_by_type?}`. `subsystem_active=false` means `StartTrapSubsystem` has not run; `subsystem_active=true` with `collectors=[]` means running but no device has opted in. INFORM counters are only present on records with `mode=inform`. `catalogs_by_type` reports per-type overlay counts and source (`embedded` / `file:resources/<slug>/traps.json` / `override:<path>`).
+- `POST /api/v1/devices/{ip}/trap` — body `{"name":"linkDown","varbindOverrides":{"IfIndex":"3"}}` → `202 Accepted` + `{"requestId": N}`. `400` for unknown catalog entry (response body includes `catalog` — the device's resolved catalog label — and `availableEntries` list so operators can self-service), `404` for unknown device, `503` when the subsystem is not running or the device has no trap config. Fire-and-forget: returns without waiting on INFORM ack.
 
-**UDP syslog export:** `syslog_manager.go` (SimulatorManager integration, SyslogConfig, `StartSyslogExport` / `StopSyslogExport`, `SyslogStatus`) + `syslog_catalog.go` (JSON catalog with embedded universal 6-entry set; weighted-random pick; `text/template`-based body / structured-data resolution with all templates pre-compiled at load) + `syslog_wire.go` (`SyslogEncoder` interface with `RFC5424Encoder` and `RFC3164Encoder` — PRI calc, ISO 8601 / `Mmm DD HH:MM:SS` timestamps, SD-PARAM escape per §6.3.3, HOSTNAME / APP-NAME / MSGID / TAG sanitisation, MaxMessageSize enforcement) + `syslog_scheduler.go` (single central min-heap scheduler with Poisson inter-arrival + `golang.org/x/time/rate` global cap; derived context so `Stop()` is bounded-time under cap) + `syslog_exporter.go` (per-device `SyslogExporter` with atomic per-device UDP socket and shared-socket fallback).
+**UDP syslog export (per-device config, phase 5):** `syslog_manager.go` (SimulatorManager integration, `SyslogSubsystemConfig`, `StartSyslogSubsystem` / `StopSyslogExport`, `SyslogStatus`) + `syslog_catalog.go` (JSON catalog with embedded universal 6-entry set; weighted-random pick; `text/template`-based body / structured-data resolution with all templates pre-compiled at load) + `syslog_wire.go` (`SyslogEncoder` interface with `RFC5424Encoder` and `RFC3164Encoder` — PRI calc, ISO 8601 / `Mmm DD HH:MM:SS` timestamps, SD-PARAM escape per §6.3.3, HOSTNAME / APP-NAME / MSGID / TAG sanitisation, MaxMessageSize enforcement) + `syslog_scheduler.go` (single central min-heap scheduler with Poisson inter-arrival + `golang.org/x/time/rate` global cap; derived context so `Stop()` is bounded-time under cap) + `syslog_exporter.go` (per-device `SyslogExporter` with atomic per-device UDP socket and shared-socket fallback). Each device owns its collector/format/interval on `DeviceSyslogConfig`; the manager owns a shared-socket pool keyed by `(collector, format)`, a per-format encoder cache, and a per-(collector, format) monotonic counter aggregate. `SyslogStatus` is an array-of-collectors aggregated by `(collector, format)`, with a top-level `subsystem_active` bool.
 
 **Syslog catalog:**
 - Default catalog is compiled into the binary from `resources/_common/syslog.json` via `embed.FS` — feature works out of the box.
@@ -203,8 +205,8 @@ In every branch the result is run through `sanitiseHostname`: spaces become hyph
 - **`StopSyslogExport` is shutdown-only** (phase-5 review D1). Same constraint as trap: `startDeviceSyslogExporter` uses captured pointers outside the short RLock. Only called from the process-exit path today. Tightening is a pre-requisite for any runtime "restart" control plane.
 
 **Syslog HTTP endpoints:**
-- `GET /api/v1/syslog/status` — JSON with `enabled`, `format` (`5424` or `3164`), `collector`, `sent`, `send_failures`, `rate_limiter_tokens_available` (when `-syslog-global-cap` is set), `devices_exporting`.
-- `POST /api/v1/devices/{ip}/syslog` — body `{"name":"interface-down","templateOverrides":{"IfIndex":"3","IfName":"Gi0/3"}}` → `202 Accepted` + `{}`. `400` for unknown catalog entry or malformed JSON, `404` for unknown device, `503` when syslog export is disabled.
+- `GET /api/v1/syslog/status` — JSON array-of-collectors: `{subsystem_active, collectors: [{collector, format, devices, sent, send_failures}], devices_exporting, rate_limiter_tokens_available?, catalogs_by_type?}`. Same `subsystem_active` semantics as trap. The `(collector, format)` tuple lets devices emit different wire formats to the same collector without interleaving on one socket.
+- `POST /api/v1/devices/{ip}/syslog` — body `{"name":"interface-down","templateOverrides":{"IfIndex":"3","IfName":"Gi0/3"}}` → `202 Accepted` + `{}`. `400` for unknown catalog entry or malformed JSON, `404` for unknown device, `503` when the subsystem is not running or the device has no syslog config. Typo'd fields rejected via `DisallowUnknownFields`.
 
 **Resource loading:** `resources.go` loads and caches the 379 JSON files at startup. Each device type directory has split JSON files for SNMP, SSH, and REST responses that are merged at load time.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ snmpget -v2c -c public 192.168.100.1 1.3.6.1.2.1.1.1.0
 ssh simadmin@192.168.100.1                            # password: simadmin
 ```
 
+Per-device exports (flow + trap + syslog in a single create call):
+
+```bash
+# Boot without any export CLI flags — the subsystems are always-on.
+sudo ./simulator
+
+# Create 10 devices that all emit IPFIX flows, SNMPv2c traps, and
+# RFC 5424 syslog to one collector. Any of the three blocks is optional.
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 10,
+    "flow":   {"collector": "192.168.1.10:4739", "protocol": "ipfix"},
+    "traps":  {"collector": "192.168.1.10:162",  "mode":     "trap"},
+    "syslog": {"collector": "192.168.1.10:514",  "format":   "5424"}
+  }'
+
+# Inspect what each subsystem has attached.
+curl http://localhost:8080/api/v1/flows/status   | jq '.data.collectors'
+curl http://localhost:8080/api/v1/traps/status   | jq '.collectors'
+curl http://localhost:8080/api/v1/syslog/status  | jq '.collectors'
+```
+
 Full walkthrough: [Getting started → Quick start](https://labmonkeys-space.github.io/l8opensim/getting-started/quick-start/).
 Container and Kubernetes deployment: [Getting started → Docker](https://labmonkeys-space.github.io/l8opensim/getting-started/docker/).
 

--- a/docs/ops/flow-export.md
+++ b/docs/ops/flow-export.md
@@ -49,6 +49,83 @@ sudo ./simulator -auto-start-ip 10.0.0.1 -auto-count 100 \
   -flow-collector 192.168.1.10:2055 -flow-source-per-device=false
 ```
 
+## Heterogeneous-fleet operation (multiple collectors / protocols)
+
+The `-flow-*` CLI flags seed a **single** collector / protocol for the
+auto-start batch. To stand up a fleet that points at more than one
+collector — or mixes protocols — start the simulator with just the
+global flags and drive device creation via
+[`POST /api/v1/devices`](../reference/web-api.md#per-device-export-blocks),
+one batch per collector / protocol.
+
+### Example: two collectors, three protocols
+
+```bash
+# 1. Boot with NO flow seed — only the global knobs (tick cadence,
+#    template cadence, source-per-device policy).
+sudo ./simulator \
+  -flow-tick-interval 1 \
+  -flow-template-interval 300 \
+  -flow-source-per-device=true
+
+# 2. Batch A → NetFlow v9 to collector A.
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 50,
+    "flow": {"collector": "192.168.1.10:2055", "protocol": "netflow9"}
+  }'
+
+# 3. Batch B → IPFIX to collector A (different protocol, same host).
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.1.1",
+    "device_count": 30,
+    "flow": {"collector": "192.168.1.10:4739", "protocol": "ipfix"}
+  }'
+
+# 4. Batch C → sFlow to collector B.
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.2.1",
+    "device_count": 20,
+    "flow": {"collector": "192.168.1.20:6343", "protocol": "sflow"}
+  }'
+```
+
+`GET /api/v1/flows/status` then reports three collector records, one
+per `(collector, protocol)` tuple:
+
+```json
+{
+  "subsystem_active": true,
+  "collectors": [
+    {"collector": "192.168.1.10:2055", "protocol": "netflow9", "devices": 50, "..." },
+    {"collector": "192.168.1.10:4739", "protocol": "ipfix",    "devices": 30, "..." },
+    {"collector": "192.168.1.20:6343", "protocol": "sflow",    "devices": 20, "..." }
+  ],
+  "devices_exporting": 100
+}
+```
+
+### Notes
+
+- The same device IP can belong to only one flow config (one `flow` block
+  per device). If you need the same device to appear on multiple
+  collectors, run multiple simulator processes — the `opensim` netns +
+  per-device-source-IP scheme isn't designed to multicast.
+- The global `-flow-tick-interval` and `-flow-template-interval` are
+  simulator-wide — every exporter ticks at the same cadence regardless
+  of batch. Per-device `tick_interval` in the REST body is accepted and
+  validated but not yet honored; a single warning is logged per
+  subsystem lifecycle if any device's value diverges from the global
+  (phase-4+5 design debt).
+- Collector-side `rp_filter` tuning applies per collector host, not
+  per protocol — see the next section.
+
 ## Prerequisites for per-device source IP
 
 When `-flow-source-per-device` is enabled (the default), flow packets

--- a/docs/ops/migration-per-device-exports.md
+++ b/docs/ops/migration-per-device-exports.md
@@ -1,0 +1,198 @@
+# Migration: per-device export config
+
+The per-device-export-config change (phases 3 + 4 + 5) rewrote how
+flow, trap, and syslog export are configured and how their status
+endpoints respond. This page covers the operator-facing migration.
+
+## What changed
+
+Before the change, each subsystem had a **single simulator-wide**
+collector / protocol / mode / format. The `-X-collector` CLI flag was
+both the "enable" switch and the sole target. `GET /api/v1/X/status`
+returned scalar fields describing that one collector.
+
+After the change:
+
+- **Each device owns its own export configuration.** The
+  `DeviceFlowConfig` / `DeviceTrapConfig` / `DeviceSyslogConfig` block
+  is attached to the device at creation time — either seeded from the
+  CLI flags (for `-auto-start-ip` devices) or explicitly in the
+  `POST /api/v1/devices` request body.
+- **The CLI flags are now seeds for the auto-start batch only.**
+  REST-created devices do not inherit them; they opt in via the
+  request body.
+- **The subsystems are always-on.** `StartTrapSubsystem` /
+  `StartSyslogSubsystem` / the flow ticker run from `main()` regardless
+  of whether any device has configured export. Enabling export is now
+  a per-device decision.
+- **`GET /api/v1/{flows,traps,syslog}/status` is an array-of-collectors.**
+  One record per `(collector, protocol)` / `(collector, mode)` /
+  `(collector, format)` tuple, aggregated across devices. Counters are
+  monotonic within a subsystem lifecycle.
+
+See the [CLI flags reference](../reference/cli-flags.md) for the full
+per-flag Scope taxonomy and the [Web API reference](../reference/web-api.md)
+for the request/response schemas.
+
+## Migrating your invocations
+
+### Case 1: auto-start batch with a single export target
+
+**Before — and after.** The CLI-seed form is unchanged for operators
+who only used `-auto-start-ip` + one collector:
+
+```bash
+# Still works, still produces the same wire behaviour
+sudo ./simulator \
+  -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -flow-collector 192.168.1.10:2055 \
+  -trap-collector 192.168.1.10:162 \
+  -syslog-collector 192.168.1.10:514
+```
+
+The only change visible here is the **status-endpoint response
+shape** — see Case 4 below.
+
+### Case 2: REST-created devices that previously inherited the CLI seed
+
+**Before:** the simulator was started with a CLI flag, and
+`POST /api/v1/devices` created devices that silently inherited the
+CLI-wide collector.
+
+```bash
+# Before: CLI seed implicitly applied to REST-created devices
+sudo ./simulator -syslog-collector 192.168.1.10:514
+
+curl -X POST http://localhost:8080/api/v1/devices \
+  -d '{"start_ip":"10.0.0.50", "device_count":1}'
+# ← this device used to inherit -syslog-collector. It no longer does.
+```
+
+**After:** REST-created devices must opt in via the request body.
+
+```bash
+sudo ./simulator   # no CLI export flags
+
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.0.50",
+    "device_count": 1,
+    "syslog": {"collector": "192.168.1.10:514", "format": "5424"}
+  }'
+```
+
+This is a **breaking change** for any deployment that relied on the
+implicit inheritance. If your orchestration creates devices via REST
+after booting with export CLI flags, you need to add the corresponding
+`flow` / `traps` / `syslog` blocks to the request body.
+
+### Case 3: heterogeneous fleet (multiple collectors or protocols)
+
+**Before:** impossible — the simulator supported only one collector
+per subsystem per process.
+
+**After:** natural. Issue one `POST /api/v1/devices` per collector /
+protocol / mode / format combination. `/api/v1/X/status` reports each
+tuple as its own record.
+
+See [Web API → Heterogeneous fleet](../reference/web-api.md#create-devices)
+for a worked example.
+
+### Case 4: status-endpoint consumers
+
+**Before — flow status:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "enabled": true,
+    "protocol": "ipfix",
+    "collector": "192.168.1.10:4739",
+    "total_packets_sent": 91215,
+    "total_bytes_sent":  136823040,
+    "devices_exporting": 100
+  }
+}
+```
+
+**After — flow status:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "subsystem_active": true,
+    "collectors": [
+      {"collector": "192.168.1.10:4739", "protocol": "ipfix", "devices": 100, "sent_packets": 91215, "sent_bytes": 136823040, "sent_records": 2436900}
+    ],
+    "devices_exporting": 100,
+    "last_template_send": "2026-04-23T10:35:00Z"
+  }
+}
+```
+
+**Trap / syslog status** are symmetric — both retired their scalar
+fields (`enabled`, `mode`, `collector`, `community`, `sent`,
+`informs_*`, `format`, `send_failures`) in favour of the
+array-of-collectors form with a top-level `subsystem_active` bool.
+
+**Dashboard / CI / probe migration:**
+
+- Replace `enabled == true` with `subsystem_active == true`.
+- Replace scalar `collector` / `protocol` / `mode` / `format` with
+  `collectors[i].collector` + its protocol/mode/format companion.
+- Replace scalar counters (`sent`, `total_*`, `send_failures`,
+  `informs_*`) with their per-record counterparts under
+  `collectors[i]`. If you want a simulator-wide total, sum across
+  `collectors[]`.
+- `informs_pending` / `informs_acked` / `informs_failed` /
+  `informs_dropped` now appear **only on records whose `mode == inform`**.
+  TRAP-mode records omit them.
+
+## Go API migration
+
+Programmatic callers of the manager (tests, embedded-use cases):
+
+- `StartTrapExport(TrapConfig)` → `StartTrapSubsystem(TrapSubsystemConfig)` +
+  per-device `DeviceTrapConfig`.
+- `StartSyslogExport(SyslogConfig)` → `StartSyslogSubsystem(SyslogSubsystemConfig)` +
+  per-device `DeviceSyslogConfig`.
+- **Stop-side naming is asymmetric**: `StopTrapExport` / `StopSyslogExport`
+  kept their names. There is NO `StopTrapSubsystem` / `StopSyslogSubsystem`
+  symbol — a grep for that won't find anything. The asymmetry is
+  intentional (Stop retains its pre-phase-4 scope: tear down the scheduler
+  and close every exporter).
+- The retired `TrapConfig` / `SyslogConfig` types bundled subsystem +
+  per-device settings. The new `*SubsystemConfig` types hold only
+  catalog path, global cap, per-device-source flag, and the
+  scheduler's mean interval. Everything else moves to the per-device
+  config attached via `ExportSeed` (auto-start path) or
+  `POST /api/v1/devices` (REST path).
+- `sm.trapActive` / `sm.syslogActive` atomic bools are retired — a
+  device participates if its own `trapConfig` / `syslogConfig` is
+  non-nil. Check the subsystem itself via
+  `sm.GetTrapStatus().SubsystemActive` /
+  `sm.GetSyslogStatus().SubsystemActive`.
+
+## Known constraints carried into this change
+
+- **`Stop*Export` is process-shutdown-only.** The subsystems are not
+  safe to restart at runtime — attach paths capture scheduler pointers
+  outside the main lock, so a concurrent Stop can orphan exporters.
+  Phase-5 review D1 deferred the lock-discipline tightening; don't
+  introduce a REST "restart subsystem" endpoint without addressing it
+  first.
+- **Per-device `tick_interval` / `interval` are validated but not
+  honored by the scheduler today.** A single warning is logged per
+  subsystem lifecycle if any attached device's value differs from the
+  simulator-wide mean. Design debt tracked against phases 3-5.
+
+## References
+
+- [CLI flags reference](../reference/cli-flags.md) — per-flag scope taxonomy.
+- [Web API reference](../reference/web-api.md) — per-device block schemas and status shapes.
+- [Flow export reference](../reference/flow-export.md) — protocol-level details.
+- [SNMP trap reference](../reference/snmp-traps.md) — TRAP / INFORM wire format and catalog.
+- [UDP syslog reference](../reference/syslog-export.md) — RFC 5424 / 3164 wire format and catalog.

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -59,21 +59,44 @@ editing resource files.
 Scenario 4 uses a deterministic rule (`ifIndex % 100 < n`) so test runs are
 reproducible across restarts.
 
+## Export flag scope
+
+Export flags (flow / trap / syslog) fall into two categories:
+
+- **seed** — applies only to devices created by the `-auto-start-ip` batch at
+  startup. Devices subsequently created via `POST /api/v1/devices` do NOT
+  inherit these values; they must opt in by including a `flow` / `traps` /
+  `syslog` block in the request body.
+- **global** — applies simulator-wide regardless of how the device was
+  created. Shared sockets, catalogs, rate-limiter, and network-namespace
+  bind policy sit here.
+
+**Duration units differ between CLI and REST:** CLI flags that express a
+duration take **integer seconds** (e.g. `-flow-tick-interval 5`,
+`-trap-interval 30`), while the REST per-device blocks require **Go
+duration strings** (`"tick_interval": "5s"`, `"interval": "30s"`).
+Passing an integer in the REST body (`"interval": 30`) is rejected with
+400 by design — the two forms are not interchangeable.
+
+See [Web API](web-api.md) for the per-device block schema and
+[Migration](../ops/migration-per-device-exports.md) for converting
+pre-per-device-config invocations.
+
 ## Flow export flags
 
 See [Flow export (operator guide)](../ops/flow-export.md) for prerequisites and
 collector setup, and [Flow export reference](flow-export.md) for protocol
 details.
 
-| Flag | Type | Default | Purpose |
-|------|------|---------|---------|
-| `-flow-collector` | string | — | Enable flow export to this UDP collector (e.g. `192.168.1.10:2055`). |
-| `-flow-protocol` | `netflow9` \| `ipfix` \| `netflow5` \| `sflow` | `netflow9` | Flow export protocol (alias: `sflow5`). |
-| `-flow-tick-interval` | int (seconds) | `5` | Flow ticker interval. |
-| `-flow-active-timeout` | int (seconds) | `30` | Active flow timeout. |
-| `-flow-inactive-timeout` | int (seconds) | `15` | Inactive flow timeout. |
-| `-flow-template-interval` | int (seconds) | `60` | Template retransmission interval (NetFlow v9 / IPFIX only). |
-| `-flow-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. |
+| Flag | Type | Default | Scope | Purpose |
+|------|------|---------|-------|---------|
+| `-flow-collector` | string | — | **seed** | Enable flow export to this UDP collector (e.g. `192.168.1.10:2055`) for the auto-start batch. |
+| `-flow-protocol` | `netflow9` \| `ipfix` \| `netflow5` \| `sflow` | `netflow9` | **seed** | Flow export protocol (alias: `sflow5`). |
+| `-flow-tick-interval` | int (seconds) | `5` | **seed** | Flow ticker interval. |
+| `-flow-active-timeout` | int (seconds) | `30` | **seed** | Active flow timeout. |
+| `-flow-inactive-timeout` | int (seconds) | `15` | **seed** | Inactive flow timeout. |
+| `-flow-template-interval` | int (seconds) | `60` | **global** | Template retransmission interval (NetFlow v9 / IPFIX only). |
+| `-flow-source-per-device` | bool | `true` | **global** | Use each device's IP as the UDP source address. |
 
 ## SNMP trap / INFORM export flags
 
@@ -81,17 +104,17 @@ See [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) for
 prerequisites and `snmptrapd` smoke-test, and
 [SNMP trap reference](snmp-traps.md) for wire format and catalog JSON.
 
-| Flag | Type | Default | Purpose |
-|------|------|---------|---------|
-| `-trap-collector` | string | — | Enable trap export to this UDP collector (e.g. `192.168.1.10:162`). Empty disables the feature. |
-| `-trap-mode` | `trap` \| `inform` | `trap` | Notification mode. TRAP is fire-and-forget; INFORM is acknowledged and retried. |
-| `-trap-interval` | duration | `30s` | Per-device mean firing interval (Poisson-distributed, not periodic). |
-| `-trap-global-cap` | int (tps) | `0` | Simulator-wide rate ceiling across fires + INFORM retries. `0` is unlimited. |
-| `-trap-catalog` | string | — | Path to a JSON catalog; empty uses the embedded universal 5-trap catalog + per-type overlays from `resources/<slug>/traps.json`. Setting this flag **disables per-type overlays** — the file becomes the sole catalog for every device. |
-| `-trap-community` | string | `public` | SNMPv2c community string. |
-| `-trap-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. **Required** when `-trap-mode inform`. |
-| `-trap-inform-timeout` | duration | `5s` | Per-retry timeout in INFORM mode. |
-| `-trap-inform-retries` | int | `2` | Maximum retransmissions per INFORM before it's declared failed. |
+| Flag | Type | Default | Scope | Purpose |
+|------|------|---------|-------|---------|
+| `-trap-collector` | string | — | **seed** | Enable trap export to this UDP collector (e.g. `192.168.1.10:162`) for the auto-start batch. Empty disables seeding; REST-created devices can still opt in via the `traps` block. |
+| `-trap-mode` | `trap` \| `inform` | `trap` | **seed** | Notification mode. TRAP is fire-and-forget; INFORM is acknowledged and retried. |
+| `-trap-interval` | duration | `30s` | **seed** | Per-device mean firing interval (Poisson-distributed, not periodic). |
+| `-trap-global-cap` | int (tps) | `0` | **global** | Simulator-wide rate ceiling across fires + INFORM retries. `0` is unlimited. |
+| `-trap-catalog` | string | — | **global** | Path to a JSON catalog; empty uses the embedded universal 5-trap catalog + per-type overlays from `resources/<slug>/traps.json`. Setting this flag **disables per-type overlays** — the file becomes the sole catalog for every device. |
+| `-trap-community` | string | `public` | **seed** | SNMPv2c community string. |
+| `-trap-source-per-device` | bool | `true` | **global** | Use each device's IP as the UDP source address. **Required** when a device is configured `mode=inform` — enforced at device-attach time: the attach fails per-device and the device's `trapConfig` is cleared. |
+| `-trap-inform-timeout` | duration | `5s` | **seed** | Per-retry timeout in INFORM mode. |
+| `-trap-inform-retries` | int | `2` | **seed** | Maximum retransmissions per INFORM before it's declared failed. |
 
 ## UDP syslog export flags
 
@@ -99,14 +122,14 @@ See [UDP syslog export (operator guide)](../ops/syslog-export.md) for
 prerequisites and `netcat` smoke-test, and
 [UDP syslog reference](syslog-export.md) for wire format and catalog JSON.
 
-| Flag | Type | Default | Purpose |
-|------|------|---------|---------|
-| `-syslog-collector` | string | — | Enable syslog export to this UDP collector (e.g. `192.168.1.10:514`). Empty disables the feature. |
-| `-syslog-format` | `5424` \| `3164` | `5424` | Wire format. RFC 5424 is structured (recommended); RFC 3164 is legacy BSD. One format per process — they don't mix on a single UDP socket. |
-| `-syslog-interval` | duration | `10s` | Per-device mean firing interval (Poisson-distributed, not periodic). |
-| `-syslog-global-cap` | int (rate) | `0` | Simulator-wide rate ceiling across scheduled fires. On-demand HTTP fires bypass the cap. `0` is unlimited. |
-| `-syslog-catalog` | string | — | Path to a JSON catalog; empty uses the embedded universal 6-entry catalog + per-type overlays from `resources/<slug>/syslog.json`. Setting this flag **disables per-type overlays** — the file becomes the sole catalog for every device. |
-| `-syslog-source-per-device` | bool | `true` | Use each device's IP as the UDP source address. Per-device bind failures are non-fatal (unlike INFORM mode on the trap side) — the exporter falls back to the shared socket with a warning. |
+| Flag | Type | Default | Scope | Purpose |
+|------|------|---------|-------|---------|
+| `-syslog-collector` | string | — | **seed** | Enable syslog export to this UDP collector (e.g. `192.168.1.10:514`) for the auto-start batch. Empty disables seeding; REST-created devices can still opt in via the `syslog` block. |
+| `-syslog-format` | `5424` \| `3164` | `5424` | **seed** | Wire format. RFC 5424 is structured (recommended); RFC 3164 is legacy BSD. Per-device as of phase 5 — different devices can emit different formats to the same collector; the shared-socket pool is keyed by `(collector, format)` so streams never interleave. |
+| `-syslog-interval` | duration | `10s` | **seed** | Per-device mean firing interval (Poisson-distributed, not periodic). |
+| `-syslog-global-cap` | int (rate) | `0` | **global** | Simulator-wide rate ceiling across scheduled fires. On-demand HTTP fires bypass the cap. `0` is unlimited. |
+| `-syslog-catalog` | string | — | **global** | Path to a JSON catalog; empty uses the embedded universal 6-entry catalog + per-type overlays from `resources/<slug>/syslog.json`. Setting this flag **disables per-type overlays** — the file becomes the sole catalog for every device. |
+| `-syslog-source-per-device` | bool | `true` | **global** | Use each device's IP as the UDP source address. Per-device bind failures are non-fatal (unlike INFORM mode on the trap side) — the exporter falls back to the shared socket with a warning. |
 
 ## Examples
 

--- a/docs/reference/flow-export.md
+++ b/docs/reference/flow-export.md
@@ -67,11 +67,92 @@ See [Flow export (operator guide)](../ops/flow-export.md#prerequisites-for-per-d
 for the prerequisites (iptables `FORWARD` rule, route to the collector from
 the namespace, collector-side `rp_filter` tuning).
 
+## Starting flow export
+
+Flow export is opt-in per device. There are two ways to configure it:
+
+### 1. CLI seed (auto-start batch)
+
+The `-flow-*` flags seed auto-created devices. Each device in the batch
+gets the same collector, protocol, and timeouts.
+
+```bash
+# NetFlow v9 → 192.168.1.10:2055, 100 auto-created devices
+sudo ./simulator \
+  -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -flow-collector 192.168.1.10:2055 \
+  -flow-protocol netflow9
+
+# Mixed fleet isn't achievable via CLI — use the REST body.
+```
+
+### 2. REST body (per-device)
+
+`POST /api/v1/devices` accepts an optional `flow` block on each request.
+Devices in different requests can point at different collectors or emit
+different protocols.
+
+```bash
+# One batch of 50 emitting IPFIX to collector A
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 50,
+    "flow": {
+      "collector": "192.168.1.10:4739",
+      "protocol": "ipfix",
+      "active_timeout": "30s"
+    }
+  }'
+
+# Second batch of 20 emitting sFlow to collector B — same process,
+# /api/v1/flows/status reports both as separate collector records.
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.1.1",
+    "device_count": 20,
+    "flow": {
+      "collector": "192.168.1.20:6343",
+      "protocol": "sflow"
+    }
+  }'
+```
+
+The `flow` block is **optional** on every request — omit it and the
+device doesn't export.
+
+**Duration fields** (`tick_interval`, `active_timeout`,
+`inactive_timeout`) require **Go duration strings** (`"5s"`, `"30s"`,
+`"1m30s"`). Integer seconds (`"tick_interval": 5`) are rejected with
+400 — a deliberate mismatch with the `-flow-tick-interval` / `-flow-*-timeout`
+CLI flags, which take integer seconds.
+
+See [Web API → POST /api/v1/devices](web-api.md#create-devices) for the
+full per-device schema.
+
 ## Status API
 
 ```bash
 curl http://localhost:8080/api/v1/flows/status
 ```
 
-See [Web API → Flow export status](web-api.md#flow-export-status) for an
-example response.
+Returns an array-of-collectors aggregated by `(collector, protocol)`:
+
+```json
+{
+  "subsystem_active": true,
+  "collectors": [
+    {"collector": "192.168.1.10:4739", "protocol": "ipfix",    "devices": 50, "sent_packets": 8123, "sent_bytes": 12123456, "sent_records": 243690},
+    {"collector": "192.168.1.20:6343", "protocol": "sflow",    "devices": 20, "sent_packets": 3100, "sent_bytes":  5560000, "sent_records":  62000}
+  ],
+  "devices_exporting": 70,
+  "last_template_send": "2026-04-23T10:35:00Z"
+}
+```
+
+`subsystem_active=false` with `collectors: []` means flow export never
+ran (the subsystem starts on-demand when the first device with a `flow`
+block attaches). See [Web API → Flow export status](web-api.md#flow-export-status)
+for the full field reference.

--- a/docs/reference/snmp-traps.md
+++ b/docs/reference/snmp-traps.md
@@ -222,6 +222,82 @@ content depends on Class 2 random fields deferred to a follow-up.
 Family-catalog concept (one catalog shared by all `cisco_*` slugs) is
 also a follow-up refactor.
 
+## Starting trap export
+
+Trap export is opt-in per device. There are two ways to configure it:
+
+### 1. CLI seed (auto-start batch)
+
+The `-trap-*` flags seed auto-created devices. Every device in the
+auto-start batch gets the same collector, mode, community, and interval.
+
+```bash
+# SNMPv2c TRAP → 192.168.1.10:162, 100 auto-created devices, default
+# interval=30s / community=public
+sudo ./simulator \
+  -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -trap-collector 192.168.1.10:162
+
+# INFORM mode (acknowledged) — requires -trap-source-per-device=true
+# (the default). The check is enforced at device-attach time: if it's
+# disabled, attach fails per-device and trapConfig is cleared.
+sudo ./simulator \
+  -auto-start-ip 10.0.0.1 -auto-count 50 \
+  -trap-collector 192.168.1.10:162 \
+  -trap-mode inform \
+  -trap-inform-timeout 3s -trap-inform-retries 5
+```
+
+### 2. REST body (per-device)
+
+`POST /api/v1/devices` accepts an optional `traps` block per request.
+Different batches can target different collectors or mix TRAP and INFORM.
+
+```bash
+# A: 50 TRAP-mode devices → collector A, community public
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 50,
+    "traps": {
+      "collector": "192.168.1.10:162",
+      "mode": "trap",
+      "community": "public",
+      "interval": "30s"
+    }
+  }'
+
+# B: 20 INFORM-mode devices → collector B, tight retry budget
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.1.1",
+    "device_count": 20,
+    "traps": {
+      "collector": "192.168.1.20:162",
+      "mode": "inform",
+      "community": "private",
+      "interval": "60s",
+      "inform_timeout": "2s",
+      "inform_retries": 3
+    }
+  }'
+```
+
+`/api/v1/traps/status` reports both batches as separate records keyed by
+`(collector, mode)`.
+
+The `traps` block is **optional** on every request — omit it and the
+device doesn't fire traps. See
+[Web API → POST /api/v1/devices](web-api.md#create-devices) for the full
+per-device schema.
+
+**Duration fields** (`interval`, `inform_timeout`) require **Go duration
+strings** (`"30s"`, `"5m"`, `"1m30s"`). Integer seconds (`"interval": 30`)
+are rejected with 400 — a deliberate mismatch with the `-trap-interval`
+CLI flag, which takes integer seconds.
+
 ## HTTP endpoints
 
 ### Fire a trap on demand
@@ -250,7 +326,7 @@ Responses:
 | `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for the device. The enriched body tells the caller which catalog the device resolved to (`cisco_ios`, `_universal`, etc.) and lists its entries alphabetically so a scripted caller can self-service when it targeted the wrong vendor. For malformed JSON or missing `name`, the legacy envelope form `{"success": false, "message": "..."}` applies. |
 | `404 Not Found` | `{"success": false, "message": "..."}` | Unknown device IP. |
 | `500 Internal Server Error` | `{"success": false, "message": "..."}` | `Fire` failed for a non-lookup reason — template resolve error, catalog resolution returned nil despite feature active (pathological manager state), or write failure. Logs on the simulator side carry the detail. |
-| `503 Service Unavailable` | `{"success": false, "message": "..."}` | Trap export is disabled (`-trap-collector` not set). |
+| `503 Service Unavailable` | `{"success": false, "message": "..."}` | The trap subsystem has not started **or** the target device has no trap config (i.e. it was created without a `traps` block and didn't inherit the CLI seed). |
 
 The endpoint is fire-and-forget — it does **not** block waiting for an
 INFORM ack.
@@ -261,22 +337,33 @@ INFORM ack.
 
 Unlike `/api/v1/flows/status`, this endpoint does **not** wrap its body
 in the `{success, message, data}` envelope — `TrapStatus` is serialised
-directly at the top level. When enabled in INFORM mode (the most complete
-response shape):
+directly at the top level.
+
+**Response shape** (array-of-collectors aggregated by `(collector, mode)`):
 
 ```json
 {
-  "enabled": true,
-  "mode": "inform",
-  "collector": "192.168.1.10:162",
-  "community": "public",
-  "sent": 182430,
-  "informs_pending": 17,
-  "informs_acked": 182380,
-  "informs_failed": 33,
-  "informs_dropped": 0,
-  "rate_limiter_tokens_available": 94,
+  "subsystem_active": true,
+  "collectors": [
+    {
+      "collector": "192.168.1.10:162",
+      "mode":      "inform",
+      "devices":   80,
+      "sent":      182430,
+      "informs_pending": 17,
+      "informs_acked":   182380,
+      "informs_failed":  33,
+      "informs_dropped": 0
+    },
+    {
+      "collector": "192.168.1.20:162",
+      "mode":      "trap",
+      "devices":   20,
+      "sent":      6000
+    }
+  ],
   "devices_exporting": 100,
+  "rate_limiter_tokens_available": 94,
   "catalogs_by_type": {
     "_universal":    {"entries": 5,  "source": "embedded"},
     "cisco_ios":     {"entries": 12, "source": "file:resources/cisco_ios/traps.json"},
@@ -285,23 +372,33 @@ response shape):
 }
 ```
 
-`catalogs_by_type` is present whenever the feature is enabled. Keys
+The **four `informs_*` fields appear only on records whose `mode == inform`**.
+TRAP-mode records omit them.
+
+`subsystem_active` is the authoritative "is the feature live?" signal —
+`true` after `StartTrapSubsystem` runs. During normal operation of the
+HTTP server this value is always `true`: the subsystem initialises in
+`main()` and the only path that flips it to `false` is `StopTrapExport`,
+which runs at process exit alongside the HTTP server. A `false` value
+is therefore only observable programmatically (test harness, embedded
+use). Clients should still branch on `subsystem_active` rather than
+length-checking `collectors`. `subsystem_active=true` with
+`collectors=[]` means the subsystem is running but no device has opted
+in.
+
+Counters are **monotonic within a subsystem lifecycle**: deleting a
+device does not zero its collector's `sent` counter; the aggregate
+persists via `sm.trapAggregates` until `StopTrapExport` (which is
+today's process-exit path). A `devices=0` record therefore means "no
+live devices for this tuple, but historical fires still counted."
+
+`catalogs_by_type` is present whenever `subsystem_active=true`. Keys
 are device-type slugs with the reserved `_universal` entry for the
 fallback catalog. Values include the merged entry count and the
 catalog's provenance: `"embedded"` (compiled-in universal),
 `"file:<path>"` (per-type overlay on disk), or
 `"override:<path>"` when `-trap-catalog` was supplied (in which case
 `catalogs_by_type` contains a single `_universal` entry).
-
-When enabled in TRAP mode, the four `informs_*` fields are omitted (no
-INFORM state to report). When disabled the response is:
-
-```json
-{"enabled": false, "sent": 0, "devices_exporting": 0}
-```
-
-(`sent` and `devices_exporting` are not tagged `omitempty` so they are
-always present; their values are zero when the feature is off.)
 
 `rate_limiter_tokens_available` is present only when `-trap-global-cap`
 is set; it's a best-effort instantaneous snapshot, not synchronised with

--- a/docs/reference/syslog-export.md
+++ b/docs/reference/syslog-export.md
@@ -278,6 +278,76 @@ content depends on Class 2 random fields deferred to a follow-up.
 Family-catalog concept (one catalog shared by all `cisco_*` slugs,
 one by all `juniper_*`) is also a follow-up refactor.
 
+## Starting syslog export
+
+Syslog export is opt-in per device. There are two ways to configure it:
+
+### 1. CLI seed (auto-start batch)
+
+The `-syslog-*` flags seed auto-created devices. Every device in the
+auto-start batch gets the same collector, format, and interval.
+
+```bash
+# RFC 5424 → 192.168.1.10:514, 100 auto-created devices
+sudo ./simulator \
+  -auto-start-ip 10.0.0.1 -auto-count 100 \
+  -syslog-collector 192.168.1.10:514
+
+# RFC 3164 legacy BSD format for downstream parsers that don't groket 5424
+sudo ./simulator \
+  -auto-start-ip 10.0.0.1 -auto-count 50 \
+  -syslog-collector 192.168.1.10:514 \
+  -syslog-format 3164
+```
+
+### 2. REST body (per-device)
+
+`POST /api/v1/devices` accepts an optional `syslog` block per request.
+Different batches can target different collectors or mix formats
+(5424 and 3164 streams never interleave on the same socket — the
+shared-socket pool is keyed by `(collector, format)`).
+
+```bash
+# A: 50 devices emitting 5424 to collector A
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 50,
+    "syslog": {
+      "collector": "192.168.1.10:514",
+      "format": "5424",
+      "interval": "15s"
+    }
+  }'
+
+# B: 20 devices emitting 3164 to the SAME collector (different socket,
+# separate status record)
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "start_ip": "10.0.1.1",
+    "device_count": 20,
+    "syslog": {
+      "collector": "192.168.1.10:514",
+      "format": "3164"
+    }
+  }'
+```
+
+`/api/v1/syslog/status` reports both batches as separate records keyed
+by `(collector, format)`.
+
+The `syslog` block is **optional** on every request — omit it and the
+device doesn't emit syslog. See
+[Web API → POST /api/v1/devices](web-api.md#create-devices) for the full
+per-device schema.
+
+**Duration fields** (`interval`) require **Go duration strings**
+(`"10s"`, `"5m"`, `"1m30s"`). Integer seconds (`"interval": 10`) are
+rejected with 400 — a deliberate mismatch with the `-syslog-interval`
+CLI flag, which takes integer seconds.
+
 ## HTTP endpoints
 
 ### Fire a syslog message on demand
@@ -308,7 +378,7 @@ Responses:
 | `202 Accepted` | `{}` | Success; the message was emitted. |
 | `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for the device. The enriched body tells the caller which catalog the device resolved to and lists its entries so a scripted caller can self-service. |
 | `404 Not Found` | error JSON | Unknown device IP. |
-| `503 Service Unavailable` | error JSON | Syslog export is disabled (`-syslog-collector` not set). |
+| `503 Service Unavailable` | error JSON | The syslog subsystem has not started **or** the target device has no syslog config (i.e. it was created without a `syslog` block and didn't inherit the CLI seed). |
 | `500 Internal Server Error` | error JSON | Pathological: catalog resolution returned nil while the feature reports active. Indicates a broken manager invariant, not a transient issue. |
 
 On-demand fires **do not** consume global rate-cap tokens.
@@ -317,17 +387,29 @@ On-demand fires **do not** consume global rate-cap tokens.
 
 `GET /api/v1/syslog/status` — current snapshot of the syslog subsystem.
 
-When enabled:
+**Response shape** (array-of-collectors aggregated by `(collector, format)`):
 
 ```json
 {
-  "enabled": true,
-  "format": "5424",
-  "collector": "192.168.1.10:514",
-  "sent": 18240,
-  "send_failures": 12,
+  "subsystem_active": true,
+  "collectors": [
+    {
+      "collector":     "192.168.1.10:514",
+      "format":        "5424",
+      "devices":       50,
+      "sent":          18240,
+      "send_failures": 3
+    },
+    {
+      "collector":     "192.168.1.10:514",
+      "format":        "3164",
+      "devices":       20,
+      "sent":          6130,
+      "send_failures": 0
+    }
+  ],
+  "devices_exporting": 70,
   "rate_limiter_tokens_available": 380,
-  "devices_exporting": 100,
   "catalogs_by_type": {
     "_universal":    {"entries": 6,  "source": "embedded"},
     "cisco_ios":     {"entries": 14, "source": "file:resources/cisco_ios/syslog.json"},
@@ -340,20 +422,26 @@ Fields:
 
 | Field | Meaning |
 |-------|---------|
-| `enabled` | Feature is active (`-syslog-collector` set and scheduler running). |
-| `format` | `"5424"` or `"3164"`. Absent when disabled. |
-| `collector` | Target `host:port`. |
-| `sent` | Total wire emissions. |
-| `send_failures` | UDP write errors (collector unreachable, socket-level failure). |
+| `subsystem_active` | `true` after `StartSyslogSubsystem` runs. During normal operation of the HTTP server this value is always `true`: the subsystem initialises in `main()` and the only path that flips it to `false` is `StopSyslogExport`, which runs at process exit alongside the HTTP server. A `false` value is therefore only observable programmatically (e.g. a test harness calling `GetSyslogStatus` without starting the subsystem). |
+| `collectors[]` | One record per `(collector, format)` tuple that ever had a device. |
+| `collectors[].collector` | Target `host:port` (canonicalised). |
+| `collectors[].format` | `"5424"` or `"3164"`. |
+| `collectors[].devices` | Count of LIVE devices emitting to this tuple. `0` means no live device but the aggregate remembers prior fires (monotonic within subsystem lifecycle). |
+| `collectors[].sent` | Cumulative wire emissions across all devices (live + deleted) for this tuple. |
+| `collectors[].send_failures` | UDP write errors (collector unreachable, socket-level failure). |
+| `devices_exporting` | Total count of LIVE devices with a `SyslogExporter` across all tuples. |
 | `rate_limiter_tokens_available` | Present only when `-syslog-global-cap` is set; instantaneous snapshot, not synchronised with concurrent waits. |
-| `devices_exporting` | Device count with an active `SyslogExporter`. |
-| `catalogs_by_type` | Map of `<slug>` → `{entries, source}` showing the merged-catalog state. `_universal` key is always present when the feature is enabled. `source` is `"embedded"`, `"file:<path>"`, or `"override:<path>"` when `-syslog-catalog` was supplied. |
+| `catalogs_by_type` | Map of `<slug>` → `{entries, source}` showing the merged-catalog state. `_universal` key is always present when the subsystem is running. `source` is `"embedded"`, `"file:<path>"`, or `"override:<path>"` when `-syslog-catalog` was supplied. |
 
-When disabled:
+When the subsystem is stopped (or never started):
 
 ```json
-{"enabled": false}
+{"subsystem_active": false, "collectors": [], "devices_exporting": 0}
 ```
+
+Clients that previously branched on the retired `enabled` scalar
+should branch on `subsystem_active` (primary) or `len(collectors) > 0`
+(secondary — true only when at least one device has opted in).
 
 ## CLI flags
 

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -95,6 +95,137 @@ curl -X POST http://localhost:8080/api/v1/devices \
   }'
 ```
 
+### Per-device export blocks
+
+`POST /api/v1/devices` accepts three optional top-level blocks —
+`flow`, `traps`, `syslog` — that attach export configuration to every
+device created by the request. Any block can be omitted; omitted blocks
+mean "this batch does not participate in that export subsystem."
+
+The subsystems are always-on after `main()` — flow / trap / syslog
+scheduler goroutines and catalog loaders run regardless of whether any
+CLI seed was supplied, so REST-created devices can opt in to any
+combination.
+
+**`flow` block:**
+
+```json
+"flow": {
+  "collector":        "192.168.1.10:2055",      // required; host:port
+  "protocol":         "netflow9",               // optional; "netflow9" | "ipfix" | "netflow5" | "sflow" (alias: "sflow5"); default "netflow9"
+  "tick_interval":    "5s",                      // optional; global ticker used, per-device value validated and logged if divergent
+  "active_timeout":   "30s",                     // optional; default 30s
+  "inactive_timeout": "15s"                      // optional; default 15s
+}
+```
+
+No per-device override exists for `source_per_device` — the
+`-flow-source-per-device` CLI flag is simulator-wide (see
+[CLI flags → Flow export](cli-flags.md#flow-export-flags)). Setting
+`"source_per_device"` in the REST body is rejected by
+`DisallowUnknownFields`.
+
+**`traps` block:**
+
+```json
+"traps": {
+  "collector":       "192.168.1.10:162",        // required; host:port
+  "mode":            "trap",                     // optional; "trap" | "inform"; default "trap"
+  "community":       "public",                   // optional; SNMPv2c community; default "public"
+  "interval":        "30s",                      // optional; per-device mean Poisson firing interval; default 30s
+  "inform_timeout":  "5s",                       // optional; INFORM retry timeout; default 5s
+  "inform_retries":  2                           // optional; max retransmissions per INFORM; default 2
+}
+```
+
+INFORM mode requires the simulator-wide `-trap-source-per-device=true`
+(the default). The check is **enforced at device-attach time**: if a
+request sets `mode: "inform"` while the flag is false, the attach
+fails per-device and the device's `trapConfig` is cleared so
+`ListDevices` doesn't show a ghost entry. This is distinct from
+request-level validation (which would fail the whole batch) — INFORM
+without per-device binding is a runtime attach failure, not a 400.
+
+**`syslog` block:**
+
+```json
+"syslog": {
+  "collector": "192.168.1.10:514",              // required; host:port
+  "format":    "5424",                           // optional; "5424" | "3164"; default "5424"
+  "interval":  "10s"                             // optional; per-device mean Poisson firing interval; default 10s
+}
+```
+
+Durations accept Go duration strings (`"10s"`, `"5m"`, `"1m30s"`);
+integer seconds are rejected.
+
+**Combined example — flow + traps + syslog on the same batch:**
+
+```bash
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 100,
+    "netmask": "24",
+    "flow": {
+      "collector": "192.168.1.10:4739",
+      "protocol":  "ipfix"
+    },
+    "traps": {
+      "collector": "192.168.1.10:162",
+      "mode":      "trap",
+      "community": "public"
+    },
+    "syslog": {
+      "collector": "192.168.1.10:514",
+      "format":    "5424"
+    }
+  }'
+```
+
+**Heterogeneous fleet — two batches pointing at different collectors:**
+
+```bash
+# Batch A: 50 devices → collector A, 5424
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_ip": "10.0.0.1",
+    "device_count": 50,
+    "syslog": {"collector": "192.168.1.10:514", "format": "5424"}
+  }'
+
+# Batch B: 20 devices → collector A, 3164 (same host, different format)
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_ip": "10.0.1.1",
+    "device_count": 20,
+    "syslog": {"collector": "192.168.1.10:514", "format": "3164"}
+  }'
+
+# Batch C: 30 devices → collector B, 5424
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_ip": "10.0.2.1",
+    "device_count": 30,
+    "syslog": {"collector": "192.168.1.20:514", "format": "5424"}
+  }'
+```
+
+`GET /api/v1/syslog/status` then reports three collector records keyed
+by `(collector, format)`. See
+[Syslog export status](#syslog-export-status).
+
+**Validation failures return `400` with the underlying error** (e.g.
+`unknown protocol`, `invalid collector address`, unresolvable host,
+explicitly invalid syslog format — non-`5424` / non-`3164`); no device
+from the batch is created (atomic batch failure). Unknown / typo'd JSON
+fields at any level are also rejected via `DisallowUnknownFields` —
+e.g. `"interval_ms": 10000` lands as a 400, not a silent drop.
+
 ## List devices
 
 ```bash
@@ -139,19 +270,33 @@ When flow export is enabled:
   "success": true,
   "message": "Success",
   "data": {
-    "enabled": true,
-    "protocol": "ipfix",
-    "collector": "192.168.1.10:4739",
-    "total_flows_exported": 1824300,
-    "total_packets_sent": 91215,
-    "total_bytes_sent": 136823040,
-    "devices_exporting": 100,
-    "last_template_send": "2026-04-16T10:35:00Z"
+    "subsystem_active": true,
+    "collectors": [
+      {"collector": "192.168.1.10:4739", "protocol": "ipfix",    "devices": 50, "sent_packets": 8123, "sent_bytes": 12123456, "sent_records": 243690},
+      {"collector": "192.168.1.20:6343", "protocol": "sflow",    "devices": 20, "sent_packets": 3100, "sent_bytes":  5560000, "sent_records":  62000}
+    ],
+    "devices_exporting": 70,
+    "last_template_send": "2026-04-23T10:35:00Z"
   }
 }
 ```
 
-When flow export is disabled the response is `{"enabled": false}`.
+Response fields:
+
+| Field | Meaning |
+|-------|---------|
+| `subsystem_active` | `true` after `main()` boots the flow ticker goroutine — always-on. Not reachable as `false` via the HTTP endpoint during normal operation: the subsystem initialises with the rest of the process and only stops at process exit, alongside the HTTP server itself. |
+| `collectors[]` | One record per `(collector, protocol)` tuple that ever had a device. Deleted-device counters persist in the aggregate until process exit. |
+| `collectors[].devices` | Count of LIVE exporters for this tuple. `0` means no live device but the aggregate remembers prior fires. |
+| `collectors[].sent_packets` / `sent_bytes` / `sent_records` | Cumulative across live + historical exporters for this tuple (monotonic within subsystem lifecycle). |
+| `devices_exporting` | Total LIVE exporters across all tuples. |
+| `last_template_send` | ISO-8601 timestamp of the most recent template emission (NetFlow v9 / IPFIX only). |
+
+Clients detect "no flow export configured" via `len(collectors) == 0`.
+The retired scalar fields (`enabled`, `protocol`, `collector`,
+`total_flows_exported`, `total_packets_sent`, `total_bytes_sent`) were
+removed in phase 3; callers that depended on them must migrate to the
+array-of-collectors shape.
 
 See [Flow export (operator guide)](../ops/flow-export.md) and
 [Flow export reference](flow-export.md) for protocol-specific details.
@@ -164,22 +309,31 @@ curl http://localhost:8080/api/v1/traps/status
 
 Unlike the flow-status endpoint, this response is **not** wrapped in the
 `{success, message, data}` envelope — the handler serialises `TrapStatus`
-directly. When trap export is enabled in INFORM mode (the most complete
-response shape):
+directly.
 
 ```json
 {
-  "enabled": true,
-  "mode": "inform",
-  "collector": "192.168.1.10:162",
-  "community": "public",
-  "sent": 182430,
-  "informs_pending": 17,
-  "informs_acked": 182380,
-  "informs_failed": 33,
-  "informs_dropped": 0,
-  "rate_limiter_tokens_available": 94,
+  "subsystem_active": true,
+  "collectors": [
+    {
+      "collector": "192.168.1.10:162",
+      "mode":      "inform",
+      "devices":   80,
+      "sent":      182430,
+      "informs_pending": 17,
+      "informs_acked":   182380,
+      "informs_failed":  33,
+      "informs_dropped": 0
+    },
+    {
+      "collector": "192.168.1.20:162",
+      "mode":      "trap",
+      "devices":   20,
+      "sent":      6000
+    }
+  ],
   "devices_exporting": 100,
+  "rate_limiter_tokens_available": 94,
   "catalogs_by_type": {
     "_universal":    {"entries": 5,  "source": "embedded"},
     "cisco_ios":     {"entries": 12, "source": "file:resources/cisco_ios/traps.json"},
@@ -188,20 +342,37 @@ response shape):
 }
 ```
 
+The four `informs_*` fields **only appear on records whose `mode == inform`**.
+TRAP-mode records omit them.
+
+`subsystem_active` is the authoritative feature-on signal — `true`
+after `StartTrapSubsystem` runs. In normal operation, the HTTP
+endpoint always returns `true`: the subsystem initialises from `main()`
+and the only path that sets `subsystem_active=false` is `StopTrapExport`,
+which is invoked at process shutdown alongside the HTTP server. A
+`false` value is therefore only observable programmatically (e.g.
+from a test harness calling `GetTrapStatus` without starting the
+subsystem). Clients that previously branched on the retired `enabled`
+scalar should use `subsystem_active`. `len(collectors) == 0` with
+`subsystem_active=true` means the subsystem is running but no device
+has opted in.
+
 `catalogs_by_type` keys are device-type slugs (plus the reserved
 `_universal` entry for the fallback catalog). `source` is
 `"embedded"`, `"file:<path>"`, or `"override:<path>"` when
-`-trap-catalog` was supplied. In TRAP mode the four `informs_*`
-fields are omitted. When trap export is disabled the response is:
+`-trap-catalog` was supplied. When disabled:
 
 ```json
-{"enabled": false, "sent": 0, "devices_exporting": 0}
+{"subsystem_active": false, "collectors": [], "devices_exporting": 0}
 ```
 
 `rate_limiter_tokens_available` is only present when `-trap-global-cap` is
 set. The `sent` counter increments on **every wire emission including
 INFORM retransmissions**, so it can exceed `informs_acked + informs_failed
 + informs_dropped + informs_pending` under retry churn.
+
+Counters are **monotonic within a subsystem lifecycle**: deleting a
+device does not zero its collector's `sent`; the aggregate survives.
 
 See [SNMP trap / INFORM export (operator guide)](../ops/snmp-traps.md) and
 [SNMP trap reference](snmp-traps.md) for the full feature details.
@@ -229,7 +400,7 @@ Response:
 | `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for this device. The enriched body reports which catalog the device resolved to (`cisco_ios`, `_universal`, etc.) and lists its entries alphabetically so a scripted caller can fix its call without a separate discovery endpoint. For malformed JSON or missing `name`, the legacy envelope form `{"success": false, "message": "..."}` applies. |
 | `404 Not Found` | error JSON | Unknown device IP. |
 | `500 Internal Server Error` | error JSON | Template resolve error, catalog resolution returned nil despite feature active (pathological manager state), or write failure. |
-| `503 Service Unavailable` | error JSON | Trap export is disabled. |
+| `503 Service Unavailable` | error JSON | The trap subsystem has not started **or** the target device has no trap config. |
 
 The endpoint does not block waiting for an INFORM ack — use
 `/api/v1/traps/status` to observe INFORM lifecycle counters.
@@ -244,19 +415,33 @@ When syslog export is enabled:
 
 ```json
 {
-  "enabled": true,
-  "format": "5424",
-  "collector": "192.168.1.10:514",
-  "sent": 18240,
-  "send_failures": 12,
+  "subsystem_active": true,
+  "collectors": [
+    {"collector": "192.168.1.10:514", "format": "5424", "devices": 50, "sent": 18240, "send_failures": 3},
+    {"collector": "192.168.1.10:514", "format": "3164", "devices": 20, "sent":  6130, "send_failures": 0}
+  ],
+  "devices_exporting": 70,
   "rate_limiter_tokens_available": 380,
-  "devices_exporting": 100,
   "catalogs_by_type": {
     "_universal":    {"entries": 6,  "source": "embedded"},
     "cisco_ios":     {"entries": 14, "source": "file:resources/cisco_ios/syslog.json"},
     "juniper_mx240": {"entries": 13, "source": "file:resources/juniper_mx240/syslog.json"}
   }
 }
+```
+
+Tuples are keyed by `(collector, format)`: a single collector receiving
+5424 from some devices and 3164 from others surfaces as two separate
+records. Per-device bind failures are non-fatal — the exporter falls
+back to the shared-pool socket with a warning and the `sent` counter
+still increments.
+
+`subsystem_active` has the same semantics as on the trap status
+endpoint; `len(collectors) == 0` is **not** sufficient on its own to
+imply "feature off." When disabled:
+
+```json
+{"subsystem_active": false, "collectors": [], "devices_exporting": 0}
 ```
 
 `format` is `"5424"` or `"3164"`. `catalogs_by_type` follows the same
@@ -290,7 +475,7 @@ Response:
 | `400 Bad Request` | `{"error": "...", "catalog": "<slug>", "availableEntries": [...]}` | Unknown catalog entry for this device. Same enriched-error shape as the trap endpoint. |
 | `404 Not Found` | error JSON | Unknown device IP. |
 | `500 Internal Server Error` | error JSON | Pathological catalog-resolution-nil state. |
-| `503 Service Unavailable` | error JSON | Syslog export is disabled. |
+| `503 Service Unavailable` | error JSON | The syslog subsystem has not started **or** the target device has no syslog config. |
 
 ## Device interaction
 


### PR DESCRIPTION
## Summary

Phase 7 of the per-device-export-config change. The flow (#90), trap (#129), and syslog (#130) PRs shipped three breaking changes to configuration and status-endpoint shapes; this PR catches the docs up to the code and adds a migration guide for operators. **No code changes.**

### What landed

- **`CLAUDE.md`** — flag tables annotated `[seed]` / `[global]`; Flow/Trap/Syslog export sections rewritten around `StartXSubsystem` + per-device config; HTTP-endpoint blurbs describe the array-of-collectors shape with `subsystem_active`.
- **`docs/reference/cli-flags.md`** — Scope column on flow / trap / syslog tables; new intro section explaining the seed-vs-global taxonomy.
- **`docs/reference/{flow-export,snmp-traps,syslog-export}.md`** — each gained a "Starting" section with dual CLI-seed + REST-body examples; status-endpoint JSON samples rewritten for the new shape with field-reference tables.
- **`docs/ops/flow-export.md`** — heterogeneous-fleet section showing two collectors / three protocols via consecutive `POST /api/v1/devices` calls.
- **`docs/reference/web-api.md`** — per-device `flow` / `traps` / `syslog` block schemas on `POST /api/v1/devices` with combined-exports and heterogeneous-fleet examples; all three status endpoints rewritten to the array-of-collectors form with `subsystem_active` + field-reference tables.
- **`README.md`** quick-start — combined-exports `curl` one-liner (flow + trap + syslog in one POST) plus the three status-endpoint inspections.
- **`docs/ops/migration-per-device-exports.md`** (new) — four-case migration guide (auto-start single collector, REST inheritance lost, heterogeneous fleet, status-endpoint consumers), Go-API migration notes, and notes on the deferred `Stop*Export` shutdown-only constraint + per-device-interval design debt.

### What did NOT change

- No code changes. `go vet` / `go test` unaffected.
- CLI surface unchanged; the flag names and defaults match the current binary.
- The openspec change's tasks.md (not tracked in-repo) updated locally to mark phase 7 complete; progress is now 44 / 60.

## Test plan

- [x] `go vet ./simulator/` unchanged by the PR (docs only)
- [x] Every code sample / curl snippet checked against the current simulator binary (flag names, JSON fields, error-response shapes)
- [ ] Render preview on the docs site (mkdocs / whatever is in use) to confirm anchor links resolve
- [ ] DCO sign-off added before merge