### PR TITLE
feat: expose simulator version via CLI, API, log, and UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ jobs:
   ci:
     name: Build & Test
     runs-on: ubuntu-latest
+    env:
+      # Tag-event workflow: bake the pushed tag into the binary as the
+      # ground-truth version. Overrides the Makefile's `git describe`
+      # fallback, which is unreliable inside actions/checkout's shallow
+      # clone.
+      APP_VERSION: ${{ github.ref_name }}
 
     steps:
       - name: Checkout
@@ -30,6 +36,19 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Assert baked version matches tag
+        run: |
+          baked=$(./go/simulator/simulator -version)
+          if [ -z "$baked" ] || [ -z "${GITHUB_REF_NAME}" ]; then
+            echo "version assertion failed: empty value — baked='$baked', tag='${GITHUB_REF_NAME}'"
+            exit 1
+          fi
+          if [ "$baked" != "${GITHUB_REF_NAME}" ]; then
+            echo "version drift: binary reports '$baked', tag is '${GITHUB_REF_NAME}'"
+            exit 1
+          fi
+          echo "version OK: $baked"
+
       - name: Test
         run: make test
 
@@ -37,6 +56,8 @@ jobs:
     name: Build & Release
     runs-on: ubuntu-latest
     needs: ci
+    env:
+      APP_VERSION: ${{ github.ref_name }}
 
     steps:
       - name: Checkout
@@ -70,6 +91,8 @@ jobs:
     name: Publish Docker image
     runs-on: ubuntu-latest
     needs: ci
+    env:
+      APP_VERSION: ${{ github.ref_name }}
 
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ sudo ./simulator [flags]
 -snmpv3-auth <proto>    # none | md5 | sha1
 -snmpv3-priv <proto>    # none | des | aes128
 -no-namespace           # Disable network namespace isolation
+-version                # Print version string and exit (no startup side effects)
 
 # Flow export flags (NetFlow v5 / v9 / IPFIX / sFlow v5)
 # Flags marked [seed] apply ONLY to auto-start devices (-auto-start-ip batch).
@@ -83,7 +84,7 @@ go test ./simulator/ -run TestSomething
 
 **Network infrastructure:** `tun.go` creates TUN interfaces, `netns.go` manages the `opensim` network namespace, `prealloc.go` does parallel pre-allocation of TUN interfaces (configurable worker count 100–200) for fast scaling.
 
-**Web API:** `web.go` (route setup) + `api.go` (handlers) + `web_routes*.go` (Linux route script generation). Serves device CRUD, CSV export, system stats, flow export status (`GET /api/v1/flows/status`), trap export status (`GET /api/v1/traps/status`), and on-demand trap firing (`POST /api/v1/devices/{ip}/trap`).
+**Web API:** `web.go` (route setup) + `api.go` (handlers) + `web_routes*.go` (Linux route script generation). Serves device CRUD, CSV export, system stats, simulator version (`GET /api/v1/version` → `{"version":"vX.Y.Z"}`, immutable per process, `Cache-Control: max-age=3600`), flow export status (`GET /api/v1/flows/status`), trap export status (`GET /api/v1/traps/status`), and on-demand trap firing (`POST /api/v1/devices/{ip}/trap`).
 
 **Flow export (per-device config, phase 3):** `flow_exporter.go` (FlowExporter, FlowEncoder interface, SimulatorManager integration) + `netflow9.go` (NetFlow9Encoder, RFC 3954) + `ipfix.go` (IPFIXEncoder, RFC 7011) + `netflow5.go` (NetFlow5Encoder, Cisco v5: 24B header, 48B/record, IPv4-only, 30-record datagram cap, no templates) + `sflow.go` (SFlowEncoder, sFlow v5 per sflow_version_5.txt: 28B XDR datagram header, variable-length flow_sample records carrying sampled_header=IPv4+UDP/TCP synthesized from the FlowRecord 5-tuple, no template mechanism). Each device owns its collector/protocol/timeouts on `DeviceFlowConfig`; the manager owns a shared-socket pool keyed by `(collector, protocol)` and one ticker goroutine. `FlowStatus` is an array-of-collectors aggregated by `(collector, protocol)`. Protocols:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,19 @@
 FROM --platform=${BUILDPLATFORM} golang:1.26-alpine AS build
 
 ARG TARGETARCH
+# APP_VERSION is the build-time version string. The Makefile's docker
+# targets pass it through from APP_VERSION resolved via
+# `git describe --tags --abbrev=0` (or the CI tag-event override);
+# unset here means the binary self-reports "dev".
+ARG APP_VERSION=dev
 
 WORKDIR /src
 
 COPY go/ .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /simulator ./simulator
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+    -ldflags "-X main.Version=${APP_VERSION}" \
+    -o /simulator ./simulator
 
 # ----
 

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,38 @@ DOCKER_TAGS  ?= $(SIM_IMAGE)
 GOOS   ?= linux
 GOARCH ?= amd64
 
+# Version resolution: APP_VERSION env > `git describe --tags` > "dev".
+# Both variables use `?=` so CI (which exports APP_VERSION on tag
+# events) wins cleanly. A shallow clone with no tags falls through to
+# "dev"; a binary built by `go build` directly (bypassing this
+# Makefile) also reports "dev" — an obvious signal that ldflags did
+# not run.
+#
+# We deliberately omit `--abbrev=0` so HEAD that is ahead of the last
+# tag bakes the commit-distance form (e.g. `v0.4.1-11-g0356c42`). This
+# is a conscious deviation from docusaurus.config.ts:resolveAppVersion
+# which uses the cleaner `--abbrev=0` form — on the binary we prefer
+# dev-build honesty (a post-tag commit never masquerades as the tag
+# itself). See openspec/changes/expose-simulator-version/design.md D6.
+VERSION     ?= $(shell git describe --tags 2>/dev/null || echo dev)
+APP_VERSION ?= $(VERSION)
+
+# Guard against shell-metachar / whitespace injection through APP_VERSION
+# into the -ldflags string. Allowed grammar tracks the characters that
+# appear in real git tags (semver + pre-release + build-metadata).
+ifneq ($(shell printf '%s' '$(APP_VERSION)' | grep -Eq '^[A-Za-z0-9._+-]+$$' && echo ok),ok)
+$(error APP_VERSION "$(APP_VERSION)" contains unsafe characters; allowed grammar: [A-Za-z0-9._+-]+)
+endif
+
+LDFLAGS     := -X main.Version=$(APP_VERSION)
+
 # Docs toolchain (Docusaurus). Contributors install Node dependencies into
 # ./node_modules via `npm ci`; Node version is pinned in .nvmrc.
 NPM ?= npm
 
 UNAME_S := $(shell uname -s)
 
-.PHONY: all build run test tidy check-tidy dist clean docker-build docker-push docker-up docker-down help \
+.PHONY: all build run test tidy check-tidy dist clean docker-build docker-push docker-up docker-down help version \
         check-go check-docker check-buildx check-linux check-node \
         docs-install docs-serve docs-build docs-clean
 
@@ -24,7 +49,11 @@ all: build
 
 ## build: Cross-compile the simulator binary for Linux (GOOS=linux GOARCH=amd64)
 build: check-go
-	cd $(BUILD_DIR) && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BINARY) .
+	cd $(BUILD_DIR) && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
+
+## version: Print the resolved version string (useful for CI diagnostics)
+version:
+	@echo $(APP_VERSION)
 
 ## tidy: Sync go.mod and go.sum
 tidy: check-go
@@ -41,8 +70,8 @@ check-tidy: check-go
 ## dist: Build release binaries for linux/amd64 and linux/arm64 into dist/
 dist: check-go
 	mkdir -p dist
-	cd $(GO_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../dist/$(BINARY)-linux-amd64 ./simulator
-	cd $(GO_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ../dist/$(BINARY)-linux-arm64 ./simulator
+	cd $(GO_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o ../dist/$(BINARY)-linux-amd64 ./simulator
+	cd $(GO_DIR) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o ../dist/$(BINARY)-linux-arm64 ./simulator
 
 ## test: Run tests (simulator package requires Linux)
 test: check-go
@@ -60,12 +89,13 @@ run: check-linux build
 
 ## docker-build: Build the simulator Docker image for the host platform
 docker-build: check-docker
-	docker build -t $(SIM_IMAGE) .
+	docker build --build-arg APP_VERSION=$(APP_VERSION) -t $(SIM_IMAGE) .
 
 ## docker-push: Build and push a multi-platform image (linux/amd64 + linux/arm64)
 docker-push: check-buildx
 	docker buildx build \
 	  --platform linux/amd64,linux/arm64 \
+	  --build-arg APP_VERSION=$(APP_VERSION) \
 	  --push \
 	  $(addprefix -t ,$(DOCKER_TAGS)) \
 	  .

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -25,6 +25,7 @@ for a minimal invocation.
 | `-snmp-port` | int | `161` | UDP port for the SNMP listener on each device. Use `1161` to avoid requiring `CAP_NET_BIND_SERVICE`. |
 | `-no-namespace` | bool | `false` | Disable network namespace isolation (run in the root namespace). |
 | `-help` | — | — | Show the help message and exit. |
+| `-version` | — | — | Print the simulator version string to stdout and exit 0. Runs before any startup side effects (no TUN, no netns, no port binds) so it works from unprivileged shells and inside minimal containers. |
 
 ## SNMPv3 flags
 

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -18,6 +18,7 @@ management web UI at `/`.
 | `/api/v1/resources` | GET | List available device resource types. |
 | `/api/v1/status` | GET | Manager status. |
 | `/api/v1/system-stats` | GET | System stats (file descriptors, memory). |
+| `/api/v1/version` | GET | Running simulator version string. Immutable per process; response carries `Cache-Control: max-age=3600`. |
 | `/api/v1/flows/status` | GET | Flow export status and cumulative counters. |
 | `/api/v1/traps/status` | GET | SNMP trap export status, INFORM counters, and per-type catalog map. |
 | `/api/v1/devices/{ip}/trap` | POST | Fire a named catalog trap on a specific device. |
@@ -255,6 +256,38 @@ curl -X DELETE http://localhost:8080/api/v1/devices/{device-id}
 
 # All devices
 curl -X DELETE http://localhost:8080/api/v1/devices
+```
+
+## Version
+
+Report the running simulator's version. The value is baked into the binary
+at build time via the Makefile's `APP_VERSION` variable (resolution order:
+`APP_VERSION` env > `git describe --tags` > `dev`) and passed to `go build`
+as `-ldflags "-X main.Version=…"`. It never changes for the lifetime of the
+process, so the endpoint sets `Cache-Control: max-age=3600` — reloads of
+the web UI within a browser session will reuse the cached value.
+
+Release binaries report the clean tag (e.g., `v0.5.0`). A `make build`
+from a HEAD that is ahead of the last tag reports the commit-distance
+form (e.g., `v0.4.1-11-g0356c42`), so a post-release dev binary never
+masquerades as the tagged release.
+
+```bash
+curl http://localhost:8080/api/v1/version
+```
+
+```json
+{"version": "v0.5.0"}
+```
+
+For an untagged development build (or any build produced by `go build`
+directly, bypassing the Makefile), the reported version is the literal
+string `dev`. Operators troubleshooting a version mismatch can call the
+same string from the CLI without starting the server:
+
+```bash
+./simulator -version
+# → v0.5.0
 ```
 
 ## Flow export status

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -99,6 +99,7 @@ func main() {
 		snmpPort        = flag.Int("snmp-port", DEFAULT_SNMP_PORT, "UDP port for SNMP listener on each device (default: 161)")
 		noNamespace     = flag.Bool("no-namespace", false, "Disable network namespace isolation (use root namespace)")
 		showHelp        = flag.Bool("help", false, "Show this help message")
+		showVersion     = flag.Bool("version", false, "Print the simulator version string and exit")
 		ifScenario      = flag.Int("if-scenario", 2, "Interface state scenario: 1=all-shutdown, 2=all-normal (default), 3=all-failure, 4=pct-failure")
 		ifFailurePct    = flag.Int("if-failure-pct", 10, "Percentage of interfaces with oper-down (used with -if-scenario 4, 0–100)")
 
@@ -132,6 +133,15 @@ func main() {
 	)
 
 	flag.Parse()
+
+	// `-version` prints the baked-in Version and exits before any
+	// simulator setup runs (no flag dependencies, no TUN, no netns, no
+	// port binds). Lets `./simulator -version` work without root and
+	// without touching system state.
+	if *showVersion {
+		fmt.Println(Version)
+		return
+	}
 
 	// Apply interface state scenario
 	ifStateConfig = &IfStateConfig{
@@ -168,7 +178,7 @@ func main() {
 		return
 	}
 
-	log.Println("Layer 8 Data Center Simulator with TUN/TAP support starting...")
+	log.Printf("simulator %s starting (pid=%d)", Version, os.Getpid())
 
 	// Check if running as root
 	if os.Geteuid() != 0 {

--- a/go/simulator/version.go
+++ b/go/simulator/version.go
@@ -1,0 +1,31 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+// Version is the simulator's self-reported build identity. It is
+// populated at link time via `-ldflags "-X main.Version=<value>"`.
+// Resolution precedence (driven by the Makefile):
+//
+//  1. APP_VERSION environment variable (CI tag-build override)
+//  2. `git describe --tags` — tagged commit → `vX.Y.Z`; HEAD ahead of
+//     the last tag → `vX.Y.Z-N-g<sha>` so ahead-of-tag dev builds
+//     never masquerade as the tag itself
+//  3. the literal string "dev" (fallback for shallow / untagged clones)
+//
+// A binary built by `go build` directly (bypassing `make build`)
+// carries the zero-value "dev" — an obvious signal that ldflags
+// injection did not run.
+var Version = "dev"

--- a/go/simulator/version_test.go
+++ b/go/simulator/version_test.go
@@ -1,0 +1,61 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVersionFlagPrintsInjectedVersion builds the simulator with a
+// known -ldflags injection and asserts that `./simulator -version`
+// prints exactly that string + newline and exits 0. Covers spec
+// Requirement 1 (build-time injection) and Requirement 2 (-version
+// flag behaviour) in a single round-trip.
+func TestVersionFlagPrintsInjectedVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: builds a binary and execs it")
+	}
+
+	const injected = "v99.99.99-test"
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "simulator-version-test")
+
+	build := exec.Command("go", "build",
+		"-ldflags", "-X main.Version="+injected,
+		"-o", binPath,
+		".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	out, err := exec.Command(binPath, "-version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("running -version failed: %v\n%s", err, out)
+	}
+
+	got := strings.TrimRight(string(out), "\n")
+	if got != injected {
+		t.Fatalf("-version stdout = %q, want %q", got, injected)
+	}
+
+	// Trailing newline check: spec requires exactly `<version>\n`.
+	if !strings.HasSuffix(string(out), "\n") {
+		t.Fatalf("-version output missing trailing newline: %q", string(out))
+	}
+}

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -132,6 +132,19 @@ func systemStatsHandler(w http.ResponseWriter, r *http.Request) {
 	sendDataResponse(w, stats)
 }
 
+// versionHandler implements GET /api/v1/version. The version is immutable
+// per process, so the response is marked cacheable (private, max-age=3600)
+// to cut chatter on page reloads. `private` keeps shared proxies from
+// caching one simulator's version across other operators or across a
+// binary swap-and-restart inside the TTL. Shape:
+//
+//	{"version": "v0.5.0"}
+func versionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "private, max-age=3600")
+	_ = json.NewEncoder(w).Encode(map[string]string{"version": Version})
+}
+
 func flowStatusHandler(w http.ResponseWriter, r *http.Request) {
 	status := manager.GetFlowStatus()
 	sendDataResponse(w, status)
@@ -439,6 +452,7 @@ func setupRoutes() *mux.Router {
 	api.HandleFunc("/resources", listResourcesHandler).Methods("GET")
 	api.HandleFunc("/status", statusHandler).Methods("GET")
 	api.HandleFunc("/system-stats", systemStatsHandler).Methods("GET")
+	api.HandleFunc("/version", versionHandler).Methods("GET")
 	api.HandleFunc("/flows/status", flowStatusHandler).Methods("GET")
 	api.HandleFunc("/traps/status", trapStatusHandler).Methods("GET")
 	api.HandleFunc("/devices/{ip}/trap", fireTrapHandler).Methods("POST")

--- a/go/simulator/web/app_api.js
+++ b/go/simulator/web/app_api.js
@@ -592,3 +592,22 @@ async function loadSystemStats() {
         console.error('Failed to load system stats:', error);
     }
 }
+
+// loadVersion fetches the simulator's self-reported version and writes
+// `(vX.Y.Z)` into the hero kicker. The version is immutable per process
+// so this runs once on page load — never in a polling interval.
+// textContent (not innerHTML) is load-bearing: keeps any unexpected
+// characters in the version string from creating a DOM-injection surface.
+async function loadVersion() {
+    try {
+        const response = await fetch('/api/v1/version');
+        if (!response.ok) return;
+        const payload = await response.json();
+        const el = document.getElementById('appVersion');
+        if (el && payload && payload.version) {
+            el.textContent = '(' + payload.version + ')';
+        }
+    } catch (error) {
+        console.error('Failed to load version:', error);
+    }
+}

--- a/go/simulator/web/app_ui.js
+++ b/go/simulator/web/app_ui.js
@@ -399,4 +399,5 @@ document.addEventListener('DOMContentLoaded', () => {
     loadSystemStats(); // Initial system stats load
     loadExportStatuses(); // Initial export-status load (phase 6)
     checkStatus(); // Initial status check
+    loadVersion(); // One-shot: version is immutable per process
 });

--- a/go/simulator/web/index.html
+++ b/go/simulator/web/index.html
@@ -14,7 +14,7 @@
                     <img class="hero-logo" src="/logo.png" alt="OpenSim logo">
                     <span class="eyebrow">Layer 8 Ecosystem</span>
                 </div>
-                <p class="hero-kicker">Layer 8 Data Center Simulator</p>
+                <p class="hero-kicker">Layer 8 Data Center Simulator <span class="hero-version" id="appVersion"></span></p>
                 <h1>Build test fleets that look like real infrastructure, not toy demos.</h1>
                 <p class="hero-summary">
                     OpenSim provisions virtual network devices with TUN/TAP interfaces, SNMP, and SSH so teams can

--- a/go/simulator/web/styles.css
+++ b/go/simulator/web/styles.css
@@ -98,6 +98,12 @@ body {
     text-transform: uppercase;
 }
 
+.hero-version {
+    margin-left: 0.25em;
+    font-weight: 400;
+    opacity: 0.7;
+}
+
 .hero h1,
 .section-heading h2,
 .hero-panel h2,

--- a/go/simulator/web_version_test.go
+++ b/go/simulator/web_version_test.go
@@ -1,0 +1,80 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// TestVersionHandlerGET asserts the shape of GET /api/v1/version: 200,
+// JSON body {"version": Version}, Content-Type application/json, and
+// Cache-Control max-age=3600.
+func TestVersionHandlerGET(t *testing.T) {
+	orig := Version
+	Version = "v0.5.0-test"
+	defer func() { Version = orig }()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	versionHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "private, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want private, max-age=3600", got)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(body) != 1 {
+		t.Errorf("body has %d keys, want 1: %v", len(body), body)
+	}
+	if got := body["version"]; got != "v0.5.0-test" {
+		t.Errorf("body.version = %q, want v0.5.0-test", got)
+	}
+}
+
+// TestVersionRouteMethodGuard asserts that non-GET methods to
+// /api/v1/version are rejected by the router with 405. Uses the real
+// router so the Methods("GET") restriction is exercised.
+func TestVersionRouteMethodGuard(t *testing.T) {
+	router := mux.NewRouter()
+	api := router.PathPrefix("/api/v1").Subrouter()
+	api.HandleFunc("/version", versionHandler).Methods("GET")
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(method, "/api/v1/version", strings.NewReader(""))
+			router.ServeHTTP(rr, req)
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s /api/v1/version: status = %d, want 405", method, rr.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Simulator binary self-reports its version via four surfaces: `-version` CLI flag, startup log banner, `GET /api/v1/version`, and the web UI hero kicker.
- Version baked at build time via `-ldflags "-X main.Version=..."` — resolution: `APP_VERSION` env > `git describe --tags` > `dev`. `--abbrev=0` deliberately dropped so ahead-of-tag builds report `vX.Y.Z-N-g<sha>` instead of masquerading as the last tag.
- First release that will carry this story is **v0.5.0** — tag push auto-asserts the baked version matches `${GITHUB_REF_NAME}` in CI.

## Why

Operators running the simulator inside a container had no way to check which build they were on. No `-version` flag, no API surface, no log banner. This closes that gap and lands it before v0.5.0 so the release notes can point at a visible improvement.

## What changed

**Go**
- `go/simulator/version.go` (new) — `var Version = "dev"` with a docstring describing the resolver.
- `go/simulator/simulator.go` — `-version` flag; startup banner now `simulator <version> starting (pid=<N>)`.
- `go/simulator/web.go` — `GET /api/v1/version` handler with `Cache-Control: private, max-age=3600`.
- `go/simulator/version_test.go` (new) — end-to-end build-and-exec check that `-ldflags` injection matches `-version` output.
- `go/simulator/web_version_test.go` (new) — handler body/header test + method-guard test (POST/PUT/DELETE/PATCH → 405).

**Web UI**
- `index.html`: hero kicker gains `<span class="hero-version" id="appVersion">`.
- `styles.css`: `.hero-version` rule (0.7 opacity, lighter weight, small margin).
- `app_api.js`: one-shot `loadVersion()` using `fetch` + `textContent` (not `innerHTML`).
- `app_ui.js`: calls `loadVersion()` once from `DOMContentLoaded`.

**Build / CI**
- `Makefile`: `VERSION`/`APP_VERSION`/`LDFLAGS` block; new `version` convenience target; all build targets pass `-ldflags "\$(LDFLAGS)"`; docker targets thread `--build-arg APP_VERSION`; APP_VERSION sanitized against `[A-Za-z0-9._+-]+` at parse time to close shell-injection surface through `-ldflags`.
- `Dockerfile`: `ARG APP_VERSION=dev` in the build stage; `go build -ldflags "-X main.Version=\${APP_VERSION}"`.
- `.github/workflows/release.yml`: every job exports `APP_VERSION=\${{ github.ref_name }}`; new assertion step refuses to proceed if the baked binary version drifts from the tag or either side is empty.

**Docs**
- `CLAUDE.md`: `-version` added to the Build & Run flag table; Web API blurb mentions `/api/v1/version`.
- `docs/reference/cli-flags.md`: `-version` row in the Core flags table.
- `docs/reference/web-api.md`: endpoint catalog row + new `## Version` section with curl example and the ahead-of-tag / `dev` fallback notes.

## Test plan

- [x] `make build` → binary's `strings` output contains the resolved version
- [x] `make version` → prints `v0.4.1-11-g0356c42` (ahead-of-tag form)
- [x] `APP_VERSION=v0.5.0-rc.test make build` → env override wins end-to-end
- [x] `APP_VERSION='evil;injection' make version` → Makefile rejects with clear error
- [x] `go test -short ./...` on the simulator package → green (16.9s, no regressions)
- [x] `TestVersionHandlerGET`, `TestVersionRouteMethodGuard`, `TestVersionFlagPrintsInjectedVersion` → all pass
- [x] `make docs-build` → green
- [ ] Tag push CI → verify `Assert baked version matches tag` step executes green (first exercise will be the real `v0.5.0` tag)
- [ ] Browser smoke: hit `/` on a running simulator, confirm hero renders `(V0.5.0)` (release) or `(V0.4.1-11-G0356C42)` (dev)

## Notes

- First release that carries this story is **v0.5.0**. The CI assertion is live on this branch but will not fire until a tag is pushed (workflow trigger is `push.tags: v*.*.*`).
- Dropping `--abbrev=0` is a conscious deviation from `docusaurus.config.ts:resolveAppVersion()`. Rationale: the docs site is rebuilt per-deploy, so short form is always fresh; a simulator binary can outlive several tags, and operators need to tell a release from an ahead-of-tag dev build at a glance.