### PR TITLE
chore(simulator): gofmt align comment columns in phase-4/5-touched files

### DIFF
--- a/go/simulator/trap_exporter.go
+++ b/go/simulator/trap_exporter.go
@@ -132,7 +132,7 @@ type TrapExporter struct {
 	// Model, Serial, ChassisID) are captured once at exporter construction
 	// because they're stable for the device's lifetime; IfName varies with
 	// IfIndex so it uses a callback (PR 3 swaps synthesis for live lookup).
-	ifIndexFn func() int // returns a random ifIndex from the device's set
+	ifIndexFn func() int               // returns a random ifIndex from the device's set
 	ifNameFn  func(ifIndex int) string // returns ifName for a drawn ifIndex
 	sysName   string
 	model     string

--- a/go/simulator/trap_scheduler.go
+++ b/go/simulator/trap_scheduler.go
@@ -64,9 +64,9 @@ type trapHeapEntry struct {
 // nextFire is popped first.
 type trapHeap []*trapHeapEntry
 
-func (h trapHeap) Len() int            { return len(h) }
-func (h trapHeap) Less(i, j int) bool  { return h[i].nextFire.Before(h[j].nextFire) }
-func (h trapHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
+func (h trapHeap) Len() int           { return len(h) }
+func (h trapHeap) Less(i, j int) bool { return h[i].nextFire.Before(h[j].nextFire) }
+func (h trapHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
 func (h *trapHeap) Push(x interface{}) {
 	e := x.(*trapHeapEntry)
 	e.index = len(*h)
@@ -96,10 +96,10 @@ func (s *TrapScheduler) MeanInterval() time.Duration { return s.meanInterval }
 // `trapCatalogsByType`. This keeps per-type catalog lifecycle on the
 // manager, where `_universal` resolution and future per-type metrics live.
 type TrapScheduler struct {
-	mu           sync.Mutex
-	heap         trapHeap
-	byIP         map[string]*trapHeapEntry // lookup for Deregister
-	devices      map[string]trapFirer      // exporter by device IP
+	mu      sync.Mutex
+	heap    trapHeap
+	byIP    map[string]*trapHeapEntry // lookup for Deregister
+	devices map[string]trapFirer      // exporter by device IP
 
 	catalogFor   func(deviceIP net.IP) *Catalog
 	meanInterval time.Duration
@@ -110,7 +110,7 @@ type TrapScheduler struct {
 	now func() time.Time
 	rnd *rand.Rand
 
-	wake     chan struct{}  // signalled by Register/Deregister/Stop to nudge Run
+	wake     chan struct{} // signalled by Register/Deregister/Stop to nudge Run
 	stopCh   chan struct{}
 	stopOnce sync.Once
 }

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -238,10 +238,10 @@ type SimulatorManager struct {
 	trapScheduler       *TrapScheduler
 	trapEncoder         TrapEncoder
 	trapLimiter         *rate.Limiter // shared global cap (nil = unlimited)
-	trapConns           sync.Map    // key: string collector, value: *net.UDPConn (shared-socket fallback pool, TRAP mode only)
-	trapAggregates      sync.Map    // key: trapAggKey, value: *trapCollectorAggregate — monotonic counters surviving device delete
-	trapFirstAttachLog  atomic.Bool // CAS-gated so the "trap export active" line fires once per lifecycle; race-free reset on Stop
-	trapIntervalWarned  atomic.Bool // CAS-gated divergence warning — one line per lifecycle, not per device (phase-5 review P13)
+	trapConns           sync.Map      // key: string collector, value: *net.UDPConn (shared-socket fallback pool, TRAP mode only)
+	trapAggregates      sync.Map      // key: trapAggKey, value: *trapCollectorAggregate — monotonic counters surviving device delete
+	trapFirstAttachLog  atomic.Bool   // CAS-gated so the "trap export active" line fires once per lifecycle; race-free reset on Stop
+	trapIntervalWarned  atomic.Bool   // CAS-gated divergence warning — one line per lifecycle, not per device (phase-5 review P13)
 	trapGlobalCap       int
 	trapSourcePerDevice bool
 	trapCatalogPath     string // "" when using embedded catalog


### PR DESCRIPTION
## Summary

Re-align trailing-comment columns on `SimulatorManager` trap/syslog fields, `TrapExporter.ifIndexFn`, and `trapHeap` method receivers — gofmt drift that became visible after phases 4 and 5 added new fields/methods next to pre-existing ones.

**No behavioural changes.** 13 lines added / 13 removed, all whitespace.

### Scope

Only the 3 files I touched in phases 4 + 5 that `gofmt -l` flagged:
- `go/simulator/types.go`
- `go/simulator/trap_exporter.go`
- `go/simulator/trap_scheduler.go`

The other ~23 gofmt violations across the simulator package are **pre-existing drift** in files outside the per-device-export refactor (`device_profiles.go`, `netns.go`, `snmpv3_crypto.go`, etc.) and are out of scope here.

### Context

Phase 8.2 of the per-device-export-config change — partial validation sweep alongside `go vet`, `go test`, `openspec validate`, and `make check-tidy`.

## Test plan

- [x] `gofmt -l` clean on the three touched files
- [x] `go vet ./...` clean
- [x] `go test ./simulator/` green (17.0s)
- [x] `make check-tidy` green
- [x] `openspec validate per-device-export-config` clean
- [ ] DCO sign-off added before merge