### PR TITLE
feat(web): per-device export UI — modal sections, badges, status panel

### DIFF
--- a/go/simulator/web/app_api.js
+++ b/go/simulator/web/app_api.js
@@ -151,7 +151,7 @@ function updateDeviceTypeDropdown(category) {
     });
 }
 
-async function createDevices(startIp, deviceCount, netmask, resourceFile) {
+async function createDevices(startIp, deviceCount, netmask, resourceFile, exportSnapshot) {
     try {
         setLoading('createLoading', true);
         const requestData = {
@@ -172,6 +172,17 @@ async function createDevices(startIp, deviceCount, netmask, resourceFile) {
             requestData.resource_file = resourceFile;
         }
 
+        // Per-device export blocks — captured by the caller in the same
+        // snapshot validateExportBlocksSnapshot saw, so a user typing
+        // into a field between validate and submit can't slip
+        // unvalidated data past us. See docs/reference/web-api.md
+        // "Per-device export blocks" for the schema.
+        if (exportSnapshot) {
+            if (exportSnapshot.flow) requestData.flow = exportSnapshot.flow;
+            if (exportSnapshot.traps) requestData.traps = exportSnapshot.traps;
+            if (exportSnapshot.syslog) requestData.syslog = exportSnapshot.syslog;
+        }
+
         const response = await apiCall('/devices', {
             method: 'POST',
             body: JSON.stringify(requestData)
@@ -187,6 +198,265 @@ async function createDevices(startIp, deviceCount, netmask, resourceFile) {
     } finally {
         setLoading('createLoading', false);
     }
+}
+
+// --- Per-device export block readers -------------------------------------
+//
+// Each reader returns null when the operator left the collector field
+// empty (the feature is opt-in per batch) and returns a populated
+// object otherwise. Field validation is enforced at form-submit time
+// in app_ui.js via validateExportBlocks(); these readers assume input
+// has passed validation.
+
+// Go duration format — a sequence of decimal-number + unit pairs,
+// units from ns|us|µs|ms|s|m|h. Matches what DeviceXConfig.Validate
+// accepts on the server. Bare "0" is also accepted as Go does (zero
+// has no required unit). Empty string and plain non-zero integers
+// (e.g. "30") fail.
+const DURATION_RE = /^(0|(\d+(?:\.\d+)?(ns|us|µs|ms|s|m|h))+)$/;
+
+// host:port — anything-non-empty:port with port 1-65535. Intentionally
+// loose on host shape (can be IP, hostname, [v6]), strict on port.
+const HOSTPORT_RE = /^.+:\d{1,5}$/;
+function validHostPort(s) {
+    if (!HOSTPORT_RE.test(s)) return false;
+    const port = parseInt(s.slice(s.lastIndexOf(':') + 1), 10);
+    return port >= 1 && port <= 65535;
+}
+
+function readFlowBlock() {
+    const collector = document.getElementById('flowCollector').value.trim();
+    if (!collector) return null;
+    const block = { collector };
+    const protocol = document.getElementById('flowProtocol').value;
+    if (protocol) block.protocol = protocol;
+    const active = document.getElementById('flowActiveTimeout').value.trim();
+    if (active) block.active_timeout = active;
+    const inactive = document.getElementById('flowInactiveTimeout').value.trim();
+    if (inactive) block.inactive_timeout = inactive;
+    return block;
+}
+
+function readTrapBlock() {
+    const collector = document.getElementById('trapCollector').value.trim();
+    if (!collector) return null;
+    const block = { collector };
+    const mode = document.getElementById('trapMode').value;
+    if (mode) block.mode = mode;
+    const community = document.getElementById('trapCommunity').value.trim();
+    if (community) block.community = community;
+    const interval = document.getElementById('trapInterval').value.trim();
+    if (interval) block.interval = interval;
+    const informTimeout = document.getElementById('trapInformTimeout').value.trim();
+    if (informTimeout) block.inform_timeout = informTimeout;
+    const informRetries = document.getElementById('trapInformRetries').value.trim();
+    // `!== ''` instead of truthy because `"0"` is a legitimate value (0
+    // retries means "fire once, no retransmit"). The other duration
+    // fields use `if (foo)` because empty-string suppression is correct
+    // there — don't normalise this to match without reading the test
+    // for the zero-retries case in DeviceTrapConfig.Validate.
+    if (informRetries !== '') block.inform_retries = parseInt(informRetries, 10);
+    return block;
+}
+
+function readSyslogBlock() {
+    const collector = document.getElementById('syslogCollector').value.trim();
+    if (!collector) return null;
+    const block = { collector };
+    const format = document.getElementById('syslogFormat').value;
+    if (format) block.format = format;
+    const interval = document.getElementById('syslogInterval').value.trim();
+    if (interval) block.interval = interval;
+    return block;
+}
+
+// readAllExportBlocks captures the three blocks once so validate and
+// submit operate on the same snapshot — avoids a TOCTOU window where
+// an operator typing into a field between validate and POST sends data
+// the validator never saw.
+function readAllExportBlocks() {
+    return {
+        flow: readFlowBlock(),
+        traps: readTrapBlock(),
+        syslog: readSyslogBlock()
+    };
+}
+
+// validateExportBlocksSnapshot returns an error message string when any
+// enabled block has an invalid field, or null when everything is OK.
+// Enforces the same rules the server's DeviceXConfig.Validate applies:
+// host:port shape (with strict 1..65535 port range) and Go-duration
+// strings for duration fields. Field names in alerts use the on-screen
+// labels so operators can find the offending input without mapping
+// snake_case JSON keys back to UI labels.
+function validateExportBlocksSnapshot(snapshot) {
+    const flow = snapshot.flow;
+    if (flow) {
+        if (!validHostPort(flow.collector)) return 'Flow → Collector must be host:port with port 1..65535 (e.g. 192.168.1.10:2055).';
+        if (flow.active_timeout && !DURATION_RE.test(flow.active_timeout)) {
+            return 'Flow → Active timeout must be a Go duration string (e.g. "30s", "1m30s").';
+        }
+        if (flow.inactive_timeout && !DURATION_RE.test(flow.inactive_timeout)) {
+            return 'Flow → Inactive timeout must be a Go duration string (e.g. "15s", "1m").';
+        }
+    }
+    const trap = snapshot.traps;
+    if (trap) {
+        if (!validHostPort(trap.collector)) return 'SNMP Traps → Collector must be host:port with port 1..65535 (e.g. 192.168.1.10:162).';
+        if (trap.interval && !DURATION_RE.test(trap.interval)) {
+            return 'SNMP Traps → Interval must be a Go duration string (e.g. "30s").';
+        }
+        if (trap.inform_timeout && !DURATION_RE.test(trap.inform_timeout)) {
+            return 'SNMP Traps → INFORM retry timeout must be a Go duration string (e.g. "5s").';
+        }
+        if ('inform_retries' in trap) {
+            const r = trap.inform_retries;
+            // Reject NaN explicitly: typeof NaN === 'number' so the
+            // typeof guard alone passes a NaN through to the server.
+            if (typeof r !== 'number' || Number.isNaN(r) || r < 0 || !Number.isInteger(r)) {
+                return 'SNMP Traps → INFORM max retries must be a non-negative integer.';
+            }
+        }
+    }
+    const syslog = snapshot.syslog;
+    if (syslog) {
+        if (!validHostPort(syslog.collector)) return 'Syslog → Collector must be host:port with port 1..65535 (e.g. 192.168.1.10:514).';
+        if (syslog.interval && !DURATION_RE.test(syslog.interval)) {
+            return 'Syslog → Interval must be a Go duration string (e.g. "10s", "1m").';
+        }
+    }
+    return null;
+}
+
+// --- Export-status pollers -----------------------------------------------
+//
+// Poll the three status endpoints on a slow cadence and render a compact
+// per-collector aggregate into the overview panel. Per-poller in-flight
+// flags prevent stacking when the server stalls — a fresh tick is
+// skipped while the previous fetch is still outstanding. The pollers
+// fail visibly: errors update the summary line to "fetch failed" rather
+// than just logging to console (silent-fail is the wrong default for
+// observability surface).
+
+const _exportStatusInFlight = { flow: false, trap: false, syslog: false };
+
+async function loadExportStatuses() {
+    await Promise.allSettled([
+        loadFlowStatus(),
+        loadTrapStatus(),
+        loadSyslogStatus()
+    ]);
+}
+
+async function loadFlowStatus() {
+    if (_exportStatusInFlight.flow) return;
+    _exportStatusInFlight.flow = true;
+    try {
+        const response = await apiCall('/flows/status');
+        // /flows/status IS enveloped via sendDataResponse; trap and
+        // syslog status endpoints are NOT (verified against
+        // docs/reference/web-api.md). Don't normalise these without
+        // updating both sides.
+        const data = (response && response.data) ? response.data : (response || {});
+        renderExportStatus('flow', data, {
+            tupleKey: c => c.collector + ' / ' + (c.protocol || '?'),
+            metricLine: c => 'pkts=' + (c.sent_packets || 0) + ' · bytes=' + (c.sent_bytes || 0)
+        });
+    } catch (error) {
+        console.error('Failed to load flow status:', error);
+        renderExportStatusError('flow');
+    } finally {
+        _exportStatusInFlight.flow = false;
+    }
+}
+
+async function loadTrapStatus() {
+    if (_exportStatusInFlight.trap) return;
+    _exportStatusInFlight.trap = true;
+    try {
+        const data = await apiCall('/traps/status'); // status endpoint is not enveloped
+        renderExportStatus('trap', data || {}, {
+            tupleKey: c => c.collector + ' / ' + (c.mode || '?'),
+            metricLine: c => {
+                const parts = ['sent=' + (c.sent || 0)];
+                if (c.mode === 'inform') {
+                    parts.push('acked=' + (c.informs_acked || 0));
+                    parts.push('failed=' + (c.informs_failed || 0));
+                }
+                return parts.join(' · ');
+            }
+        });
+    } catch (error) {
+        console.error('Failed to load trap status:', error);
+        renderExportStatusError('trap');
+    } finally {
+        _exportStatusInFlight.trap = false;
+    }
+}
+
+async function loadSyslogStatus() {
+    if (_exportStatusInFlight.syslog) return;
+    _exportStatusInFlight.syslog = true;
+    try {
+        const data = await apiCall('/syslog/status'); // not enveloped
+        renderExportStatus('syslog', data || {}, {
+            tupleKey: c => c.collector + ' / ' + (c.format || '?'),
+            metricLine: c => 'sent=' + (c.sent || 0) + ' · failures=' + (c.send_failures || 0)
+        });
+    } catch (error) {
+        console.error('Failed to load syslog status:', error);
+        renderExportStatusError('syslog');
+    } finally {
+        _exportStatusInFlight.syslog = false;
+    }
+}
+
+function renderExportStatus(kind, data, opts) {
+    const summary = document.getElementById(kind + 'StatusSummary');
+    const list = document.getElementById(kind + 'StatusList');
+    if (!summary || !list) return;
+
+    const collectors = Array.isArray(data.collectors) ? data.collectors : [];
+    const devices = data.devices_exporting || 0;
+    // Truthy check rather than `=== true` so a server schema that adds
+    // / renames the field doesn't render populated data as "not
+    // running"; if collectors is non-empty, we trust that signal too.
+    const active = !!data.subsystem_active || collectors.length > 0;
+
+    if (!active) {
+        summary.textContent = 'not running';
+        list.innerHTML = '';
+        return;
+    }
+    if (collectors.length === 0) {
+        summary.textContent = 'running · 0 collectors';
+        list.innerHTML = '';
+        return;
+    }
+    summary.textContent = collectors.length + (collectors.length === 1 ? ' collector' : ' collectors') + ' · ' + devices + ' devices';
+    list.innerHTML = collectors.map(c =>
+        '<li><strong>' + escapeHtml(opts.tupleKey(c)) + '</strong> — ' +
+        escapeHtml((c.devices || 0) + ' dev · ' + opts.metricLine(c)) + '</li>'
+    ).join('');
+}
+
+function renderExportStatusError(kind) {
+    const summary = document.getElementById(kind + 'StatusSummary');
+    const list = document.getElementById(kind + 'StatusList');
+    if (summary) summary.textContent = 'fetch failed';
+    if (list) list.innerHTML = '';
+}
+
+// escapeHtml is the single sanitiser for both element text and
+// double-quoted attribute values. Covers `&`, `<`, `>`, `"`, `'` so
+// callers don't need to know which context they're embedding into.
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 async function deleteDevice(deviceId) {

--- a/go/simulator/web/app_ui.js
+++ b/go/simulator/web/app_ui.js
@@ -190,6 +190,7 @@ function renderDevices() {
         '<th>Interface</th>' +
         '<th>Device Type</th>' +
         '<th>Ports</th>' +
+        '<th>Exports</th>' +
         '<th>Status</th>' +
         '<th>Actions</th>' +
         '</tr>' +
@@ -202,6 +203,7 @@ function renderDevices() {
             '<td><span class="device-interface">' + (device.interface || 'N/A') + '</span></td>' +
             '<td><span class="device-type">' + (device.device_type || 'Unknown') + '</span></td>' +
             '<td><span class="device-ports">SNMP ' + device.snmp_port + ' · SSH ' + device.ssh_port + '</span></td>' +
+            '<td>' + renderExportBadges(device) + '</td>' +
             '<td><span class="device-status ' + (device.running ? 'status-running' : 'status-stopped') + '">' +
             (device.running ? 'Running' : 'Stopped') + '</span></td>' +
             '<td><div class="device-actions">' +
@@ -243,6 +245,32 @@ function renderDevices() {
     updatePaginationControls();
 }
 
+// renderExportBadges returns an inline-HTML snippet showing three
+// per-subsystem badges (F/T/S). Configured subsystems render with the
+// accent colour; unconfigured render muted. Each tile carries an
+// `aria-label` describing the state + destination so screen readers
+// don't just hear "F T S" with no context (color-only state
+// communication fails WCAG 1.1.1 / 1.4.1). The `title` attribute
+// duplicates the label as a sighted-user hover-tooltip.
+function renderExportBadges(device) {
+    return '<div class="device-exports" role="group" aria-label="Export configuration">' +
+        renderOneBadge('F', 'Flow', device.flow, b => (b.protocol || 'netflow9')) +
+        renderOneBadge('T', 'SNMP traps', device.traps, b => (b.mode || 'trap')) +
+        renderOneBadge('S', 'Syslog', device.syslog, b => (b.format || '5424')) +
+        '</div>';
+}
+
+function renderOneBadge(letter, kind, block, kindSuffix) {
+    if (block && block.collector) {
+        const desc = kind + ' export to ' + block.collector + ' (' + kindSuffix(block) + ')';
+        return '<span class="device-export-badge" role="img" aria-label="' + escapeHtml(desc) +
+            '" title="' + escapeHtml(desc) + '">' + letter + '</span>';
+    }
+    const desc = kind + ' export disabled';
+    return '<span class="device-export-badge device-export-badge-muted" role="img" aria-label="' + escapeHtml(desc) +
+        '" title="' + escapeHtml(desc) + '">' + letter + '</span>';
+}
+
 function updateStats() {
     const total = devices.length;
     const running = devices.filter(d => d.running).length;
@@ -277,6 +305,7 @@ function updateSystemStatsDisplay(stats) {
 // Event listeners
 elements.createForm.addEventListener('submit', async (e) => {
     e.preventDefault();
+    const submitBtn = elements.createForm.querySelector('button[type="submit"]');
     const startIp = document.getElementById('startIp').value;
     const deviceCount = document.getElementById('deviceCount').value;
     const netmask = document.getElementById('netmask').value;
@@ -285,11 +314,39 @@ elements.createForm.addEventListener('submit', async (e) => {
         showAlert('Please fill in all required fields', 'error');
         return;
     }
-    await createDevices(startIp, deviceCount, netmask, resourceFile);
+    // Snapshot the three per-device export blocks ONCE so the
+    // validator and the request body see identical input. Without this,
+    // an operator typing into a field between validate and POST could
+    // slip unvalidated data past the client check.
+    const exportSnapshot = readAllExportBlocks();
+    const exportError = validateExportBlocksSnapshot(exportSnapshot);
+    if (exportError) {
+        showAlert(exportError, 'error');
+        return;
+    }
+    // Disable the submit button + mark aria-busy for the duration of
+    // the POST so a double-click can't fire two device-create batches.
+    if (submitBtn) {
+        submitBtn.disabled = true;
+        submitBtn.setAttribute('aria-busy', 'true');
+    }
+    try {
+        await createDevices(startIp, deviceCount, netmask, resourceFile, exportSnapshot);
+    } finally {
+        if (submitBtn) {
+            submitBtn.disabled = false;
+            submitBtn.removeAttribute('aria-busy');
+        }
+    }
     elements.createForm.reset();
     document.getElementById('deviceCount').value = '1';
     document.getElementById('netmask').value = '24';
     document.getElementById('resourceFile').value = '';
+    // Reset the export sections: close the <details> and clear inputs.
+    ['flowSection', 'trapSection', 'syslogSection'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.open = false;
+    });
 });
 
 elements.exportBtn.addEventListener('click', exportDevicesCSV);
@@ -312,12 +369,34 @@ elements.filterPorts.addEventListener('input', applyFilters);
 elements.filterStatus.addEventListener('change', applyFilters);
 elements.clearFiltersBtn.addEventListener('click', clearAllFilters);
 
-setInterval(loadDevices, 30000);
-setInterval(loadSystemStats, 5000); // Refresh system stats every 5 seconds
+// Each periodic poller is wrapped so it no-ops when the tab is hidden
+// (background tabs don't need fresh device lists / system stats /
+// telemetry aggregates). The first refresh on visibility-restore is
+// triggered by the visibilitychange handler below.
+function whenVisible(fn) {
+    return () => {
+        if (!document.hidden) fn();
+    };
+}
+
+setInterval(whenVisible(loadDevices), 30000);
+setInterval(whenVisible(loadSystemStats), 5000); // Refresh system stats every 5 seconds
+setInterval(whenVisible(loadExportStatuses), 10000); // Per-subsystem aggregate poll (phase 6)
+
+document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+        // Catch up immediately on focus; the next interval tick will
+        // resume normal cadence.
+        loadDevices();
+        loadSystemStats();
+        loadExportStatuses();
+    }
+});
 
 document.addEventListener('DOMContentLoaded', () => {
     loadDevices();
     loadResources();
     loadSystemStats(); // Initial system stats load
+    loadExportStatuses(); // Initial export-status load (phase 6)
     checkStatus(); // Initial status check
 });

--- a/go/simulator/web/index.html
+++ b/go/simulator/web/index.html
@@ -90,6 +90,31 @@
                     </div>
                 </div>
             </div>
+
+            <div class="panel status export-status">
+                <div class="section-heading">
+                    <p class="section-kicker">Exports</p>
+                    <h2>Telemetry streams</h2>
+                    <p class="section-summary">Per-collector aggregates from each export subsystem. Rows are live when at least one device has opted in.</p>
+                </div>
+                <div class="export-status-grid">
+                    <div class="export-status-card">
+                        <p class="status-label">Flow</p>
+                        <h3 id="flowStatusSummary" aria-live="polite">loading…</h3>
+                        <ul id="flowStatusList" class="export-status-list"></ul>
+                    </div>
+                    <div class="export-status-card">
+                        <p class="status-label">SNMP traps</p>
+                        <h3 id="trapStatusSummary" aria-live="polite">loading…</h3>
+                        <ul id="trapStatusList" class="export-status-list"></ul>
+                    </div>
+                    <div class="export-status-card">
+                        <p class="status-label">Syslog</p>
+                        <h3 id="syslogStatusSummary" aria-live="polite">loading…</h3>
+                        <ul id="syslogStatusList" class="export-status-list"></ul>
+                    </div>
+                </div>
+            </div>
         </section>
 
         <div id="alerts" class="alerts" aria-live="polite"></div>
@@ -133,6 +158,90 @@
                         <option value="">Default (Auto-detect)</option>
                     </select>
                 </div>
+                <details class="export-section" id="flowSection">
+                    <summary>Flow export (NetFlow / IPFIX / sFlow)</summary>
+                    <p class="export-summary">Devices emit synthetic flow telemetry to the collector. Leave blank to skip flow export for this batch.</p>
+                    <div class="export-grid">
+                        <div class="form-group">
+                            <label for="flowCollector">Collector (host:port)</label>
+                            <input type="text" id="flowCollector" placeholder="192.168.1.10:2055">
+                        </div>
+                        <div class="form-group">
+                            <label for="flowProtocol">Protocol</label>
+                            <select id="flowProtocol">
+                                <option value="netflow9">NetFlow v9 (default)</option>
+                                <option value="ipfix">IPFIX</option>
+                                <option value="netflow5">NetFlow v5</option>
+                                <option value="sflow">sFlow v5</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="flowActiveTimeout">Active timeout</label>
+                            <input type="text" id="flowActiveTimeout" placeholder="30s">
+                        </div>
+                        <div class="form-group">
+                            <label for="flowInactiveTimeout">Inactive timeout</label>
+                            <input type="text" id="flowInactiveTimeout" placeholder="15s">
+                        </div>
+                    </div>
+                </details>
+
+                <details class="export-section" id="trapSection">
+                    <summary>SNMP traps (v2c TRAP / INFORM)</summary>
+                    <p class="export-summary">Devices fire SNMPv2c traps or INFORM requests at a Poisson cadence. Leave blank to skip traps for this batch.</p>
+                    <div class="export-grid">
+                        <div class="form-group">
+                            <label for="trapCollector">Collector (host:port)</label>
+                            <input type="text" id="trapCollector" placeholder="192.168.1.10:162">
+                        </div>
+                        <div class="form-group">
+                            <label for="trapMode">Mode</label>
+                            <select id="trapMode">
+                                <option value="trap">TRAP (fire-and-forget)</option>
+                                <option value="inform">INFORM (acknowledged)</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="trapCommunity">Community</label>
+                            <input type="text" id="trapCommunity" placeholder="public">
+                        </div>
+                        <div class="form-group">
+                            <label for="trapInterval">Interval (Poisson mean)</label>
+                            <input type="text" id="trapInterval" placeholder="30s">
+                        </div>
+                        <div class="form-group">
+                            <label for="trapInformTimeout">INFORM retry timeout</label>
+                            <input type="text" id="trapInformTimeout" placeholder="5s">
+                        </div>
+                        <div class="form-group">
+                            <label for="trapInformRetries">INFORM max retries</label>
+                            <input type="number" id="trapInformRetries" min="0" placeholder="2">
+                        </div>
+                    </div>
+                </details>
+
+                <details class="export-section" id="syslogSection">
+                    <summary>UDP syslog (RFC 5424 / RFC 3164)</summary>
+                    <p class="export-summary">Devices emit syslog messages at a Poisson cadence. Leave blank to skip syslog for this batch.</p>
+                    <div class="export-grid">
+                        <div class="form-group">
+                            <label for="syslogCollector">Collector (host:port)</label>
+                            <input type="text" id="syslogCollector" placeholder="192.168.1.10:514">
+                        </div>
+                        <div class="form-group">
+                            <label for="syslogFormat">Format</label>
+                            <select id="syslogFormat">
+                                <option value="5424">RFC 5424 (structured)</option>
+                                <option value="3164">RFC 3164 (legacy BSD)</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="syslogInterval">Interval (Poisson mean)</label>
+                            <input type="text" id="syslogInterval" placeholder="10s">
+                        </div>
+                    </div>
+                </details>
+
                 <div class="form-group form-group-actions">
                     <button type="submit" class="btn">
                         Create devices

--- a/go/simulator/web/styles.css
+++ b/go/simulator/web/styles.css
@@ -561,3 +561,128 @@ select:focus {
         min-width: 860px;
     }
 }
+
+/* Per-device export config (phase 6) ---------------------------------- */
+
+.export-section {
+    grid-column: span 12;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.5);
+    padding: 16px 20px;
+}
+
+.export-section[open] {
+    background: rgba(255, 255, 255, 0.75);
+}
+
+.export-section summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--surface-ink);
+    font-size: 1rem;
+    outline: none;
+    user-select: none;
+}
+
+.export-section summary:hover {
+    color: var(--accent);
+}
+
+.export-summary {
+    margin: 10px 0 16px;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.export-grid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 16px;
+    align-items: end;
+}
+
+.export-grid .form-group {
+    grid-column: span 4;
+}
+
+@media (max-width: 900px) {
+    .export-grid .form-group {
+        grid-column: span 12;
+    }
+}
+
+/* Export-status panel (phase 6) --------------------------------------- */
+
+.export-status-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+}
+
+.export-status-card {
+    padding: 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.5);
+}
+
+.export-status-card h3 {
+    margin-top: 10px;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.export-status-list {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.export-status-list li {
+    padding: 4px 0;
+    border-top: 1px dashed var(--border);
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.export-status-list li:first-child {
+    border-top: none;
+}
+
+@media (max-width: 900px) {
+    .export-status-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Device-list per-device export badges (phase 6) ---------------------- */
+
+.device-exports {
+    display: inline-flex;
+    gap: 4px;
+}
+
+.device-export-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 10px;
+    background: var(--accent);
+    color: white;
+    font-size: 0.7rem;
+    font-weight: 600;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.device-export-badge-muted {
+    background: var(--border);
+    color: var(--muted);
+}
+


### PR DESCRIPTION
## Summary

Phase 6 of per-device-export-config. Brings the existing web UI up to parity with the per-device REST API shipped in phases 3–5 (#90, #129, #130).

**Zero Go changes.** All four files under `go/simulator/web/` — `index.html`, `styles.css`, `app_api.js`, `app_ui.js` — served from disk (`http.Dir("web")`), so a running simulator picks up the new UI on the next page load without a rebuild.

### What's in the UI now

- **CreateDevices form** — three `<details>` collapsible export sections (Flow / Traps / Syslog) below the core fields. Collapsed by default; fields live only when the operator explicitly opens and fills a section.
- **Client-side validation** — `validateExportBlocks` mirrors the server's `DeviceXConfig.Validate` rules: `host:port` shape on collectors, Go-duration-string regex on every timeout / interval field, non-negative-int for `inform_retries`. Surfaces the specific failing field as an alert before POST, so `"interval": 30` doesn't round-trip to the server's generic 400.
- **Device-list "Exports" column** — three F / T / S badges per row. Accent-coloured when that subsystem is configured on the device (hover-title carries the destination); muted otherwise. Scans the fleet for opt-in state at a glance.
- **Telemetry streams panel** — new overview card polling `/api/v1/{flows,traps,syslog}/status` every 10s. Renders the array-of-collectors shape: summary line ("N collectors · M devices") and one list item per `(collector, protocol|mode|format)` tuple with metrics. `subsystem_active=false` → "not running"; `subsystem_active=true` with empty collectors → "running · 0 collectors".

### Deferred

- **6.5** browser smoke-test — operator task, not runnable from the PR-authoring session. Test plan covers the four combinations an operator should exercise before merge.

### Openspec progress

Change is now **51/60** (85%). Remaining:
- 1.5 external-consumer inventory
- 4.6 INFORM → batch-level 400 upgrade (deferred debt)
- 4.10 / 5.9 test-coverage tail
- 8.3 / 8.4 (Linux host smoke)
- 8.6 / 8.7 (PR-sequence note + archive)

## Test plan

- [x] `go vet ./...` clean (no Go changes)
- [x] `node --check` on both JS files (clean)
- [ ] Open `http://localhost:8080/ui` — confirm the three collapsible sections render collapsed below the core create form
- [ ] Open the Flow section, POST with a malformed collector like `192.168.1.10` (no port) — expect a red alert before the network round-trip
- [ ] Open the Traps section, set interval to `30` (no unit) — expect the Go-duration validation error
- [ ] Create a device with one subsystem configured — F/T/S row shows one accent tile + two muted tiles; "Telemetry streams" panel picks up the device within 10s
- [ ] Create a second batch against a different collector — status panel shows two rows in that subsystem's list
- [ ] Delete all devices — status panel rolls back to "running · 0 collectors"
- [ ] DCO sign-off added before merge