### PR TITLE
fix(api): close per-device HTTP server on stop

### DIFF
--- a/go/simulator/api.go
+++ b/go/simulator/api.go
@@ -118,20 +118,22 @@ func (s *APIServer) Stop() error {
 		return nil
 	}
 
+	// Reset state unconditionally so a Close() error does not leave the
+	// APIServer wedged in running=true with stale pointers. A retried
+	// Stop() would otherwise double-close the server; a subsequent Start()
+	// would short-circuit on running=true and silently "succeed" without
+	// restarting. Close/listener errors are still surfaced to the caller.
+	var closeErr error
 	if s.server != nil {
-		if err := s.server.Close(); err != nil {
-			return err
-		}
+		closeErr = s.server.Close()
 	} else if s.listener != nil {
-		if err := s.listener.Close(); err != nil {
-			return err
-		}
+		closeErr = s.listener.Close()
 	}
 
 	s.server = nil
 	s.listener = nil
 	s.running = false
-	return nil
+	return closeErr
 }
 
 // handleAPIRequestMultiMethod processes incoming API requests that may have multiple method handlers

--- a/go/simulator/api.go
+++ b/go/simulator/api.go
@@ -24,7 +24,29 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
+
+type apiHTTPServer interface {
+	Serve(net.Listener) error
+	Close() error
+}
+
+var apiListenTCP = func(device *DeviceSimulator, addr string) (net.Listener, error) {
+	if device.netNamespace != nil {
+		return device.netNamespace.ListenTCPInNamespace("tcp", addr)
+	}
+	lc := net.ListenConfig{Control: setSocketBufferSize}
+	return lc.Listen(context.Background(), "tcp", addr)
+}
+
+var apiNewHTTPServer = func(handler http.Handler) apiHTTPServer {
+	return &http.Server{
+		Handler:           handler,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+}
 
 // APIServer implementation for storage device REST APIs
 func (s *APIServer) Start() error {
@@ -61,14 +83,7 @@ func (s *APIServer) Start() error {
 	}
 
 	// Create listener
-	var listener net.Listener
-	var err error
-	if s.device.netNamespace != nil {
-		listener, err = s.device.netNamespace.ListenTCPInNamespace("tcp", addr)
-	} else {
-		lc := net.ListenConfig{Control: setSocketBufferSize}
-		listener, err = lc.Listen(context.Background(), "tcp", addr)
-	}
+	listener, err := apiListenTCP(s.device, addr)
 	if err != nil {
 		return fmt.Errorf("failed to start API server on %s: %v", addr, err)
 	}
@@ -82,15 +97,13 @@ func (s *APIServer) Start() error {
 	}
 	listener = tls.NewListener(listener, tlsConfig)
 
+	server := apiNewHTTPServer(mux)
 	s.listener = listener
+	s.server = server
 	s.running = true
 
 	// Start HTTPS server in background
 	go func() {
-		server := &http.Server{
-			Handler: mux,
-		}
-
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Printf("API server error on %s: %v", addr, err)
 		}
@@ -105,12 +118,18 @@ func (s *APIServer) Stop() error {
 		return nil
 	}
 
-	if s.listener != nil {
+	if s.server != nil {
+		if err := s.server.Close(); err != nil {
+			return err
+		}
+	} else if s.listener != nil {
 		if err := s.listener.Close(); err != nil {
 			return err
 		}
 	}
 
+	s.server = nil
+	s.listener = nil
 	s.running = false
 	return nil
 }

--- a/go/simulator/api_test.go
+++ b/go/simulator/api_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestAPIServerStopClosesHTTPServer(t *testing.T) {
+	originalListen := apiListenTCP
+	originalNewServer := apiNewHTTPServer
+	t.Cleanup(func() {
+		apiListenTCP = originalListen
+		apiNewHTTPServer = originalNewServer
+	})
+
+	listener := &stubListener{}
+	server := newBlockingAPIServer()
+	apiListenTCP = func(device *DeviceSimulator, addr string) (net.Listener, error) {
+		return listener, nil
+	}
+	apiNewHTTPServer = func(handler http.Handler) apiHTTPServer {
+		return server
+	}
+
+	device := &DeviceSimulator{
+		IP:      net.IPv4(127, 0, 0, 1),
+		APIPort: 8443,
+		resources: &DeviceResources{
+			API: []APIResource{
+				{
+					Method:   "GET",
+					Path:     "/health",
+					Response: map[string]string{"status": "ok"},
+				},
+			},
+		},
+	}
+	apiServer := &APIServer{
+		device:        device,
+		sharedTLSCert: &tls.Certificate{},
+	}
+
+	if err := apiServer.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	<-server.serveCalled
+
+	if err := apiServer.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	select {
+	case <-server.closeCalled:
+	default:
+		t.Fatal("Stop() did not close the HTTP server")
+	}
+}
+
+type blockingAPIServer struct {
+	serveCalled chan struct{}
+	closeCalled chan struct{}
+	done        chan struct{}
+}
+
+func newBlockingAPIServer() *blockingAPIServer {
+	return &blockingAPIServer{
+		serveCalled: make(chan struct{}),
+		closeCalled: make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+}
+
+func (s *blockingAPIServer) Serve(net.Listener) error {
+	close(s.serveCalled)
+	<-s.done
+	return http.ErrServerClosed
+}
+
+func (s *blockingAPIServer) Close() error {
+	close(s.closeCalled)
+	close(s.done)
+	return nil
+}
+
+type stubListener struct{}
+
+func (l *stubListener) Accept() (net.Conn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (l *stubListener) Close() error { return nil }
+
+func (l *stubListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8443}
+}

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -152,6 +152,7 @@ type SSHServer struct {
 type APIServer struct {
 	device        *DeviceSimulator
 	listener      net.Listener
+	server        apiHTTPServer
 	running       bool
 	sharedTLSCert *tls.Certificate // Shared TLS cert from SimulatorManager
 }


### PR DESCRIPTION
## Summary
Store the per-device HTTP server so Stop can close active connections and tear down API servers cleanly.

## Testing
- GOCACHE=/tmp/gocache-pr4 go test ./simulator -run TestAPIServerStopClosesHTTPServer