### PR TITLE
fix(manager): delete tun interface on device removal

### DIFF
--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -33,6 +33,14 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+var deleteDeviceTunInterfaces = func(sm *SimulatorManager, interfaceNames []string) error {
+	return sm.bulkDeleteTunInterfaces(interfaceNames)
+}
+
+var deleteDeviceTunInterfacesInNamespace = func(sm *SimulatorManager, interfaceNames []string) error {
+	return sm.bulkDeleteTunInterfacesInNamespace(interfaceNames)
+}
+
 // SimulatorManager implementation
 func NewSimulatorManager() *SimulatorManager {
 	return NewSimulatorManagerWithOptions(true) // Default: use namespace isolation
@@ -267,13 +275,29 @@ func (sm *SimulatorManager) DeleteDevice(deviceID string) error {
 		// log.Printf("Error stopping device %s: %v", deviceID, err)
 	}
 
-	// Always close TUN FD on deletion, even for pre-allocated interfaces
-	if device.tunIface != nil && device.tunIface.PreAllocated {
-		device.tunIface.destroy()
-		// Remove from pre-allocated pool
-		sm.tunPoolMutex.Lock()
-		delete(sm.tunInterfacePool, device.IP.String())
-		sm.tunPoolMutex.Unlock()
+	if device.tunIface != nil {
+		interfaceName := device.tunIface.Name
+
+		// Always close TUN FD on deletion, even for pre-allocated interfaces.
+		if device.tunIface.PreAllocated {
+			device.tunIface.destroy()
+		}
+
+		var err error
+		if sm.useNamespace && sm.netNamespace != nil {
+			err = deleteDeviceTunInterfacesInNamespace(sm, []string{interfaceName})
+		} else {
+			err = deleteDeviceTunInterfaces(sm, []string{interfaceName})
+		}
+		if err != nil {
+			return fmt.Errorf("delete TUN interface %s: %w", interfaceName, err)
+		}
+
+		if device.tunIface.PreAllocated {
+			sm.tunPoolMutex.Lock()
+			delete(sm.tunInterfacePool, device.IP.String())
+			sm.tunPoolMutex.Unlock()
+		}
 	}
 
 	delete(sm.devices, deviceID)

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -270,39 +270,62 @@ func (sm *SimulatorManager) DeleteDevice(deviceID string) error {
 		return fmt.Errorf("device %s not found", deviceID)
 	}
 
+	// Capture TUN interface identity BEFORE Stop runs. device.Stop()
+	// nils d.tunIface for non-preallocated interfaces as of the partial-
+	// startup cleanup fix; reading device.tunIface after Stop would then
+	// miss the bulk-delete for those devices and silently leak the
+	// kernel netdev — defeating the purpose of deleting it here.
+	var (
+		hasTun        bool
+		interfaceName string
+		preAllocated  bool
+	)
+	if device.tunIface != nil {
+		hasTun = true
+		interfaceName = device.tunIface.Name
+		preAllocated = device.tunIface.PreAllocated
+	}
+
 	// Stop and cleanup device
 	if err := device.Stop(); err != nil {
 		// log.Printf("Error stopping device %s: %v", deviceID, err)
 	}
 
-	if device.tunIface != nil {
-		interfaceName := device.tunIface.Name
-
-		// Always close TUN FD on deletion, even for pre-allocated interfaces.
-		if device.tunIface.PreAllocated {
+	var tunErr error
+	if hasTun {
+		// Pre-allocated interfaces keep their FD open through Stop;
+		// close it here before asking netlink to remove the link. For
+		// non-preallocated interfaces, Stop already ran destroy() and
+		// nilled d.tunIface — we use the captured name / flag instead.
+		if preAllocated && device.tunIface != nil {
 			device.tunIface.destroy()
 		}
 
-		var err error
 		if sm.useNamespace && sm.netNamespace != nil {
-			err = deleteDeviceTunInterfacesInNamespace(sm, []string{interfaceName})
+			tunErr = deleteDeviceTunInterfacesInNamespace(sm, []string{interfaceName})
 		} else {
-			err = deleteDeviceTunInterfaces(sm, []string{interfaceName})
-		}
-		if err != nil {
-			return fmt.Errorf("delete TUN interface %s: %w", interfaceName, err)
+			tunErr = deleteDeviceTunInterfaces(sm, []string{interfaceName})
 		}
 
-		if device.tunIface.PreAllocated {
+		if preAllocated {
 			sm.tunPoolMutex.Lock()
 			delete(sm.tunInterfacePool, device.IP.String())
 			sm.tunPoolMutex.Unlock()
 		}
 	}
 
+	// Always remove from maps — even if netlink delete failed. The
+	// device is already Stop'd, FDs are closed, and leaving it in the
+	// maps would create a ghost that reports as a device but is dead.
+	// Matches DeleteAllDevices's log-and-continue behaviour. The tun
+	// delete error is still surfaced to the caller below.
 	delete(sm.devices, deviceID)
 	delete(sm.deviceIPs, device.IP.String())
 	delete(sm.deviceTypesByIP, device.IP.String())
+
+	if tunErr != nil {
+		return fmt.Errorf("delete TUN interface %s: %w", interfaceName, tunErr)
+	}
 	return nil
 }
 

--- a/go/simulator/manager_delete_device_test.go
+++ b/go/simulator/manager_delete_device_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net"
 	"reflect"
 	"testing"
@@ -45,5 +46,53 @@ func TestDeleteDeviceDeletesTunInterface(t *testing.T) {
 	}
 	if _, exists := sm.deviceTypesByIP[deviceIP.String()]; exists {
 		t.Fatal("device type was not removed from deviceTypesByIP")
+	}
+}
+
+// Regression: if the netlink delete fails, DeleteDevice must still remove
+// the device from its maps. The device's listeners are already Stop'd and
+// the FD is closed; leaving it in sm.devices creates a permanently-wedged
+// ghost that reports as alive but can't be interacted with. Pre-fix,
+// DeleteDevice returned early on the netlink error, half-deleting the
+// device. The surfaced error is still propagated to the caller.
+func TestDeleteDeviceCleansMapsEvenOnTunDeleteError(t *testing.T) {
+	originalDelete := deleteDeviceTunInterfaces
+	t.Cleanup(func() { deleteDeviceTunInterfaces = originalDelete })
+
+	netlinkErr := errors.New("netlink: device busy")
+	deleteDeviceTunInterfaces = func(sm *SimulatorManager, interfaceNames []string) error {
+		return netlinkErr
+	}
+
+	deviceIP := net.IPv4(127, 0, 0, 2)
+	device := &DeviceSimulator{
+		ID:       "device-busy",
+		IP:       deviceIP,
+		tunIface: &TunInterface{Name: "sim456"},
+		running:  true,
+	}
+	sm := &SimulatorManager{
+		devices:         map[string]*DeviceSimulator{device.ID: device},
+		deviceIPs:       map[string]struct{}{deviceIP.String(): {}},
+		deviceTypesByIP: map[string]string{deviceIP.String(): "cisco_ios"},
+	}
+
+	manager = nil
+	err := sm.DeleteDevice(device.ID)
+	if err == nil {
+		t.Fatal("DeleteDevice() error = nil, want netlink error")
+	}
+	if !errors.Is(err, netlinkErr) {
+		t.Fatalf("DeleteDevice() error = %v, want to wrap %v", err, netlinkErr)
+	}
+
+	if _, exists := sm.devices[device.ID]; exists {
+		t.Fatal("device was not removed from devices map despite netlink failure")
+	}
+	if _, exists := sm.deviceIPs[deviceIP.String()]; exists {
+		t.Fatal("device IP was not removed from deviceIPs despite netlink failure")
+	}
+	if _, exists := sm.deviceTypesByIP[deviceIP.String()]; exists {
+		t.Fatal("device type was not removed from deviceTypesByIP despite netlink failure")
 	}
 }

--- a/go/simulator/manager_delete_device_test.go
+++ b/go/simulator/manager_delete_device_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestDeleteDeviceDeletesTunInterface(t *testing.T) {
+	originalDelete := deleteDeviceTunInterfaces
+	t.Cleanup(func() { deleteDeviceTunInterfaces = originalDelete })
+
+	var deleted []string
+	deleteDeviceTunInterfaces = func(sm *SimulatorManager, interfaceNames []string) error {
+		deleted = append([]string(nil), interfaceNames...)
+		return nil
+	}
+
+	deviceIP := net.IPv4(127, 0, 0, 1)
+	device := &DeviceSimulator{
+		ID:       "device-1",
+		IP:       deviceIP,
+		tunIface: &TunInterface{Name: "sim123"},
+		running:  true,
+	}
+	sm := &SimulatorManager{
+		devices:         map[string]*DeviceSimulator{device.ID: device},
+		deviceIPs:       map[string]struct{}{deviceIP.String(): {}},
+		deviceTypesByIP: map[string]string{deviceIP.String(): "cisco_ios"},
+	}
+
+	manager = nil
+	if err := sm.DeleteDevice(device.ID); err != nil {
+		t.Fatalf("DeleteDevice() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(deleted, []string{"sim123"}) {
+		t.Fatalf("deleted interfaces = %v, want [sim123]", deleted)
+	}
+	if _, exists := sm.devices[device.ID]; exists {
+		t.Fatal("device was not removed from devices map")
+	}
+	if _, exists := sm.deviceIPs[deviceIP.String()]; exists {
+		t.Fatal("device IP was not removed from deviceIPs")
+	}
+	if _, exists := sm.deviceTypesByIP[deviceIP.String()]; exists {
+		t.Fatal("device type was not removed from deviceTypesByIP")
+	}
+}


### PR DESCRIPTION
## Summary
Delete the device TUN interface during single-device removal instead of only closing its file descriptor.

## Testing
- GOCACHE=/tmp/gocache-pr2 go test ./simulator -run TestDeleteDeviceDeletesTunInterface