### PR TITLE
feat(export): reject inform-mode batches at handler when per-device source binding is off

### DIFF
--- a/go/simulator/trap_api_test.go
+++ b/go/simulator/trap_api_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -322,6 +323,43 @@ func TestInformInvariant_AtExporterLevel(t *testing.T) {
 				attempt, pending, acked, failed, dropped, originated)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestCreateDevicesHandler_RejectsInformWithoutPerDeviceBinding asserts
+// the phase-4.6 batch-level guard: when the trap subsystem is configured
+// without per-device source binding and a POST body sets
+// traps.mode=inform, the entire batch should fail with 400 rather than
+// allow some devices through and silently drop the rest at attach time.
+func TestCreateDevicesHandler_RejectsInformWithoutPerDeviceBinding(t *testing.T) {
+	sm := newTestSimulatorManager()
+	if err := sm.StartTrapSubsystem(TrapSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Second,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopTrapExport)
+	withManager(t, sm)
+
+	body := strings.NewReader(`{
+		"start_ip": "10.0.0.1",
+		"device_count": 1,
+		"traps": {
+			"collector": "127.0.0.1:16201",
+			"mode":      "inform",
+			"community": "public"
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices", body)
+	rr := httptest.NewRecorder()
+	setupRoutes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status code: got %d, want 400 — body=%q", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "inform") || !strings.Contains(rr.Body.String(), "trap-source-per-device") {
+		t.Errorf("body should mention inform + trap-source-per-device: %q", rr.Body.String())
 	}
 }
 

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -243,6 +243,20 @@ func (sm *SimulatorManager) closeTrapConnPool() {
 	})
 }
 
+// TrapSourcePerDevice returns the simulator-wide
+// `-trap-source-per-device` flag. Exposed so HTTP handlers can pre-flight
+// reject INFORM-mode batches when per-device binding is disabled
+// (phase 4.6) — keeping the access read-locked so a concurrent Stop /
+// Start cannot mid-flight a partial value.
+func (sm *SimulatorManager) TrapSourcePerDevice() bool {
+	if sm == nil {
+		return false
+	}
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.trapSourcePerDevice
+}
+
 // getTrapScheduler returns the manager's trap scheduler pointer under
 // sm.mu.RLock so callers cannot race a concurrent StopTrapExport that
 // nils the field (phase-5 review D3 fix). Safe with nil manager.

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/pprof"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -51,12 +52,11 @@ func createDevicesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse and validate per-device export blocks (phase 3 task 3.7).
-	// Each block is optional; missing or nil → export disabled for batch.
-	// Validation failures return 400 with the underlying error so the
-	// operator can see what went wrong. `Traps` and `Syslog` blocks pass
-	// through into the seed but the subsystems themselves still run off
-	// the old globals until phases 4/5 land.
+	// Parse and validate per-device export blocks. Each block is
+	// optional; missing or nil → export disabled for batch. Validation
+	// failures return 400 with the underlying error so the operator
+	// can see what went wrong. After phases 4 and 5 each block now
+	// drives a real per-device exporter via the always-on subsystem.
 	seed := &ExportSeed{Flow: req.Flow, Traps: req.Traps, Syslog: req.Syslog}
 	if seed.Flow != nil {
 		seed.Flow.ApplyDefaults()
@@ -69,6 +69,16 @@ func createDevicesHandler(w http.ResponseWriter, r *http.Request) {
 		seed.Traps.ApplyDefaults()
 		if err := seed.Traps.Validate(); err != nil {
 			sendErrorResponse(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// INFORM mode requires per-device UDP source binding so the
+		// exporter can demux acks without a global request-id table.
+		// Reject the whole batch with 400 here rather than letting
+		// each device fail the attach individually (phase 4.6) — atomic
+		// batch failure matches the contract for every other validation
+		// rule on this endpoint.
+		if strings.EqualFold(seed.Traps.Mode, "inform") && !manager.TrapSourcePerDevice() {
+			sendErrorResponse(w, "traps: mode=inform requires the simulator-wide -trap-source-per-device flag (default true) to be enabled", http.StatusBadRequest)
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

Phase 4.6 of per-device-export-config — closes the last code-affecting deviation in the change ledger.

**Before:** `POST /api/v1/devices` with `traps.mode=inform` and a simulator started with `-trap-source-per-device=false` returned `202 Accepted` ("Created N devices") and silently failed each device's trap attach individually. Operators saw a successful response and a fleet that wasn't firing INFORMs.

**After:** the handler runs the INFORM / per-device-binding check up front and rejects the whole batch with `400 Bad Request` plus a clear error message. The per-device guard in `startDeviceTrapExporter` stays as defence in depth for direct programmatic callers that bypass the handler.

### Adds

- `(*SimulatorManager).TrapSourcePerDevice()` — read-locked accessor so it can't race a Stop / Start cycle
- `createDevicesHandler` INFORM pre-flight check after `seed.Traps.Validate()`
- `TestCreateDevicesHandler_RejectsInformWithoutPerDeviceBinding` — end-to-end test through `setupRoutes()`

Also fixes the stale phase-3 comment in `web.go` ("until phases 4/5 land") that predated those phases shipping.

### Closes the change

This PR ticks four ledger items and unblocks the archive:

- **4.6** — INFORM validation moves to handler 400 ✅
- **4.10.3** — REST `traps.mode=inform` + `-trap-source-per-device=false` → 400 (test added) ✅
- **8.6** — PR-sequence note updated to reflect the actual six-PR chain (#90 / #129 / #130 / #131 / #133 / this) plus the #132 chore PR ✅
- **8.7** — `openspec archive per-device-export-config` runs immediately after this merges (operator-side action; archive command mutates the local openspec dir which is gitignored).

After merge the change goes from **53 / 60** to fully wrapped: the remaining 7 items are the 1.5 external-consumer inventory (planning, not code), 4.10.1 / 4.10.2 / 4.10.4 / 5.9.1 / 5.9.2 / 5.9.3 (test-coverage tail — partly covered by `export_attach_test.go`, fully covered would need scale-up integration tests), and 8.3 / 8.4 (Linux-host smoke). All acceptable as deferred per the design doc; they don't block archive.

## Test plan

- [x] `go vet ./simulator/` clean
- [x] `go test ./simulator/` — full suite green (16.7s)
- [x] `go test ./simulator/ -run TestCreateDevicesHandler_RejectsInformWithoutPerDeviceBinding` — PASS
- [ ] Manual smoke: boot with `-trap-source-per-device=false`, POST `{traps:{mode:"inform",...}}`, confirm 400 with the new error message
- [ ] Manual smoke: boot with default `-trap-source-per-device=true`, same POST, confirm 202 / device gets a working INFORM exporter
- [ ] DCO sign-off added before merge