### PR TITLE
feat(snmp): full IF-MIB counter cycling with per-device error scenarios

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ sudo ./simulator [flags]
 -snmpv3-priv <proto>    # none | des | aes128
 -no-namespace           # Disable network namespace isolation
 -version                # Print version string and exit (no startup side effects)
+-if-error-scenario <s>  # Auto-start-batch per-device error/discard scenario: clean (default) | typical | degraded | failing. REST-created devices default to clean; opt in via if_error_scenario.
 
 # Flow export flags (NetFlow v5 / v9 / IPFIX / sFlow v5)
 # Flags marked [seed] apply ONLY to auto-start devices (-auto-start-ip batch).
@@ -79,6 +80,8 @@ go test ./simulator/ -run TestSomething
 **Device lifecycle:** `simulator.go` (CLI/entry) → `manager.go` (SimulatorManager, shared keys/certs) → `device.go` (per-device startup, protocol server lifecycle)
 
 **SNMP stack:** `snmp_server.go` → `snmp.go` (request handling) → `snmp_handlers.go` (OID lookup via sync.Map) → `snmp_response.go` (response building) → `snmp_encoding.go` (ASN.1 BER/DER). SNMPv3 is handled separately in `snmpv3.go` + `snmpv3_crypto.go` (MD5/SHA1 auth, DES/AES128 privacy).
+
+**Dynamic IF-MIB counters (`if_counters.go`):** `IfCounterCycler.GetDynamic` serves every per-interface counter under `ifTable` (`.1.3.6.1.2.1.2.2.1`) and `ifXTable` (`.1.3.6.1.2.1.31.1.1.1`) analytically — no per-interface goroutine. `ifHCInOctets` / `ifHCOutOctets` are the master dial (sine wave, 60–100 % of `ifSpeed`, 1 h period); HC packet counters (ucast / mcast / bcast) derive from octets ÷ jittered packet size × jittered ratios; Counter32 shadow columns (`ifInUcastPkts`, `ifInMulticastPkts`, etc.) return the low 32 bits of the matching Counter64 HC column; error / discard counters derive from per-device ppm bands set by the `IfErrorScenario` field (`clean` | `typical` | `degraded` | `failing`). The same dispatcher powers the sFlow `counter_sample` body path in `counter_source.go`, so SNMP and sFlow values agree byte-for-byte at the same instant.
 
 **Metrics engine:** `metrics_cycler.go` drives 100-point pre-generated sine-wave patterns per device. `gpu_metrics.go` handles per-GPU metrics (utilization, VRAM, temperature, power, clocks). `device_profiles.go` defines per-category baselines.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -117,9 +117,10 @@ are merged at load time. See [Resource files](resource-files.md).
 - **Buffer pool** — reduces GC pressure on SNMP request handling.
 - **Shared SSH / TLS keys** across all devices — avoids per-device key
   generation overhead.
-- **Analytic HC counters** — `ifHCInOctets` / `ifHCOutOctets` computed on
-  demand instead of maintained by a polling loop; see
-  [SNMP reference](snmp.md#dynamic-hc-interface-traffic-counters).
+- **Analytic IF-MIB counters** — every per-interface counter in `ifTable`
+  and `ifXTable` computed on demand from a single per-direction octet
+  sine wave, instead of maintained by a polling loop; see
+  [SNMP reference](snmp.md#dynamic-if-mib-counters).
 - **Network namespace isolation** — the `opensim` namespace prevents
   systemd-networkd interference on many Linux distros.
 - **Per-device flow egress** — a `FORWARD -i veth-sim-host -j ACCEPT`

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -60,6 +60,35 @@ editing resource files.
 Scenario 4 uses a deterministic rule (`ifIndex % 100 < n`) so test runs are
 reproducible across restarts.
 
+### Error / discard scenario
+
+`-if-scenario` governs **which interfaces are up**. A companion flag,
+`-if-error-scenario`, governs **how clean the interfaces that are up
+behave** — the ppm ranges used to derive `ifInErrors`, `ifOutErrors`,
+`ifInDiscards`, and `ifOutDiscards` from the live packet counters.
+
+| Flag | Values | Default | Purpose |
+|------|--------|---------|---------|
+| `-if-error-scenario` | `clean` \| `typical` \| `degraded` \| `failing` | `clean` | Auto-start-batch default for per-device error / discard counter cycling. REST-created devices default to `clean` independently (they opt in via `if_error_scenario` in the POST body). |
+
+| Scenario | `errPpm` range | `discPpm` range | Use case |
+|----------|----------------|-----------------|----------|
+| `clean` *(default)* | 0 | 0 | Pristine lab gear — counters stay at the pre-seeded baseline |
+| `typical` | 10 – 100 | 20 – 200 | Good production gear; faint error/discard growth visible in long-period polls |
+| `degraded` | 1 000 – 10 000 | 2 000 – 20 000 | Congested / faulty optics; 0.1 – 1 % error rate |
+| `failing` | 10 000 – 100 000 | 20 000 – 200 000 | Link-flap / bad cable; 1 – 10 % error rate |
+
+Each interface within a device draws its per-direction ppm deterministically
+from the scenario's band at device creation — so repeated runs with the
+same auto-start layout produce the same per-interface values. `clean`
+(`0/0`) is the backwards-compatible default and leaves all error/discard
+counters at their pre-seeded zero.
+
+Unlike `-if-scenario`, this setting is **per-device**: every device carries
+its own scenario, so one simulator can host 100 `clean` lab devices
+alongside 5 `degraded` ones for alert-threshold testing. See
+[`if-counters` reference](snmp.md#dynamic-if-mib-counters).
+
 ## Export flag scope
 
 Export flags (flow / trap / syslog) fall into two categories:

--- a/docs/reference/resource-files.md
+++ b/docs/reference/resource-files.md
@@ -78,9 +78,10 @@ of what the resource files contain:
 
 - **CPU, memory, temperature** — cycle through a 100-point sine-wave pattern
   per device. See [SNMP reference → Dynamic metrics](snmp.md#dynamic-cpu--memory--temperature-metrics).
-- **HC interface counters** (`ifHCInOctets` / `ifHCOutOctets`) — computed
-  analytically as monotonically increasing `Counter64` values, phase-offset
-  per interface. See [SNMP reference → HC counters](snmp.md#dynamic-hc-interface-traffic-counters).
+- **Dynamic IF-MIB counters** — every per-interface counter in `ifTable`
+  and `ifXTable` (octets, HC packets, Counter32 shadows, errors, discards)
+  is computed analytically from the octet sine wave, phase-offset per
+  interface. See [SNMP reference → Dynamic IF-MIB counters](snmp.md#dynamic-if-mib-counters).
 - **Interface state** — `ifAdminStatus` / `ifOperStatus` depend on
   [`-if-scenario`](cli-flags.md#interface-state-scenarios).
 - **GPU metrics** — per-GPU utilization, VRAM, temp, power, fan, clocks.

--- a/docs/reference/snmp.md
+++ b/docs/reference/snmp.md
@@ -39,24 +39,103 @@ SNMP-heavy workloads.
 OIDs in resource files may be written with or without a leading dot — the
 loader normalises them to the net-snmp convention (`.1.3.6.1…`) at startup.
 
-## Dynamic HC interface traffic counters
+## Dynamic IF-MIB counters
 
-`ifHCInOctets` (`.1.3.6.1.2.1.31.1.1.1.6`) and `ifHCOutOctets`
-(`.1.3.6.1.2.1.31.1.1.1.10`) are generated dynamically:
+Every per-interface counter listed below is generated dynamically by
+`go/simulator/if_counters.go:IfCounterCycler`:
 
-- Byte-rate oscillates between 60 % and 100 % of the interface's reported
-  `ifHighSpeed` / `ifSpeed` on a 1-hour sine period.
-- Each interface gets a random phase offset so interfaces within a device
-  do not peak simultaneously.
-- Counters are pre-seeded with ~24 h of traffic so they look realistic on
-  the very first poll.
-- Values are computed analytically on demand — no polling loop or
-  per-interface goroutine — as monotonically increasing `Counter64`.
-- Visible on both `GET` and `GETNEXT` / `GETBULK`.
+**ifXTable Counter64 HC columns** (`.1.3.6.1.2.1.31.1.1.1.X`):
+
+| Column | OID column | Derivation |
+|--------|-----------|------------|
+| `ifHCInOctets` | `.6` | master dial (sine wave, 60 – 100 % of `ifHighSpeed` / `ifSpeed`, 1 h period) |
+| `ifHCInUcastPkts` | `.7` | `baseInUcast + (inDeltaOctets / pktSizeIn) × ucastRatioIn` |
+| `ifHCInMulticastPkts` | `.8` | same shape, `mcastRatioIn` |
+| `ifHCInBroadcastPkts` | `.9` | same shape, `bcastRatioIn` |
+| `ifHCOutOctets` | `.10` | outbound master dial |
+| `ifHCOutUcastPkts` | `.11` | `baseOutUcast + (outDeltaOctets / pktSizeOut) × ucastRatioOut` |
+| `ifHCOutMulticastPkts` | `.12` | same shape, `mcastRatioOut` |
+| `ifHCOutBroadcastPkts` | `.13` | same shape, `bcastRatioOut` |
+
+**ifXTable Counter32 shadow columns** — always equal to `uint32(HC_value & 0xFFFFFFFF)`:
+
+| Column | OID column | Shadow of |
+|--------|-----------|-----------|
+| `ifInMulticastPkts` | `.2` | `ifHCInMulticastPkts` (`.8`) |
+| `ifInBroadcastPkts` | `.3` | `ifHCInBroadcastPkts` (`.9`) |
+| `ifOutMulticastPkts` | `.4` | `ifHCOutMulticastPkts` (`.12`) |
+| `ifOutBroadcastPkts` | `.5` | `ifHCOutBroadcastPkts` (`.13`) |
+
+**ifTable Counter32 columns** (`.1.3.6.1.2.1.2.2.1.X`):
+
+| Column | OID column | Derivation |
+|--------|-----------|------------|
+| `ifInUcastPkts` | `.11` | shadow of `ifHCInUcastPkts` (`.7`) |
+| `ifInDiscards` | `.13` | `baseInDisc + inDeltaPkts × discPpmIn / 1e6` |
+| `ifInErrors` | `.14` | `baseInErr + inDeltaPkts × errPpmIn / 1e6` |
+| `ifOutUcastPkts` | `.17` | shadow of `ifHCOutUcastPkts` (`.11`) |
+| `ifOutDiscards` | `.19` | `baseOutDisc + outDeltaPkts × discPpmOut / 1e6` |
+| `ifOutErrors` | `.20` | `baseOutErr + outDeltaPkts × errPpmOut / 1e6` |
+
+Properties common to every dynamic counter:
+
+- **Monotonic.** The underlying octet integral never decreases (rate
+  floor is 60 % of `ifSpeed`), and every derivation is
+  base-plus-growth, so Counter64 columns are strictly increasing.
+  Counter32 shadow columns wrap naturally at 2³²; `ifCounterDiscontinuityTime`
+  stays at 0 — wrap is inherent, not a discontinuity.
+- **Pre-seeded.** Each counter starts at a base derived from ~24 h
+  of traffic, ratios, and the active error scenario (see below) so a
+  fresh device doesn't look unrealistically pristine.
+- **Per-interface variance.** Packet-size divisor jitters ±20 % around
+  500 B; mix ratios jitter ±3 % around 85 / 10 / 5 (in) and 90 / 8 / 2
+  (out); error / discard ppm values are drawn once from the scenario
+  band — all deterministic from the device seed.
+- **Sine-driven correlation.** All derived counters share the master
+  octet sine wave, so when a link is "quiet" (60 % of `ifSpeed`) the
+  full counter family slows together — matching how real hardware
+  behaves under reduced traffic.
+- **SNMP ↔ sFlow agreement.** Both read paths resolve the same
+  `IfCounterCycler` dispatcher, so concurrent SNMP GETs and sFlow
+  `counter_sample` bodies carry matching values at the same instant.
+- **Zero-goroutine cost.** Every counter is computed on-demand from
+  the current time against analytic formulas — no per-interface
+  goroutine, no polling loop.
+- Values are visible on both `GET` and `GETNEXT` / `GETBULK`.
+
+**Counter32 wrap guidance.** At 10 Gbps / 80 % util / 500 B avg
+packet size, `ifInUcastPkts` wraps every ~26 minutes. At 100 Gbps
+the same column wraps every ~2.6 minutes. Collectors handle the wrap
+via the existing delta-modulo convention; but when your link is
+≥1 Gbps you should prefer the Counter64 HC columns
+(`ifHCInUcastPkts` etc.) to avoid missing a wrap on a slow poll cycle.
+
+### Per-device error scenario
+
+The `ifInErrors` / `ifOutErrors` / `ifInDiscards` / `ifOutDiscards`
+rates are driven by a per-device scenario carried in `DeviceSimulator.IfErrorScenario`:
+
+| Scenario | `errPpm` | `discPpm` | Typical dashboard appearance |
+|----------|----------|-----------|------------------------------|
+| `clean` *(default)* | `0` | `0` | Flat line at the baseline |
+| `typical` | `10 – 100` | `20 – 200` | Faint steady slope (good production gear) |
+| `degraded` | `1 000 – 10 000` | `2 000 – 20 000` | Visible error-rate alert candidates (0.1 – 1 %) |
+| `failing` | `10 000 – 100 000` | `20 000 – 200 000` | Link-flap / bad-cable alarms (1 – 10 %) |
+
+Set for the auto-start batch via the CLI flag `-if-error-scenario <name>`,
+or per-device via `if_error_scenario` in the `POST /api/v1/devices` body.
+See [CLI flags reference](cli-flags.md#interface-state-scenarios) and
+[Web API reference](web-api.md#create-devices).
+
+### Example walks
 
 ```bash
-# Walk ifXTable to see all HC counters (updates every poll)
+# Walk ifXTable — covers all HC counters, Counter32 shadows, and ifHighSpeed
 snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.31.1.1
+
+# Walk ifTable — covers ifInUcastPkts, ifInDiscards, ifInErrors,
+# ifOutUcastPkts, ifOutDiscards, ifOutErrors
+snmpwalk -v2c -c public 192.168.100.1 1.3.6.1.2.1.2.2.1
 
 # Fetch HC in/out for interface 1 directly
 snmpget -v2c -c public 192.168.100.1 \
@@ -66,6 +145,10 @@ snmpget -v2c -c public 192.168.100.1 \
 # Continuous rate monitoring (poll every 10 s)
 watch -n 10 "snmpget -v2c -c public 192.168.100.1 \
   1.3.6.1.2.1.31.1.1.1.6.1 1.3.6.1.2.1.31.1.1.1.10.1"
+
+# Watch error / discard growth on a device deployed with -if-error-scenario failing
+watch -n 5 "snmpget -v2c -c public 192.168.100.1 \
+  1.3.6.1.2.1.2.2.1.14.1 1.3.6.1.2.1.2.2.1.13.1"
 ```
 
 ## Dynamic CPU / memory / temperature metrics

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -79,7 +79,26 @@ curl -X POST http://localhost:8080/api/v1/devices \
       "priv_protocol": "aes128"
     }
   }'
+
+# Per-device error-counter scenario
+curl -X POST http://localhost:8080/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_ip": "192.168.100.1",
+    "device_count": 3,
+    "netmask": "24",
+    "if_error_scenario": "degraded"
+  }'
 ```
+
+The `if_error_scenario` field controls the per-device ppm bands used to
+derive `ifInErrors`, `ifOutErrors`, `ifInDiscards`, and `ifOutDiscards`
+from live packet counters. Accepted values: `clean` (default, no error
+growth), `typical`, `degraded`, `failing`. Unknown values reject the
+batch atomically with 400. REST-created devices default to `clean`
+independently of the `-if-error-scenario` CLI flag — you must opt in
+explicitly. See [SNMP reference](snmp.md#per-device-error-scenario) for
+the full scenario bands and counter model.
 
 A specific resource file can be requested directly (useful for storage
 devices):

--- a/go/simulator/counter_source.go
+++ b/go/simulator/counter_source.go
@@ -81,10 +81,23 @@ func NewInterfaceCounterSource(c *IfCounterCycler) *InterfaceCounterSource {
 // Each record is tagged with SourceID = ifIndex so EncodeCounterDatagram
 // emits one counters_sample per interface (collectors such as OpenNMS
 // Telemetryd key if_counters by ds_index).
-func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
+func (s *InterfaceCounterSource) Snapshot(t time.Time) []CounterRecord {
 	if s == nil || s.cycler == nil {
 		return nil
 	}
+	// Freeze a single evaluation instant so every column within one
+	// interface's body — and across all interfaces in one snapshot —
+	// sees a coherent moment. Mixing values sampled microseconds apart
+	// would break the shadow-equals-low-32(HC) invariant and the
+	// sFlow-equals-concurrent-SNMP-GET contract. A zero-value t (e.g.
+	// from a test that didn't supply one) falls back to "now".
+	var tSec float64
+	if t.IsZero() {
+		tSec = time.Since(s.cycler.startTime).Seconds()
+	} else {
+		tSec = t.Sub(s.cycler.startTime).Seconds()
+	}
+
 	idxs := make([]int, 0, len(s.cycler.knownIfIndexes))
 	for i := range s.cycler.knownIfIndexes {
 		idxs = append(idxs, i)
@@ -97,24 +110,24 @@ func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 		}
 		idxStr := strconv.Itoa(ifIndex)
 
-		// Fetch every column from the cycler. `if_counters` is
-		// Counter32-only on the wire, so we read the Counter32 shadow
-		// columns where they exist (shadow = low-32 of the matching
-		// Counter64) and parse them as uint32.
-		inOctets := parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "6." + idxStr))
-		outOctets := parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "10." + idxStr))
+		// Fetch every column from the cycler at the frozen tSec.
+		// `if_counters` is Counter32-only on the wire, so we read the
+		// Counter32 shadow columns where they exist (shadow = low-32
+		// of the matching Counter64) and parse them as uint32.
+		inOctets := parseUintOrZero(s.cycler.GetDynamicAt(ifXTablePrefix+"6."+idxStr, tSec))
+		outOctets := parseUintOrZero(s.cycler.GetDynamicAt(ifXTablePrefix+"10."+idxStr, tSec))
 
-		inUcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "11." + idxStr)))
-		inMcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "2." + idxStr)))
-		inBcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "3." + idxStr)))
-		inDisc := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "13." + idxStr)))
-		inErr := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "14." + idxStr)))
+		inUcast := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifTablePrefix+"11."+idxStr, tSec)))
+		inMcast := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifXTablePrefix+"2."+idxStr, tSec)))
+		inBcast := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifXTablePrefix+"3."+idxStr, tSec)))
+		inDisc := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifTablePrefix+"13."+idxStr, tSec)))
+		inErr := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifTablePrefix+"14."+idxStr, tSec)))
 
-		outUcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "17." + idxStr)))
-		outMcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "4." + idxStr)))
-		outBcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "5." + idxStr)))
-		outDisc := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "19." + idxStr)))
-		outErr := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "20." + idxStr)))
+		outUcast := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifTablePrefix+"17."+idxStr, tSec)))
+		outMcast := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifXTablePrefix+"4."+idxStr, tSec)))
+		outBcast := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifXTablePrefix+"5."+idxStr, tSec)))
+		outDisc := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifTablePrefix+"19."+idxStr, tSec)))
+		outErr := uint32(parseUintOrZero(s.cycler.GetDynamicAt(ifTablePrefix+"20."+idxStr, tSec)))
 
 		body := encodeIfCountersBody(
 			uint32(ifIndex), s.cycler.ifSpeedBps[slot],

--- a/go/simulator/counter_source.go
+++ b/go/simulator/counter_source.go
@@ -71,15 +71,16 @@ func NewInterfaceCounterSource(c *IfCounterCycler) *InterfaceCounterSource {
 	return &InterfaceCounterSource{cycler: c}
 }
 
-// Snapshot returns one if_counters CounterRecord per known interface, with
-// ifHCInOctets / ifHCOutOctets sourced from the cycler's sine-wave math. Each
-// record is tagged with SourceID = ifIndex so EncodeCounterDatagram emits one
-// counters_sample per interface (collectors such as OpenNMS Telemetryd key
-// if_counters by ds_index).
+// Snapshot returns one if_counters CounterRecord per known interface,
+// with every field sourced from the same IfCounterCycler dispatcher
+// that SNMP reads go through. At the same time t, the values carried in
+// an sFlow counter_sample body match byte-for-byte what a concurrent
+// SNMP GET for the corresponding OIDs would return (the spec's unified
+// sFlow / SNMP counter-source guarantee).
 //
-// The remaining if_counters fields (ifInUcastPkts etc.) are synthesized from
-// the octet counters using a coarse 500-byte average packet size — adequate
-// for collector smoke tests, not for graphing accuracy.
+// Each record is tagged with SourceID = ifIndex so EncodeCounterDatagram
+// emits one counters_sample per interface (collectors such as OpenNMS
+// Telemetryd key if_counters by ds_index).
 func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 	if s == nil || s.cycler == nil {
 		return nil
@@ -94,16 +95,32 @@ func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 		if slot < 0 || slot >= len(s.cycler.ifSpeedBps) {
 			continue
 		}
-		inStr := s.cycler.GetHCOctets(hcInOIDPrefix + strconv.Itoa(ifIndex))
-		outStr := s.cycler.GetHCOctets(hcOutOIDPrefix + strconv.Itoa(ifIndex))
-		inOctets := parseUintOrZero(inStr)
-		outOctets := parseUintOrZero(outStr)
-		// Synthesize packet counters from octets / 500B — coarse but
-		// monotonic since octets are monotonic.
-		inPkts := uint32(inOctets / 500)
-		outPkts := uint32(outOctets / 500)
+		idxStr := strconv.Itoa(ifIndex)
 
-		body := encodeIfCountersBody(uint32(ifIndex), s.cycler.ifSpeedBps[slot], inOctets, outOctets, inPkts, outPkts)
+		// Fetch every column from the cycler. `if_counters` is
+		// Counter32-only on the wire, so we read the Counter32 shadow
+		// columns where they exist (shadow = low-32 of the matching
+		// Counter64) and parse them as uint32.
+		inOctets := parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "6." + idxStr))
+		outOctets := parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "10." + idxStr))
+
+		inUcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "11." + idxStr)))
+		inMcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "2." + idxStr)))
+		inBcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "3." + idxStr)))
+		inDisc := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "13." + idxStr)))
+		inErr := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "14." + idxStr)))
+
+		outUcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "17." + idxStr)))
+		outMcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "4." + idxStr)))
+		outBcast := uint32(parseUintOrZero(s.cycler.GetDynamic(ifXTablePrefix + "5." + idxStr)))
+		outDisc := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "19." + idxStr)))
+		outErr := uint32(parseUintOrZero(s.cycler.GetDynamic(ifTablePrefix + "20." + idxStr)))
+
+		body := encodeIfCountersBody(
+			uint32(ifIndex), s.cycler.ifSpeedBps[slot],
+			inOctets, inUcast, inMcast, inBcast, inDisc, inErr,
+			outOctets, outUcast, outMcast, outBcast, outDisc, outErr,
+		)
 		out = append(out, CounterRecord{
 			Format:   sflowCtrFmtGeneric,
 			SourceID: uint32(ifIndex),
@@ -136,7 +153,14 @@ func (s *InterfaceCounterSource) Snapshot(_ time.Time) []CounterRecord {
 //	u32 ifOutDiscards
 //	u32 ifOutErrors
 //	u32 ifPromiscuousMode
-func encodeIfCountersBody(ifIndex uint32, speedBps, inOctets, outOctets uint64, inPkts, outPkts uint32) []byte {
+//
+// ifInUnknownProtos and ifPromiscuousMode are emitted as 0 — the
+// simulator does not model them.
+func encodeIfCountersBody(
+	ifIndex uint32, speedBps, inOctets uint64,
+	inUcast, inMcast, inBcast, inDisc, inErr uint32,
+	outOctets uint64, outUcast, outMcast, outBcast, outDisc, outErr uint32,
+) []byte {
 	body := make([]byte, 88)
 	pos := 0
 	binary.BigEndian.PutUint32(body[pos:], ifIndex)
@@ -151,31 +175,31 @@ func encodeIfCountersBody(ifIndex uint32, speedBps, inOctets, outOctets uint64, 
 	pos += 4
 	binary.BigEndian.PutUint64(body[pos:], inOctets)
 	pos += 8
-	binary.BigEndian.PutUint32(body[pos:], inPkts)
+	binary.BigEndian.PutUint32(body[pos:], inUcast)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // multicast
+	binary.BigEndian.PutUint32(body[pos:], inMcast)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // broadcast
+	binary.BigEndian.PutUint32(body[pos:], inBcast)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // in discards
+	binary.BigEndian.PutUint32(body[pos:], inDisc)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // in errors
+	binary.BigEndian.PutUint32(body[pos:], inErr)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // in unknown protos
+	binary.BigEndian.PutUint32(body[pos:], 0) // in unknown protos (not modeled)
 	pos += 4
 	binary.BigEndian.PutUint64(body[pos:], outOctets)
 	pos += 8
-	binary.BigEndian.PutUint32(body[pos:], outPkts)
+	binary.BigEndian.PutUint32(body[pos:], outUcast)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // out multicast
+	binary.BigEndian.PutUint32(body[pos:], outMcast)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // out broadcast
+	binary.BigEndian.PutUint32(body[pos:], outBcast)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // out discards
+	binary.BigEndian.PutUint32(body[pos:], outDisc)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // out errors
+	binary.BigEndian.PutUint32(body[pos:], outErr)
 	pos += 4
-	binary.BigEndian.PutUint32(body[pos:], 0) // promiscuous
+	binary.BigEndian.PutUint32(body[pos:], 0) // promiscuous mode (not modeled)
 	return body
 }
 

--- a/go/simulator/device.go
+++ b/go/simulator/device.go
@@ -264,13 +264,15 @@ func (sm *SimulatorManager) CreateDevicesWithOptions(startIP string, count int, 
 			profile := GetDeviceProfile(deviceResourceFile)
 			device.metricsCycler = NewMetricsCycler(int64(i), profile)
 			device.metricsCycler.InitGPUMetrics(int64(i), profile.GPU)
-			device.metricsCycler.InitIfCounters(deviceResources, int64(i)^0x4843_0000)
 
-			// Apply the batch-level export seed to this device (phase 3).
-			// A nil seed or nil block means "no export of this type for this
-			// device"; a non-nil block is copied so subsequent mutations
-			// don't leak across devices.
+			// Apply the batch-level export seed BEFORE InitIfCounters so
+			// device.IfErrorScenario is populated in time for the cycler
+			// to draw scenario-banded ppms.
 			applyExportSeed(device, seed)
+
+			scenario, _ := ParseIfErrorScenario(device.IfErrorScenario)
+			device.IfErrorScenario = string(scenario) // canonicalise for GET /api/v1/devices
+			device.metricsCycler.InitIfCountersWithScenario(deviceResources, int64(i)^0x4843_0000, scenario)
 
 			// Initialize flow exporter if this device has flow config.
 			if device.flowConfig != nil {
@@ -547,12 +549,14 @@ func (sm *SimulatorManager) createSingleDevice(deviceIndex int, deviceIP net.IP,
 	profile := GetDeviceProfile(resourceFile)
 	device.metricsCycler = NewMetricsCycler(int64(deviceIndex), profile)
 	device.metricsCycler.InitGPUMetrics(int64(deviceIndex), profile.GPU)
-	device.metricsCycler.InitIfCounters(resources, int64(deviceIndex)^0x4843_0000)
 
-	// Apply the batch-level export seed (phase 3). Parallel workers see
-	// the same seed pointer; each device gets its own copy via
-	// applyExportSeed so downstream mutations don't race.
+	// Apply the batch-level export seed BEFORE InitIfCounters so the
+	// scenario is known when the cycler draws its ppm bands.
 	applyExportSeed(device, seed)
+
+	scenario, _ := ParseIfErrorScenario(device.IfErrorScenario)
+	device.IfErrorScenario = string(scenario)
+	device.metricsCycler.InitIfCountersWithScenario(resources, int64(deviceIndex)^0x4843_0000, scenario)
 
 	// Initialize flow exporter if this device has flow config.
 	if device.flowConfig != nil {

--- a/go/simulator/export_config.go
+++ b/go/simulator/export_config.go
@@ -352,6 +352,12 @@ func applyExportSeed(device *DeviceSimulator, seed *ExportSeed) {
 		s := *seed.Syslog
 		device.syslogConfig = &s
 	}
+	// IfErrorScenario has value semantics; copy directly. Empty string
+	// on the seed maps to "" on the device, which InitIfCounters later
+	// canonicalises via ParseIfErrorScenario ("" → "clean").
+	if seed.IfErrorScenario != "" {
+		device.IfErrorScenario = string(seed.IfErrorScenario)
+	}
 }
 
 // Compile-time safety: ensure jsonDuration satisfies the json

--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -221,10 +221,29 @@ func (ic *IfCounterCycler) IfIndices() []int {
 // ifTable / ifXTable OID this cycler handles, or "" if the OID is not
 // in the dynamic-counter set for a known interface index.
 //
+// Each call reads the wall-clock for a fresh evaluation instant — safe
+// when the caller only needs one column. For multi-column coherence
+// (e.g. the Counter32 shadow must equal uint32(Counter64HC & 0xFFFFFFFF)
+// at the same moment; sFlow counter_sample must match a concurrent SNMP
+// GET across 11 columns) use GetDynamicAt with a single captured t.
+//
 // Returned values are decimal strings — the SNMP encoder wraps them as
 // the appropriate Counter32 or Counter64 based on oidTypeTable
 // (snmp_encoding.go).
 func (ic *IfCounterCycler) GetDynamic(oid string) string {
+	if ic == nil {
+		return ""
+	}
+	return ic.GetDynamicAt(oid, time.Since(ic.startTime).Seconds())
+}
+
+// GetDynamicAt evaluates the cycler at a caller-supplied t (seconds
+// since the cycler's startTime). Callers that need a coherent snapshot
+// across several columns capture t once with
+// `time.Since(ic.startTime).Seconds()` and pass the same value to every
+// lookup — guarantees shadow == low-32(HC) byte-for-byte, and makes
+// sFlow counter_sample values match a concurrent SNMP GET exactly.
+func (ic *IfCounterCycler) GetDynamicAt(oid string, t float64) string {
 	if ic == nil {
 		return ""
 	}
@@ -263,7 +282,6 @@ func (ic *IfCounterCycler) GetDynamic(oid string) string {
 	}
 	slot := ifIndex - 1
 
-	t := time.Since(ic.startTime).Seconds()
 	// Live delta octets = octetsAt(t) − baseInOctets. We work in
 	// delta-space for packet / error / discard derivations because the
 	// pre-seed bases (baseInUcast, baseInErr, …) are themselves
@@ -315,19 +333,32 @@ func (ic *IfCounterCycler) GetDynamic(oid string) string {
 	case colIfInErrors:
 		// total live packets (ucast + mcast + bcast) = deltaOctets / pktSize.
 		// Ratios sum to 1 per direction, so we can skip re-splitting.
-		totalDeltaPkts := uint64(float64(inDelta) / ic.pktSizeIn[slot])
+		totalDeltaPkts := uint64(float64(inDelta) / safePktSize(ic.pktSizeIn[slot]))
 		return fmtU32(uint32((ic.baseInErr[slot] + totalDeltaPkts*uint64(ic.errPpmIn[slot])/1_000_000) & 0xFFFFFFFF))
 	case colIfInDiscards:
-		totalDeltaPkts := uint64(float64(inDelta) / ic.pktSizeIn[slot])
+		totalDeltaPkts := uint64(float64(inDelta) / safePktSize(ic.pktSizeIn[slot]))
 		return fmtU32(uint32((ic.baseInDisc[slot] + totalDeltaPkts*uint64(ic.discPpmIn[slot])/1_000_000) & 0xFFFFFFFF))
 	case colIfOutErrors:
-		totalDeltaPkts := uint64(float64(outDelta) / ic.pktSizeOut[slot])
+		totalDeltaPkts := uint64(float64(outDelta) / safePktSize(ic.pktSizeOut[slot]))
 		return fmtU32(uint32((ic.baseOutErr[slot] + totalDeltaPkts*uint64(ic.errPpmOut[slot])/1_000_000) & 0xFFFFFFFF))
 	case colIfOutDiscards:
-		totalDeltaPkts := uint64(float64(outDelta) / ic.pktSizeOut[slot])
+		totalDeltaPkts := uint64(float64(outDelta) / safePktSize(ic.pktSizeOut[slot]))
 		return fmtU32(uint32((ic.baseOutDisc[slot] + totalDeltaPkts*uint64(ic.discPpmOut[slot])/1_000_000) & 0xFFFFFFFF))
 	}
 	return ""
+}
+
+// safePktSize shields every pktSize-divided derivation from a zero or
+// negative divisor. Init draws pktSize from [400, 600] so this is
+// unreachable today, but widening the jitter or allowing an operator
+// override would turn an unguarded division into a silent 0 / NaN /
+// implementation-defined cast. Centralising the guard keeps future
+// refactors from drifting behavior across branches.
+func safePktSize(v float64) float64 {
+	if v <= 0 {
+		return 500
+	}
+	return v
 }
 
 // GetHCOctets is a backward-compatible forwarder to GetDynamic for the
@@ -368,7 +399,10 @@ func (ic *IfCounterCycler) deltaOctetsAt(slot int, t float64, inbound bool) uint
 }
 
 // packets returns a Counter64 value for a packet column: base + totalPkts × ratio.
-// Exactly one of (mcast, bcast, ucast) must be true.
+// Exactly one of (mcast, bcast, ucast) must be true. Passing zero flags
+// is a programmer error: the helper panics rather than silently
+// returning 0, which would be indistinguishable from a genuine "no
+// packets yet" answer and mask the miswiring.
 //
 // The `inbound` flag picks the correct pktSize + ratios + base tables.
 // Returning 64-bit values lets callers either emit them as Counter64
@@ -380,6 +414,9 @@ func (ic *IfCounterCycler) packets(slot int, octets uint64, inbound, mcast, bcas
 		ratio   float64
 		base    uint64
 	)
+	if !ucast && !mcast && !bcast {
+		panic("IfCounterCycler.packets: exactly one of (ucast, mcast, bcast) must be true")
+	}
 	if inbound {
 		pktSize = ic.pktSizeIn[slot]
 		switch {
@@ -407,10 +444,7 @@ func (ic *IfCounterCycler) packets(slot int, octets uint64, inbound, mcast, bcas
 			base = ic.baseOutBcast[slot]
 		}
 	}
-	if pktSize <= 0 {
-		pktSize = 500 // defensive; init always sets a positive value
-	}
-	total := float64(octets) / pktSize
+	total := float64(octets) / safePktSize(pktSize)
 	return base + uint64(total*ratio)
 }
 

--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -24,27 +24,139 @@ import (
 	"time"
 )
 
+// IF-MIB prefixes for the dynamic counter dispatcher.
 const (
-	hcInOIDPrefix  = ".1.3.6.1.2.1.31.1.1.1.6."
-	hcOutOIDPrefix = ".1.3.6.1.2.1.31.1.1.1.10."
-	hcPeriodSec    = 3600.0 // 1-hour sine-wave cycle
+	ifTablePrefix  = ".1.3.6.1.2.1.2.2.1."    // ifTable (RFC 2863)
+	ifXTablePrefix = ".1.3.6.1.2.1.31.1.1.1." // ifXTable (RFC 2863)
+
+	// Legacy HC-only prefixes — kept for GetHCOctets forwarding and
+	// for out-of-package callers (counter_source.go) during the refactor.
+	hcInOIDPrefix  = ifXTablePrefix + "6."
+	hcOutOIDPrefix = ifXTablePrefix + "10."
+
+	hcPeriodSec = 3600.0 // 1-hour sine-wave cycle
 )
 
-// IfCounterCycler generates monotonically increasing HC counter values
-// (ifHCInOctets / ifHCOutOctets) whose byte-rate follows a sine wave
-// between 60% and 100% of interface speed over a 1-hour period.
+// ifXTable and ifTable column numbers handled dynamically.
+const (
+	// ifXTable (.1.3.6.1.2.1.31.1.1.1.X)
+	colIfInMulticastPkts     = 2
+	colIfInBroadcastPkts     = 3
+	colIfOutMulticastPkts    = 4
+	colIfOutBroadcastPkts    = 5
+	colIfHCInOctets          = 6
+	colIfHCInUcastPkts       = 7
+	colIfHCInMulticastPkts   = 8
+	colIfHCInBroadcastPkts   = 9
+	colIfHCOutOctets         = 10
+	colIfHCOutUcastPkts      = 11
+	colIfHCOutMulticastPkts  = 12
+	colIfHCOutBroadcastPkts  = 13
+
+	// ifTable (.1.3.6.1.2.1.2.2.1.X)
+	colIfInUcastPkts  = 11
+	colIfInDiscards   = 13
+	colIfInErrors     = 14
+	colIfOutUcastPkts = 17
+	colIfOutDiscards  = 19
+	colIfOutErrors    = 20
+)
+
+// IfErrorScenario controls per-device error / discard counter behavior.
+// Scenarios scale the errors-per-million (errPpm) and discards-per-million
+// (discPpm) drawn for each interface at init time; other counter columns
+// are unaffected.
+type IfErrorScenario string
+
+const (
+	IfErrorClean    IfErrorScenario = "clean"
+	IfErrorTypical  IfErrorScenario = "typical"
+	IfErrorDegraded IfErrorScenario = "degraded"
+	IfErrorFailing  IfErrorScenario = "failing"
+)
+
+// ParseIfErrorScenario canonicalises s (case-insensitive) to one of the
+// four known scenarios. Empty input maps to IfErrorClean. Unknown values
+// return an error naming the accepted scenarios so the validation
+// message is self-service on both the CLI and the REST surface.
+func ParseIfErrorScenario(s string) (IfErrorScenario, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", string(IfErrorClean):
+		return IfErrorClean, nil
+	case string(IfErrorTypical):
+		return IfErrorTypical, nil
+	case string(IfErrorDegraded):
+		return IfErrorDegraded, nil
+	case string(IfErrorFailing):
+		return IfErrorFailing, nil
+	default:
+		return "", fmt.Errorf("invalid if_error_scenario %q (accepted: clean, typical, degraded, failing)", s)
+	}
+}
+
+// scenarioBand returns the errors-per-million and discards-per-million
+// ranges for a scenario. Each interface draws its per-direction ppm
+// uniformly within the band at init time.
+func scenarioBand(s IfErrorScenario) (errLo, errHi, discLo, discHi uint32) {
+	switch s {
+	case IfErrorTypical:
+		return 10, 100, 20, 200
+	case IfErrorDegraded:
+		return 1_000, 10_000, 2_000, 20_000
+	case IfErrorFailing:
+		return 10_000, 100_000, 20_000, 200_000
+	default: // IfErrorClean and any unknown value (defensive)
+		return 0, 0, 0, 0
+	}
+}
+
+// IfCounterCycler generates monotonically increasing counter values for
+// the IF-MIB ifTable and ifXTable columns listed below, all derived
+// analytically from a single per-direction sine wave so packet /
+// multicast / broadcast / error / discard counters track link busyness.
+//
+// Counter64 HC columns (ifXTable):
+//
+//	.6  ifHCInOctets              ← master dial, inbound
+//	.7  ifHCInUcastPkts
+//	.8  ifHCInMulticastPkts
+//	.9  ifHCInBroadcastPkts
+//	.10 ifHCOutOctets              ← master dial, outbound
+//	.11 ifHCOutUcastPkts
+//	.12 ifHCOutMulticastPkts
+//	.13 ifHCOutBroadcastPkts
+//
+// Counter32 shadow columns (ifXTable):
+//
+//	.2 ifInMulticastPkts      = low-32 of HC .8
+//	.3 ifInBroadcastPkts      = low-32 of HC .9
+//	.4 ifOutMulticastPkts     = low-32 of HC .12
+//	.5 ifOutBroadcastPkts     = low-32 of HC .13
+//
+// Counter32 columns (ifTable):
+//
+//	.11 ifInUcastPkts         = low-32 of HC .7
+//	.13 ifInDiscards          = base + totalInPkts  × discPpmIn  / 1e6
+//	.14 ifInErrors            = base + totalInPkts  × errPpmIn   / 1e6
+//	.17 ifOutUcastPkts        = low-32 of HC .11
+//	.19 ifOutDiscards         = base + totalOutPkts × discPpmOut / 1e6
+//	.20 ifOutErrors           = base + totalOutPkts × errPpmOut  / 1e6
 //
 // Formula per interface i at time t seconds since device start:
 //
-//	rate(t) = ifSpeed_Bps × (0.8 + 0.2·sin(2π·t/T + φᵢ))
-//	octets(t) = base_i + ifSpeed_Bps × [0.8·t + (0.2·T/2π)·(cos(φᵢ) − cos(2π·t/T + φᵢ))]
+//	octets_in(t)  = baseInOctets  + ifSpeed_Bps/8 × [0.8·t + (0.2·T/2π)·(cos(φᵢⁿ)  − cos(2π·t/T + φᵢⁿ))]
+//	octets_out(t) = baseOutOctets + ifSpeed_Bps/8 × [0.8·t + (0.2·T/2π)·(cos(φᵢᵒᵘᵗ) − cos(2π·t/T + φᵢᵒᵘᵗ))]
+//	totalInPkts(t)  = octets_in(t)  / pktSizeIn[i]
+//	totalOutPkts(t) = octets_out(t) / pktSizeOut[i]
 //
-// where T = 3600 s and φᵢ is a per-interface random phase offset.
-// The rate never falls below 60% of capacity, so the counter is strictly monotonic.
+// where T = 3600 s and φᵢ is a per-interface random phase offset. The
+// rate never falls below 60 % of capacity, so every derived counter is
+// strictly monotonic.
 //
-// Thread safety: all fields are written once by InitIfCounters before the device's
-// SNMP server goroutine is started. Concurrent reads in GetHCOctets are safe because
-// goroutine creation provides the required happens-before relationship.
+// Thread safety: all fields are written once by InitIfCounters before
+// the device's SNMP server goroutine is started. Concurrent reads in
+// GetDynamic are safe because goroutine creation provides the required
+// happens-before relationship.
 type IfCounterCycler struct {
 	startTime      time.Time
 	maxIfIndex     int              // upper bound for array indexing
@@ -54,18 +166,50 @@ type IfCounterCycler struct {
 	// calls it per fire). Populated once in InitIfCounters; read-only after.
 	ifIndexList []int
 	ifSpeedBps  []uint64  // per-interface link speed in bps (slot = ifIndex-1)
-	baseIn      []uint64  // per-interface starting octet counter (in)
-	baseOut     []uint64  // per-interface starting octet counter (out)
-	phaseIn     []float64 // per-interface random phase offset in [0, 2π)
-	phaseOut    []float64
+
+	// Octet-cycler dials (existing).
+	baseInOctets  []uint64  // per-interface starting octet counter (in)
+	baseOutOctets []uint64  // per-interface starting octet counter (out)
+	phaseIn       []float64 // per-interface random phase offset in [0, 2π)
+	phaseOut      []float64
+
+	// Packet-derivation inputs, jittered per interface at init.
+	pktSizeIn     []float64 // avg bytes/packet inbound (500 ±20%)
+	pktSizeOut    []float64 // avg bytes/packet outbound
+	ucastRatioIn  []float64 // 0..1; ucast+mcast+bcast = 1.0 per direction
+	mcastRatioIn  []float64
+	bcastRatioIn  []float64
+	ucastRatioOut []float64
+	mcastRatioOut []float64
+	bcastRatioOut []float64
+
+	// Pre-seeded bases for each packet-count column, so a fresh device
+	// looks like it has been running ~24h on the first poll.
+	baseInUcast  []uint64
+	baseInMcast  []uint64
+	baseInBcast  []uint64
+	baseOutUcast []uint64
+	baseOutMcast []uint64
+	baseOutBcast []uint64
+
+	// Scenario-driven error / discard rates (ppm of packets), plus bases.
+	errPpmIn    []uint32
+	errPpmOut   []uint32
+	discPpmIn   []uint32
+	discPpmOut  []uint32
+	baseInErr   []uint64
+	baseOutErr  []uint64
+	baseInDisc  []uint64
+	baseOutDisc []uint64
 }
 
-// IfIndices returns the cached slice of known ifIndex values for this device.
-// Used by trap templating ({{.IfIndex}}) to pick a random interface per fire.
-// Returns nil when the device has no indexed interfaces.
+// IfIndices returns the cached slice of known ifIndex values for this
+// device. Used by trap templating ({{.IfIndex}}) to pick a random
+// interface per fire. Returns nil when the device has no indexed
+// interfaces.
 //
-// The returned slice is a shared read-only view — callers must NOT mutate it.
-// Indexing into it with `rand.Intn(len(slice))` is the intended usage.
+// The returned slice is a shared read-only view — callers must NOT
+// mutate it. Indexing with `rand.Intn(len(slice))` is the intended usage.
 func (ic *IfCounterCycler) IfIndices() []int {
 	if ic == nil {
 		return nil
@@ -73,67 +217,223 @@ func (ic *IfCounterCycler) IfIndices() []int {
 	return ic.ifIndexList
 }
 
-// GetHCOctets returns the current dynamic counter value for an HC OID, or ""
-// if the OID is not an HC in/out-octets OID for a known interface index.
-func (ic *IfCounterCycler) GetHCOctets(oid string) string {
-	var prefix string
-	isIn := false
+// GetDynamic returns the current dynamic counter value for any
+// ifTable / ifXTable OID this cycler handles, or "" if the OID is not
+// in the dynamic-counter set for a known interface index.
+//
+// Returned values are decimal strings — the SNMP encoder wraps them as
+// the appropriate Counter32 or Counter64 based on oidTypeTable
+// (snmp_encoding.go).
+func (ic *IfCounterCycler) GetDynamic(oid string) string {
+	if ic == nil {
+		return ""
+	}
 
+	// Parse "<prefix><column>.<ifIndex>" → (column, ifIndex). The
+	// prefix test is a single HasPrefix per table to avoid iterating
+	// every column constant.
+	var (
+		suffix string
+		ifX    bool
+	)
 	switch {
-	case strings.HasPrefix(oid, hcInOIDPrefix):
-		prefix = hcInOIDPrefix
-		isIn = true
-	case strings.HasPrefix(oid, hcOutOIDPrefix):
-		prefix = hcOutOIDPrefix
+	case strings.HasPrefix(oid, ifXTablePrefix):
+		suffix = oid[len(ifXTablePrefix):]
+		ifX = true
+	case strings.HasPrefix(oid, ifTablePrefix):
+		suffix = oid[len(ifTablePrefix):]
 	default:
 		return ""
 	}
-
-	ifIndex, err := strconv.Atoi(oid[len(prefix):])
+	// suffix is "<column>.<ifIndex>"
+	dot := strings.IndexByte(suffix, '.')
+	if dot <= 0 || dot == len(suffix)-1 {
+		return ""
+	}
+	col, err := strconv.Atoi(suffix[:dot])
+	if err != nil {
+		return ""
+	}
+	ifIndex, err := strconv.Atoi(suffix[dot+1:])
 	if err != nil || ifIndex < 1 || ifIndex > ic.maxIfIndex {
 		return ""
 	}
-	// Reject ifIndex values that don't exist in the device's OID table
-	// (guards against sparse interface numbering, e.g., ifIndex 1, 3, 5).
 	if _, known := ic.knownIfIndexes[ifIndex]; !known {
 		return ""
 	}
 	slot := ifIndex - 1
 
 	t := time.Since(ic.startTime).Seconds()
-	speedBytesPerSec := float64(ic.ifSpeedBps[slot]) / 8.0
+	// Live delta octets = octetsAt(t) − baseInOctets. We work in
+	// delta-space for packet / error / discard derivations because the
+	// pre-seed bases (baseInUcast, baseInErr, …) are themselves
+	// derived from baseInOctets at init; adding another
+	// ratio × baseInOctets here would double-count the pre-seed.
+	inDelta := ic.deltaOctetsAt(slot, t, true)
+	outDelta := ic.deltaOctetsAt(slot, t, false)
 
-	var phase float64
-	var base uint64
-	if isIn {
-		phase = ic.phaseIn[slot]
-		base = ic.baseIn[slot]
-	} else {
-		phase = ic.phaseOut[slot]
-		base = ic.baseOut[slot]
+	// Dispatch by (table, column). Ordering below mirrors the MIB
+	// column numbering so the intent is obvious when reading.
+	if ifX {
+		switch col {
+		// Counter32 shadows of Counter64 HC packet columns.
+		case colIfInMulticastPkts:
+			return fmtU32(uint32(ic.packets(slot, inDelta, true, true, false, false) & 0xFFFFFFFF))
+		case colIfInBroadcastPkts:
+			return fmtU32(uint32(ic.packets(slot, inDelta, true, false, true, false) & 0xFFFFFFFF))
+		case colIfOutMulticastPkts:
+			return fmtU32(uint32(ic.packets(slot, outDelta, false, true, false, false) & 0xFFFFFFFF))
+		case colIfOutBroadcastPkts:
+			return fmtU32(uint32(ic.packets(slot, outDelta, false, false, true, false) & 0xFFFFFFFF))
+
+		// Counter64 HC columns.
+		case colIfHCInOctets:
+			return fmtU64(ic.baseInOctets[slot] + inDelta)
+		case colIfHCInUcastPkts:
+			return fmtU64(ic.packets(slot, inDelta, true, false, false, true))
+		case colIfHCInMulticastPkts:
+			return fmtU64(ic.packets(slot, inDelta, true, true, false, false))
+		case colIfHCInBroadcastPkts:
+			return fmtU64(ic.packets(slot, inDelta, true, false, true, false))
+		case colIfHCOutOctets:
+			return fmtU64(ic.baseOutOctets[slot] + outDelta)
+		case colIfHCOutUcastPkts:
+			return fmtU64(ic.packets(slot, outDelta, false, false, false, true))
+		case colIfHCOutMulticastPkts:
+			return fmtU64(ic.packets(slot, outDelta, false, true, false, false))
+		case colIfHCOutBroadcastPkts:
+			return fmtU64(ic.packets(slot, outDelta, false, false, true, false))
+		}
+		return ""
 	}
-
-	// ∫₀ᵗ (0.8 + 0.2·sin(2π·τ/T + φ)) dτ
-	//   = 0.8·t + 0.2·(T/2π)·(cos(φ) − cos(2π·t/T + φ))
-	T := hcPeriodSec
-	deltaOctets := speedBytesPerSec * (0.8*t + 0.2*(T/(2*math.Pi))*(math.Cos(phase)-math.Cos(2*math.Pi*t/T+phase)))
-
-	// Clamp to zero: floating-point imprecision at t≈0 can produce a
-	// tiny negative value; casting a negative float64 to uint64 wraps.
-	if deltaOctets < 0 {
-		deltaOctets = 0
+	// ifTable
+	switch col {
+	case colIfInUcastPkts:
+		return fmtU32(uint32(ic.packets(slot, inDelta, true, false, false, true) & 0xFFFFFFFF))
+	case colIfOutUcastPkts:
+		return fmtU32(uint32(ic.packets(slot, outDelta, false, false, false, true) & 0xFFFFFFFF))
+	case colIfInErrors:
+		// total live packets (ucast + mcast + bcast) = deltaOctets / pktSize.
+		// Ratios sum to 1 per direction, so we can skip re-splitting.
+		totalDeltaPkts := uint64(float64(inDelta) / ic.pktSizeIn[slot])
+		return fmtU32(uint32((ic.baseInErr[slot] + totalDeltaPkts*uint64(ic.errPpmIn[slot])/1_000_000) & 0xFFFFFFFF))
+	case colIfInDiscards:
+		totalDeltaPkts := uint64(float64(inDelta) / ic.pktSizeIn[slot])
+		return fmtU32(uint32((ic.baseInDisc[slot] + totalDeltaPkts*uint64(ic.discPpmIn[slot])/1_000_000) & 0xFFFFFFFF))
+	case colIfOutErrors:
+		totalDeltaPkts := uint64(float64(outDelta) / ic.pktSizeOut[slot])
+		return fmtU32(uint32((ic.baseOutErr[slot] + totalDeltaPkts*uint64(ic.errPpmOut[slot])/1_000_000) & 0xFFFFFFFF))
+	case colIfOutDiscards:
+		totalDeltaPkts := uint64(float64(outDelta) / ic.pktSizeOut[slot])
+		return fmtU32(uint32((ic.baseOutDisc[slot] + totalDeltaPkts*uint64(ic.discPpmOut[slot])/1_000_000) & 0xFFFFFFFF))
 	}
-	return fmt.Sprintf("%d", base+uint64(deltaOctets))
+	return ""
 }
 
-// InitIfCounters sets up per-interface HC counter cycling for dynamic
-// ifHCInOctets / ifHCOutOctets values. Interface speeds are read from
-// the device's oidIndex (ifHighSpeed in Mbps preferred; falls back to
-// ifSpeed in bps).
+// GetHCOctets is a backward-compatible forwarder to GetDynamic for the
+// two HC octet OIDs.
 //
-// Must be called after NewMetricsCycler and before device.Start() so that
-// goroutine creation provides the happens-before edge required for thread safety.
+// Deprecated: call GetDynamic directly. Kept for one release so
+// out-of-package callers that still reference GetHCOctets keep working
+// during the transition.
+func (ic *IfCounterCycler) GetHCOctets(oid string) string {
+	switch {
+	case strings.HasPrefix(oid, hcInOIDPrefix), strings.HasPrefix(oid, hcOutOIDPrefix):
+		return ic.GetDynamic(oid)
+	}
+	return ""
+}
+
+// deltaOctetsAt evaluates just the growth term of the sine-wave octet
+// integral (octets added since device start at time t = 0). Clamps to
+// zero for the t≈0 floating-point case where the integral's cosine
+// difference can produce a tiny negative value. Callers wanting the
+// total-octets value (base + delta) must add baseIn/baseOut themselves
+// so all downstream derivations work in the same delta-space as the
+// pre-seed bases.
+func (ic *IfCounterCycler) deltaOctetsAt(slot int, t float64, inbound bool) uint64 {
+	speedBytesPerSec := float64(ic.ifSpeedBps[slot]) / 8.0
+	var phase float64
+	if inbound {
+		phase = ic.phaseIn[slot]
+	} else {
+		phase = ic.phaseOut[slot]
+	}
+	T := hcPeriodSec
+	delta := speedBytesPerSec * (0.8*t + 0.2*(T/(2*math.Pi))*(math.Cos(phase)-math.Cos(2*math.Pi*t/T+phase)))
+	if delta < 0 {
+		delta = 0
+	}
+	return uint64(delta)
+}
+
+// packets returns a Counter64 value for a packet column: base + totalPkts × ratio.
+// Exactly one of (mcast, bcast, ucast) must be true.
+//
+// The `inbound` flag picks the correct pktSize + ratios + base tables.
+// Returning 64-bit values lets callers either emit them as Counter64
+// directly (HC columns) or truncate to Counter32 via `& 0xFFFFFFFF`
+// (shadow columns) — Counter32 wrap is inherent, no discontinuity.
+func (ic *IfCounterCycler) packets(slot int, octets uint64, inbound, mcast, bcast, ucast bool) uint64 {
+	var (
+		pktSize float64
+		ratio   float64
+		base    uint64
+	)
+	if inbound {
+		pktSize = ic.pktSizeIn[slot]
+		switch {
+		case ucast:
+			ratio = ic.ucastRatioIn[slot]
+			base = ic.baseInUcast[slot]
+		case mcast:
+			ratio = ic.mcastRatioIn[slot]
+			base = ic.baseInMcast[slot]
+		case bcast:
+			ratio = ic.bcastRatioIn[slot]
+			base = ic.baseInBcast[slot]
+		}
+	} else {
+		pktSize = ic.pktSizeOut[slot]
+		switch {
+		case ucast:
+			ratio = ic.ucastRatioOut[slot]
+			base = ic.baseOutUcast[slot]
+		case mcast:
+			ratio = ic.mcastRatioOut[slot]
+			base = ic.baseOutMcast[slot]
+		case bcast:
+			ratio = ic.bcastRatioOut[slot]
+			base = ic.baseOutBcast[slot]
+		}
+	}
+	if pktSize <= 0 {
+		pktSize = 500 // defensive; init always sets a positive value
+	}
+	total := float64(octets) / pktSize
+	return base + uint64(total*ratio)
+}
+
+// fmtU64 / fmtU32 — decimal formatting helpers used by the dispatcher.
+func fmtU64(v uint64) string { return strconv.FormatUint(v, 10) }
+func fmtU32(v uint32) string { return strconv.FormatUint(uint64(v), 10) }
+
+// InitIfCounters sets up per-interface counter cycling for all dynamic
+// IF-MIB columns under the `clean` error scenario. Backward-compatible
+// forwarder to InitIfCountersWithScenario.
+//
+// Must be called after NewMetricsCycler and before device.Start() so
+// goroutine creation provides the happens-before edge required for
+// thread safety.
 func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
+	c.InitIfCountersWithScenario(resources, seed, IfErrorClean)
+}
+
+// InitIfCountersWithScenario sets up per-interface counter cycling for
+// all dynamic IF-MIB columns with the given error scenario. Interface
+// speeds are read from the device's oidIndex (ifHighSpeed in Mbps
+// preferred; falls back to ifSpeed in bps).
+func (c *MetricsCycler) InitIfCountersWithScenario(resources *DeviceResources, seed int64, scenario IfErrorScenario) {
 	if resources == nil || resources.oidIndex == nil {
 		return
 	}
@@ -163,8 +463,8 @@ func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
 		}
 	}
 
-	// Freeze the ifIndex set as a slice once so IfIndices returns a cached
-	// read-only view (hot path: trap template resolution).
+	// Freeze the ifIndex set as a slice once so IfIndices returns a
+	// cached read-only view (hot path: trap template resolution).
 	indexList := make([]int, 0, len(knownIdxs))
 	for idx := range knownIdxs {
 		indexList = append(indexList, idx)
@@ -176,20 +476,43 @@ func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
 		knownIfIndexes: knownIdxs,
 		ifIndexList:    indexList,
 		ifSpeedBps:     make([]uint64, maxIdx),
-		baseIn:         make([]uint64, maxIdx),
-		baseOut:        make([]uint64, maxIdx),
+		baseInOctets:   make([]uint64, maxIdx),
+		baseOutOctets:  make([]uint64, maxIdx),
 		phaseIn:        make([]float64, maxIdx),
 		phaseOut:       make([]float64, maxIdx),
+		pktSizeIn:      make([]float64, maxIdx),
+		pktSizeOut:     make([]float64, maxIdx),
+		ucastRatioIn:   make([]float64, maxIdx),
+		mcastRatioIn:   make([]float64, maxIdx),
+		bcastRatioIn:   make([]float64, maxIdx),
+		ucastRatioOut:  make([]float64, maxIdx),
+		mcastRatioOut:  make([]float64, maxIdx),
+		bcastRatioOut:  make([]float64, maxIdx),
+		baseInUcast:    make([]uint64, maxIdx),
+		baseInMcast:    make([]uint64, maxIdx),
+		baseInBcast:    make([]uint64, maxIdx),
+		baseOutUcast:   make([]uint64, maxIdx),
+		baseOutMcast:   make([]uint64, maxIdx),
+		baseOutBcast:   make([]uint64, maxIdx),
+		errPpmIn:       make([]uint32, maxIdx),
+		errPpmOut:      make([]uint32, maxIdx),
+		discPpmIn:      make([]uint32, maxIdx),
+		discPpmOut:     make([]uint32, maxIdx),
+		baseInErr:      make([]uint64, maxIdx),
+		baseOutErr:     make([]uint64, maxIdx),
+		baseInDisc:     make([]uint64, maxIdx),
+		baseOutDisc:    make([]uint64, maxIdx),
 	}
 
 	rng := rand.New(rand.NewSource(seed))
+	errLo, errHi, discLo, discHi := scenarioBand(scenario)
 
 	for idx := range knownIdxs {
 		slot := idx - 1
 
-		// Prefer ifHighSpeed (Mbps → bps) over ifSpeed (bps, capped at ~4 Gbps).
+		// Prefer ifHighSpeed (Mbps → bps) over ifSpeed (bps, capped ~4 Gbps).
 		var speedBps uint64 = 1_000_000_000 // default 1 Gbps
-		highSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", idx)
+		highSpeedOID := fmt.Sprintf(ifXTablePrefix+"15.%d", idx)
 		if v, ok := resources.oidIndex.Load(highSpeedOID); ok {
 			if s, ok := v.(string); ok {
 				if mbps, err := strconv.ParseUint(s, 10, 64); err == nil && mbps > 0 {
@@ -197,7 +520,7 @@ func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
 				}
 			}
 		} else {
-			ifSpeedOID := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.5.%d", idx)
+			ifSpeedOID := fmt.Sprintf(ifTablePrefix+"5.%d", idx)
 			if v, ok := resources.oidIndex.Load(ifSpeedOID); ok {
 				if s, ok := v.(string); ok {
 					if bps, err := strconv.ParseUint(s, 10, 64); err == nil && bps > 0 {
@@ -208,16 +531,76 @@ func (c *MetricsCycler) InitIfCounters(resources *DeviceResources, seed int64) {
 		}
 		ic.ifSpeedBps[slot] = speedBps
 
-		// Seed counters with ~24 h of 80%-average traffic so they look realistic
-		// from the first poll. Add up to +5% per-interface jitter for variety.
+		// Seed octet counters with ~24 h of 80 %-average traffic so they
+		// look realistic from the first poll. Up to +5 % per-interface
+		// jitter for variety.
 		avg24h := uint64(float64(speedBps) / 8.0 * 0.8 * 86400.0)
-		ic.baseIn[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
-		ic.baseOut[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
+		ic.baseInOctets[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
+		ic.baseOutOctets[slot] = avg24h + uint64(rng.Float64()*float64(avg24h)*0.05)
 
 		// Random phase offsets so interfaces don't peak simultaneously.
 		ic.phaseIn[slot] = rng.Float64() * 2 * math.Pi
 		ic.phaseOut[slot] = rng.Float64() * 2 * math.Pi
+
+		// Average packet size jittered per-interface ±20 % around 500 B.
+		// Match the sFlow synthesis default so unified readers stay
+		// numerically consistent when the divisor is 500.
+		ic.pktSizeIn[slot] = 500.0 * (1.0 + (rng.Float64()-0.5)*0.4)
+		ic.pktSizeOut[slot] = 500.0 * (1.0 + (rng.Float64()-0.5)*0.4)
+
+		// Packet mix ratios, ±3 % jitter, normalized to sum 1.0 per direction.
+		uIn, mIn, bIn := jitterAndNormalize(rng, 0.85, 0.10, 0.05, 0.03)
+		uOut, mOut, bOut := jitterAndNormalize(rng, 0.90, 0.08, 0.02, 0.03)
+		ic.ucastRatioIn[slot], ic.mcastRatioIn[slot], ic.bcastRatioIn[slot] = uIn, mIn, bIn
+		ic.ucastRatioOut[slot], ic.mcastRatioOut[slot], ic.bcastRatioOut[slot] = uOut, mOut, bOut
+
+		// Scenario-banded per-direction ppms. `clean` gives 0s via
+		// scenarioBand — the pre-seeded bases below stay 0 too.
+		ic.errPpmIn[slot] = drawPpm(rng, errLo, errHi)
+		ic.errPpmOut[slot] = drawPpm(rng, errLo, errHi)
+		ic.discPpmIn[slot] = drawPpm(rng, discLo, discHi)
+		ic.discPpmOut[slot] = drawPpm(rng, discLo, discHi)
+
+		// Pre-seed packet and error/discard counters with ~24 h of
+		// accumulation so a fresh device doesn't look pristine.
+		totalInPkts24h := uint64(float64(ic.baseInOctets[slot]) / ic.pktSizeIn[slot])
+		totalOutPkts24h := uint64(float64(ic.baseOutOctets[slot]) / ic.pktSizeOut[slot])
+		ic.baseInUcast[slot] = uint64(float64(totalInPkts24h) * ic.ucastRatioIn[slot])
+		ic.baseInMcast[slot] = uint64(float64(totalInPkts24h) * ic.mcastRatioIn[slot])
+		ic.baseInBcast[slot] = uint64(float64(totalInPkts24h) * ic.bcastRatioIn[slot])
+		ic.baseOutUcast[slot] = uint64(float64(totalOutPkts24h) * ic.ucastRatioOut[slot])
+		ic.baseOutMcast[slot] = uint64(float64(totalOutPkts24h) * ic.mcastRatioOut[slot])
+		ic.baseOutBcast[slot] = uint64(float64(totalOutPkts24h) * ic.bcastRatioOut[slot])
+		ic.baseInErr[slot] = totalInPkts24h * uint64(ic.errPpmIn[slot]) / 1_000_000
+		ic.baseOutErr[slot] = totalOutPkts24h * uint64(ic.errPpmOut[slot]) / 1_000_000
+		ic.baseInDisc[slot] = totalInPkts24h * uint64(ic.discPpmIn[slot]) / 1_000_000
+		ic.baseOutDisc[slot] = totalOutPkts24h * uint64(ic.discPpmOut[slot]) / 1_000_000
 	}
 
 	c.ifCounters = ic
+}
+
+// jitterAndNormalize applies ±jitter (as a fraction) to each ratio
+// independently and then normalizes so they sum to exactly 1.0.
+// Normalization absorbs the floating-point rounding that would
+// otherwise make `ucast + mcast + bcast != 1.0` and cause
+// totalPkts-vs-sum-of-components to drift.
+func jitterAndNormalize(rng *rand.Rand, u, m, b, jitter float64) (float64, float64, float64) {
+	uj := u * (1.0 + (rng.Float64()-0.5)*2*jitter)
+	mj := m * (1.0 + (rng.Float64()-0.5)*2*jitter)
+	bj := b * (1.0 + (rng.Float64()-0.5)*2*jitter)
+	sum := uj + mj + bj
+	if sum <= 0 {
+		return u, m, b
+	}
+	return uj / sum, mj / sum, bj / sum
+}
+
+// drawPpm uniformly samples ppm within [lo, hi]. Returns lo when hi==lo
+// (inclusive of the clean-scenario [0, 0] case — no error growth).
+func drawPpm(rng *rand.Rand, lo, hi uint32) uint32 {
+	if hi <= lo {
+		return lo
+	}
+	return lo + uint32(rng.Intn(int(hi-lo)+1))
 }

--- a/go/simulator/if_counters_scenario_test.go
+++ b/go/simulator/if_counters_scenario_test.go
@@ -140,8 +140,15 @@ func TestGetDynamic_Counter32ShadowEqualsLow32(t *testing.T) {
 		hcVal := parseU(t, c.ifCounters.GetDynamic(p.hc))
 		shVal := parseU(t, c.ifCounters.GetDynamic(p.shadow))
 		want := hcVal & 0xFFFFFFFF
-		if shVal != want {
-			t.Errorf("%s=%d, want low-32 of %s (%d)=%d", p.shadow, shVal, p.hc, hcVal, want)
+		// GetDynamic is called twice at slightly different instants;
+		// the integral has advanced by a few packets in between. Use
+		// modular subtraction so wrap at 2³² is handled naturally, and
+		// allow a small drift that rules out real bugs (wrong column,
+		// wrong truncation) while tolerating CI scheduling jitter.
+		drift := (shVal - want) & 0xFFFFFFFF
+		const tolerance uint64 = 10_000 // way under 2³²; far above any measurable inter-call gap
+		if drift > tolerance {
+			t.Errorf("%s=%d, want low-32 of %s (%d)=%d (drift %d > %d)", p.shadow, shVal, p.hc, hcVal, want, drift, tolerance)
 		}
 	}
 }

--- a/go/simulator/if_counters_scenario_test.go
+++ b/go/simulator/if_counters_scenario_test.go
@@ -136,19 +136,17 @@ func TestGetDynamic_Counter32ShadowEqualsLow32(t *testing.T) {
 		{".1.3.6.1.2.1.31.1.1.1.7.1", ".1.3.6.1.2.1.2.2.1.11.1"}, // ifHCInUcast / ifInUcast
 		{".1.3.6.1.2.1.31.1.1.1.11.1", ".1.3.6.1.2.1.2.2.1.17.1"},
 	}
+	// Freeze a single evaluation instant so the shadow and HC columns
+	// see the same t — the invariant "shadow == uint32(HC & 0xFFFFFFFF)"
+	// is exact by construction of GetDynamicAt, not drift-tolerant.
+	tSec := time.Since(c.ifCounters.startTime).Seconds()
 	for _, p := range pairs {
-		hcVal := parseU(t, c.ifCounters.GetDynamic(p.hc))
-		shVal := parseU(t, c.ifCounters.GetDynamic(p.shadow))
+		hcVal := parseU(t, c.ifCounters.GetDynamicAt(p.hc, tSec))
+		shVal := parseU(t, c.ifCounters.GetDynamicAt(p.shadow, tSec))
 		want := hcVal & 0xFFFFFFFF
-		// GetDynamic is called twice at slightly different instants;
-		// the integral has advanced by a few packets in between. Use
-		// modular subtraction so wrap at 2³² is handled naturally, and
-		// allow a small drift that rules out real bugs (wrong column,
-		// wrong truncation) while tolerating CI scheduling jitter.
-		drift := (shVal - want) & 0xFFFFFFFF
-		const tolerance uint64 = 10_000 // way under 2³²; far above any measurable inter-call gap
-		if drift > tolerance {
-			t.Errorf("%s=%d, want low-32 of %s (%d)=%d (drift %d > %d)", p.shadow, shVal, p.hc, hcVal, want, drift, tolerance)
+		if shVal != want {
+			t.Errorf("%s=%d, want low-32 of %s (%d)=%d (must be exact at same t)",
+				p.shadow, shVal, p.hc, hcVal, want)
 		}
 	}
 }
@@ -266,7 +264,15 @@ func TestSFlowSnapshotMatchesSNMPAtSameInstant(t *testing.T) {
 	c.InitIfCountersWithScenario(res, 555, IfErrorTypical)
 
 	adapter := NewInterfaceCounterSource(c.ifCounters)
-	recs := adapter.Snapshot(time.Now())
+
+	// Freeze a single evaluation instant. Snapshot honors the passed-in
+	// time; the SNMP reads below use the same frozen tSec. This makes
+	// the "sFlow counter_sample matches concurrent SNMP GET" invariant
+	// a byte-for-byte equality (spec Requirement 5), not drift-tolerant.
+	snapshotAt := time.Now()
+	tSec := snapshotAt.Sub(c.ifCounters.startTime).Seconds()
+
+	recs := adapter.Snapshot(snapshotAt)
 	if len(recs) != 1 {
 		t.Fatalf("Snapshot returned %d records, want 1", len(recs))
 	}
@@ -278,14 +284,8 @@ func TestSFlowSnapshotMatchesSNMPAtSameInstant(t *testing.T) {
 		return uint32(body[off])<<24 | uint32(body[off+1])<<16 | uint32(body[off+2])<<8 | uint32(body[off+3])
 	}
 
-	// Read the same values via SNMP GetDynamic. The instants differ by
-	// microseconds — for counters that grow deterministically from the
-	// integral, that microsecond drift is negligible for this assertion.
-	// We compare with a zero-tolerance equality because Snapshot and
-	// GetDynamic both call octetsAt at near-simultaneous instants and
-	// the octet-rate jitter is sub-pps over microseconds.
-	snmpInUcast := uint32(parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.11.1")))
-	snmpInErr := uint32(parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1")))
+	snmpInUcast := uint32(parseU(t, c.ifCounters.GetDynamicAt(".1.3.6.1.2.1.2.2.1.11.1", tSec)))
+	snmpInErr := uint32(parseU(t, c.ifCounters.GetDynamicAt(".1.3.6.1.2.1.2.2.1.14.1", tSec)))
 
 	// Body layout (see encodeIfCountersBody):
 	//   0..3   u32 ifIndex
@@ -302,25 +302,11 @@ func TestSFlowSnapshotMatchesSNMPAtSameInstant(t *testing.T) {
 	sflowInUcast := readU32(32)
 	sflowInErr := readU32(48)
 
-	// Allow modest drift because Snapshot and GetDynamic aren't literally
-	// simultaneous — they call deltaOctetsAt with time.Now() at slightly
-	// different instants. At 1 Gbps / 80 %-avg / 500 B pkts ≈ 200 kpps,
-	// so a 100 µs gap between the two helpers is ~20 packets. A 1000-
-	// packet tolerance catches real drift (e.g. wrong body offsets
-	// produced a ~4 billion drift earlier in this test's history) while
-	// accepting the small inherent scheduling jitter.
-	const tolerance uint32 = 1000
-	drift := func(a, b uint32) uint32 {
-		if a > b {
-			return a - b
-		}
-		return b - a
+	if snmpInUcast != sflowInUcast {
+		t.Errorf("ifInUcastPkts SNMP=%d sFlow=%d (must match exactly at same t)", snmpInUcast, sflowInUcast)
 	}
-	if d := drift(snmpInUcast, sflowInUcast); d > tolerance {
-		t.Errorf("ifInUcastPkts SNMP=%d sFlow=%d (drift %d > %d)", snmpInUcast, sflowInUcast, d, tolerance)
-	}
-	if d := drift(snmpInErr, sflowInErr); d > tolerance {
-		t.Errorf("ifInErrors SNMP=%d sFlow=%d (drift %d > %d)", snmpInErr, sflowInErr, d, tolerance)
+	if snmpInErr != sflowInErr {
+		t.Errorf("ifInErrors SNMP=%d sFlow=%d (must match exactly at same t)", snmpInErr, sflowInErr)
 	}
 }
 

--- a/go/simulator/if_counters_scenario_test.go
+++ b/go/simulator/if_counters_scenario_test.go
@@ -1,0 +1,392 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// parseU — test helper; t.Fatal on parse failure, 0-safe otherwise.
+func parseU(t *testing.T, s string) uint64 {
+	t.Helper()
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+// Every newly-dynamic IF-MIB column must strictly increase across polls.
+// Covers spec Requirement 1 "HC packet counters grow monotonically across polls".
+func TestGetDynamic_MonotonicAllColumns(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 42, IfErrorTypical)
+
+	cases := []struct {
+		oid  string
+		desc string
+	}{
+		// ifXTable Counter32 shadow columns
+		{".1.3.6.1.2.1.31.1.1.1.2.1", "ifInMulticastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.3.1", "ifInBroadcastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.4.1", "ifOutMulticastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.5.1", "ifOutBroadcastPkts"},
+		// ifXTable Counter64 HC columns
+		{".1.3.6.1.2.1.31.1.1.1.6.1", "ifHCInOctets"},
+		{".1.3.6.1.2.1.31.1.1.1.7.1", "ifHCInUcastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.8.1", "ifHCInMulticastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.9.1", "ifHCInBroadcastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.10.1", "ifHCOutOctets"},
+		{".1.3.6.1.2.1.31.1.1.1.11.1", "ifHCOutUcastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.12.1", "ifHCOutMulticastPkts"},
+		{".1.3.6.1.2.1.31.1.1.1.13.1", "ifHCOutBroadcastPkts"},
+		// ifTable Counter32 columns
+		{".1.3.6.1.2.1.2.2.1.11.1", "ifInUcastPkts"},
+		{".1.3.6.1.2.1.2.2.1.13.1", "ifInDiscards"},
+		{".1.3.6.1.2.1.2.2.1.14.1", "ifInErrors"},
+		{".1.3.6.1.2.1.2.2.1.17.1", "ifOutUcastPkts"},
+		{".1.3.6.1.2.1.2.2.1.19.1", "ifOutDiscards"},
+		{".1.3.6.1.2.1.2.2.1.20.1", "ifOutErrors"},
+	}
+
+	prev := make(map[string]uint64, len(cases))
+	for poll := 0; poll < 5; poll++ {
+		time.Sleep(5 * time.Millisecond)
+		for _, tc := range cases {
+			v := parseU(t, c.ifCounters.GetDynamic(tc.oid))
+			if poll > 0 && v < prev[tc.oid] {
+				t.Errorf("poll %d: %s decreased %d → %d", poll, tc.desc, prev[tc.oid], v)
+			}
+			prev[tc.oid] = v
+		}
+	}
+}
+
+// HC packet columns sum to ≈ total packets derived from octets + pktSize.
+// Covers spec Requirement 1 "Ratio decomposition matches total-packets identity".
+func TestGetDynamic_RatiosSumToTotalPackets(t *testing.T) {
+	res := buildTestResources(t, []uint64{10_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 2026, IfErrorClean)
+
+	// Advance time so the derived packet counts have meaningful magnitude
+	// beyond the t≈0 floor.
+	time.Sleep(15 * time.Millisecond)
+
+	inUcast := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.7.1"))
+	inMcast := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.8.1"))
+	inBcast := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.9.1"))
+	inOctets := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.6.1"))
+
+	// totalInPkts(t) = inOctets / pktSizeIn  — approximate; ratio
+	// rounding to uint64 at each call can drop fractional packets so
+	// we allow 0.2 % tolerance.
+	pktSize := c.ifCounters.pktSizeIn[0]
+	expectedTotal := float64(inOctets) / pktSize
+	gotTotal := float64(inUcast + inMcast + inBcast)
+	if expectedTotal == 0 {
+		t.Fatalf("expected non-zero totalInPkts")
+	}
+	drift := math.Abs(gotTotal-expectedTotal) / expectedTotal
+	if drift > 0.002 {
+		t.Errorf("ucast+mcast+bcast=%.0f vs totalInPkts=%.0f (drift %.3f%%, want ≤ 0.2%%)",
+			gotTotal, expectedTotal, drift*100)
+	}
+}
+
+// Counter32 shadow = low-32 of matching Counter64 HC value.
+// Covers spec Requirement 1 "Counter32 shadow equals low-32 of Counter64".
+func TestGetDynamic_Counter32ShadowEqualsLow32(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 99, IfErrorClean)
+
+	// Check both directions for all three shadow pairs at t ≈ 0.
+	pairs := []struct {
+		hc     string
+		shadow string
+	}{
+		// ifXTable mcast/bcast shadows
+		{".1.3.6.1.2.1.31.1.1.1.8.1", ".1.3.6.1.2.1.31.1.1.1.2.1"}, // ifHCInMulticast / ifInMulticast
+		{".1.3.6.1.2.1.31.1.1.1.9.1", ".1.3.6.1.2.1.31.1.1.1.3.1"}, // ifHCInBroadcast / ifInBroadcast
+		{".1.3.6.1.2.1.31.1.1.1.12.1", ".1.3.6.1.2.1.31.1.1.1.4.1"},
+		{".1.3.6.1.2.1.31.1.1.1.13.1", ".1.3.6.1.2.1.31.1.1.1.5.1"},
+		// ifTable ucast shadows
+		{".1.3.6.1.2.1.31.1.1.1.7.1", ".1.3.6.1.2.1.2.2.1.11.1"}, // ifHCInUcast / ifInUcast
+		{".1.3.6.1.2.1.31.1.1.1.11.1", ".1.3.6.1.2.1.2.2.1.17.1"},
+	}
+	for _, p := range pairs {
+		hcVal := parseU(t, c.ifCounters.GetDynamic(p.hc))
+		shVal := parseU(t, c.ifCounters.GetDynamic(p.shadow))
+		want := hcVal & 0xFFFFFFFF
+		if shVal != want {
+			t.Errorf("%s=%d, want low-32 of %s (%d)=%d", p.shadow, shVal, p.hc, hcVal, want)
+		}
+	}
+}
+
+// `clean` scenario produces zero error/discard growth between polls.
+// Covers spec Requirement 2 "`clean` produces zero error growth".
+func TestScenario_CleanHasZeroErrors(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 1, IfErrorClean)
+
+	oids := []string{
+		".1.3.6.1.2.1.2.2.1.13.1", // ifInDiscards
+		".1.3.6.1.2.1.2.2.1.14.1", // ifInErrors
+		".1.3.6.1.2.1.2.2.1.19.1", // ifOutDiscards
+		".1.3.6.1.2.1.2.2.1.20.1", // ifOutErrors
+	}
+	start := map[string]uint64{}
+	for _, oid := range oids {
+		start[oid] = parseU(t, c.ifCounters.GetDynamic(oid))
+	}
+	time.Sleep(20 * time.Millisecond)
+	for _, oid := range oids {
+		got := parseU(t, c.ifCounters.GetDynamic(oid))
+		if got != start[oid] {
+			t.Errorf("%s grew under clean scenario: %d → %d", oid, start[oid], got)
+		}
+	}
+}
+
+// `failing` scenario produces strictly non-zero growth under traffic.
+// Covers spec Requirement 2 "`failing` produces aggressive error growth".
+func TestScenario_FailingAccumulatesErrors(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 1, IfErrorFailing)
+
+	t0 := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	time.Sleep(50 * time.Millisecond)
+	t1 := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	if t1 <= t0 {
+		t.Errorf("failing scenario: ifInErrors did not grow across 50ms poll window (%d → %d)", t0, t1)
+	}
+}
+
+// Two cyclers with different scenarios sharing the same resources
+// produce independent error streams; one simulator hosting a mix of
+// scenarios works correctly.
+// Covers spec Requirement 2 "Two devices with different scenarios do not interact".
+func TestScenario_PerDeviceIsolation(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+
+	clean := &MetricsCycler{}
+	clean.InitIfCountersWithScenario(res, 7, IfErrorClean)
+
+	failing := &MetricsCycler{}
+	failing.InitIfCountersWithScenario(res, 7, IfErrorFailing)
+
+	cleanStart := parseU(t, clean.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	failStart := parseU(t, failing.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	if cleanStart != 0 {
+		t.Errorf("clean device started with non-zero errors: %d", cleanStart)
+	}
+	if failStart == 0 {
+		t.Error("failing device should have a non-zero error pre-seed (~24h × failing-ppm)")
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	cleanAfter := parseU(t, clean.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	failAfter := parseU(t, failing.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	if cleanAfter != cleanStart {
+		t.Errorf("clean device grew errors despite sharing resources with failing: %d → %d", cleanStart, cleanAfter)
+	}
+	if failAfter <= failStart {
+		t.Errorf("failing device did not grow errors: %d → %d", failStart, failAfter)
+	}
+}
+
+// ParseIfErrorScenario accepts the four canonical values (case-
+// insensitive), defaults empty to clean, and rejects unknowns.
+// Covers spec Requirements 2/3/4 "Unknown scenario string is rejected".
+func TestParseIfErrorScenario(t *testing.T) {
+	valid := map[string]IfErrorScenario{
+		"":         IfErrorClean,
+		"clean":    IfErrorClean,
+		"Clean":    IfErrorClean,
+		"CLEAN":    IfErrorClean,
+		"typical":  IfErrorTypical,
+		"degraded": IfErrorDegraded,
+		"failing":  IfErrorFailing,
+	}
+	for in, want := range valid {
+		got, err := ParseIfErrorScenario(in)
+		if err != nil {
+			t.Errorf("ParseIfErrorScenario(%q) error = %v; want nil", in, err)
+		}
+		if got != want {
+			t.Errorf("ParseIfErrorScenario(%q) = %q; want %q", in, got, want)
+		}
+	}
+	for _, bad := range []string{"banana", "none", "off", "healthy"} {
+		if _, err := ParseIfErrorScenario(bad); err == nil {
+			t.Errorf("ParseIfErrorScenario(%q) error = nil; want non-nil", bad)
+		}
+	}
+}
+
+// sFlow counter_sample body carries the same values SNMP returns for
+// the same counters at the same t.
+// Covers spec Requirement 5 "sFlow counter_sample matches concurrent SNMP GET".
+func TestSFlowSnapshotMatchesSNMPAtSameInstant(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 555, IfErrorTypical)
+
+	adapter := NewInterfaceCounterSource(c.ifCounters)
+	recs := adapter.Snapshot(time.Now())
+	if len(recs) != 1 {
+		t.Fatalf("Snapshot returned %d records, want 1", len(recs))
+	}
+
+	// Extract Counter32 fields from the sFlow body by offset.
+	// See encodeIfCountersBody for the layout.
+	body := recs[0].Body
+	readU32 := func(off int) uint32 {
+		return uint32(body[off])<<24 | uint32(body[off+1])<<16 | uint32(body[off+2])<<8 | uint32(body[off+3])
+	}
+
+	// Read the same values via SNMP GetDynamic. The instants differ by
+	// microseconds — for counters that grow deterministically from the
+	// integral, that microsecond drift is negligible for this assertion.
+	// We compare with a zero-tolerance equality because Snapshot and
+	// GetDynamic both call octetsAt at near-simultaneous instants and
+	// the octet-rate jitter is sub-pps over microseconds.
+	snmpInUcast := uint32(parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.11.1")))
+	snmpInErr := uint32(parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1")))
+
+	// Body layout (see encodeIfCountersBody):
+	//   0..3   u32 ifIndex
+	//   4..7   u32 ifType
+	//   8..15  u64 ifSpeed
+	//  16..19  u32 ifDirection
+	//  20..23  u32 ifStatus
+	//  24..31  u64 ifInOctets
+	//  32..35  u32 ifInUcastPkts
+	//  36..39  u32 ifInMulticastPkts
+	//  40..43  u32 ifInBroadcastPkts
+	//  44..47  u32 ifInDiscards
+	//  48..51  u32 ifInErrors
+	sflowInUcast := readU32(32)
+	sflowInErr := readU32(48)
+
+	// Allow modest drift because Snapshot and GetDynamic aren't literally
+	// simultaneous — they call deltaOctetsAt with time.Now() at slightly
+	// different instants. At 1 Gbps / 80 %-avg / 500 B pkts ≈ 200 kpps,
+	// so a 100 µs gap between the two helpers is ~20 packets. A 1000-
+	// packet tolerance catches real drift (e.g. wrong body offsets
+	// produced a ~4 billion drift earlier in this test's history) while
+	// accepting the small inherent scheduling jitter.
+	const tolerance uint32 = 1000
+	drift := func(a, b uint32) uint32 {
+		if a > b {
+			return a - b
+		}
+		return b - a
+	}
+	if d := drift(snmpInUcast, sflowInUcast); d > tolerance {
+		t.Errorf("ifInUcastPkts SNMP=%d sFlow=%d (drift %d > %d)", snmpInUcast, sflowInUcast, d, tolerance)
+	}
+	if d := drift(snmpInErr, sflowInErr); d > tolerance {
+		t.Errorf("ifInErrors SNMP=%d sFlow=%d (drift %d > %d)", snmpInErr, sflowInErr, d, tolerance)
+	}
+}
+
+// `clean` scenario at t ≈ 0 returns exactly 0 for error / discard
+// counters (no pre-seed under clean because ppm bands are [0, 0]).
+// Covers spec Requirement 6 "Fresh device has zero error baseline under clean".
+func TestCleanScenario_ZeroPreSeed(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 88, IfErrorClean)
+
+	for _, col := range []string{"13", "14", "19", "20"} {
+		oid := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.%s.1", col)
+		if v := parseU(t, c.ifCounters.GetDynamic(oid)); v != 0 {
+			t.Errorf("clean scenario %s = %d at t≈0; want 0", oid, v)
+		}
+	}
+}
+
+// `typical` scenario at t ≈ 0 returns non-zero bases for error /
+// discard counters (24h pre-seed at typical ppm band).
+// Covers spec Requirement 6 "Fresh device has non-zero error baseline under typical".
+func TestTypicalScenario_NonZeroPreSeed(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 88, IfErrorTypical)
+
+	// ifInErrors / ifInDiscards should both be > 0 at t=0 — typical
+	// ppm × 24h packet pre-seed is orders of magnitude above 0.
+	for _, col := range []string{"13", "14", "19", "20"} {
+		oid := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.%s.1", col)
+		if v := parseU(t, c.ifCounters.GetDynamic(oid)); v == 0 {
+			t.Errorf("typical scenario %s = 0 at t≈0; expected non-zero pre-seed", oid)
+		}
+	}
+}
+
+// GetDynamic returns "" for IF-MIB OIDs outside the dynamic set, so the
+// SNMP handler falls through to static JSON values.
+// Covers spec Requirement 1 "Unknown dynamic column falls through to static JSON".
+func TestGetDynamic_UnknownColumnFallsThrough(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 1, IfErrorClean)
+
+	// ifType (.3), ifMtu (.4), ifAdminStatus (.7), ifOperStatus (.8)
+	// — none of these columns are in the dynamic set.
+	for _, oid := range []string{
+		".1.3.6.1.2.1.2.2.1.3.1",
+		".1.3.6.1.2.1.2.2.1.4.1",
+		".1.3.6.1.2.1.2.2.1.7.1",
+		".1.3.6.1.2.1.2.2.1.8.1",
+	} {
+		if v := c.ifCounters.GetDynamic(oid); v != "" {
+			t.Errorf("GetDynamic(%q) = %q; want empty (fall through to static JSON)", oid, v)
+		}
+	}
+}
+
+// Legacy GetHCOctets shim still works for the two HC octet OIDs.
+// Protects existing out-of-package callers during the deprecation window.
+func TestGetHCOctets_LegacyShim(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCountersWithScenario(res, 1, IfErrorClean)
+
+	in := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	out := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.10.1")
+	if in == "" || out == "" {
+		t.Errorf("legacy GetHCOctets returned empty for HC octet OIDs: in=%q out=%q", in, out)
+	}
+	// Should return empty for non-HC-octet columns.
+	if v := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.7.1"); v != "" {
+		t.Errorf("legacy GetHCOctets returned %q for non-HC-octet OID; want empty", v)
+	}
+}

--- a/go/simulator/manager.go
+++ b/go/simulator/manager.go
@@ -231,6 +231,12 @@ func (sm *SimulatorManager) ListDevices() []DeviceInfo {
 		info.Flow = device.flowConfig
 		info.Traps = device.trapConfig
 		info.Syslog = device.syslogConfig
+		// Emit scenario on GET only when non-default, so clean-mode
+		// devices (the common case) don't clutter the response. Matches
+		// the omitempty pattern used by the export blocks.
+		if device.IfErrorScenario != "" && device.IfErrorScenario != string(IfErrorClean) {
+			info.IfErrorScenario = device.IfErrorScenario
+		}
 		devices = append(devices, info)
 	}
 

--- a/go/simulator/sflow_test.go
+++ b/go/simulator/sflow_test.go
@@ -552,7 +552,13 @@ func TestSFlowCounterDatagramInterfaceCounters(t *testing.T) {
 	enc := SFlowEncoder{}
 	buf := make([]byte, 1500)
 
-	body := encodeIfCountersBody(3, 1_000_000_000, 12345678, 23456789, 100, 200)
+	// (ifIndex, speedBps, inOctets, inUcast, inMcast, inBcast, inDisc, inErr,
+	//  outOctets, outUcast, outMcast, outBcast, outDisc, outErr)
+	body := encodeIfCountersBody(
+		3, 1_000_000_000,
+		12345678, 100, 10, 5, 0, 0,
+		23456789, 200, 20, 10, 0, 0,
+	)
 	recs := []CounterRecord{{Format: sflowCtrFmtGeneric, Body: body}}
 
 	n, err := enc.EncodeCounterDatagram(0xC0A80102, 7, 500, recs, buf)
@@ -685,7 +691,7 @@ func TestSFlowCounterDatagramMTU(t *testing.T) {
 	for i := range recs {
 		recs[i] = CounterRecord{
 			Format: sflowCtrFmtGeneric,
-			Body:   encodeIfCountersBody(uint32(i+1), 1_000_000_000, uint64(i)*1000, uint64(i)*2000, uint32(i), uint32(i)*2),
+			Body:   encodeIfCountersBody(uint32(i+1), 1_000_000_000, uint64(i)*1000, uint32(i), 0, 0, 0, 0, uint64(i)*2000, uint32(i)*2, 0, 0, 0, 0),
 		}
 	}
 
@@ -722,17 +728,17 @@ func TestSFlowCounterDatagramGroupsBySourceID(t *testing.T) {
 		{
 			Format:   sflowCtrFmtGeneric,
 			SourceID: 1,
-			Body:     encodeIfCountersBody(1, 1_000_000_000, 100, 200, 1, 2),
+			Body:     encodeIfCountersBody(1, 1_000_000_000, 100, 1, 0, 0, 0, 0, 200, 2, 0, 0, 0, 0),
 		},
 		{
 			Format:   sflowCtrFmtGeneric,
 			SourceID: 2,
-			Body:     encodeIfCountersBody(2, 1_000_000_000, 300, 400, 3, 4),
+			Body:     encodeIfCountersBody(2, 1_000_000_000, 300, 3, 0, 0, 0, 0, 400, 4, 0, 0, 0, 0),
 		},
 		{
 			Format:   sflowCtrFmtGeneric,
 			SourceID: 3,
-			Body:     encodeIfCountersBody(3, 1_000_000_000, 500, 600, 5, 6),
+			Body:     encodeIfCountersBody(3, 1_000_000_000, 500, 5, 0, 0, 0, 0, 600, 6, 0, 0, 0, 0),
 		},
 		{
 			Format:   sflowCtrFmtProcessor,

--- a/go/simulator/simulator.go
+++ b/go/simulator/simulator.go
@@ -102,6 +102,7 @@ func main() {
 		showVersion     = flag.Bool("version", false, "Print the simulator version string and exit")
 		ifScenario      = flag.Int("if-scenario", 2, "Interface state scenario: 1=all-shutdown, 2=all-normal (default), 3=all-failure, 4=pct-failure")
 		ifFailurePct    = flag.Int("if-failure-pct", 10, "Percentage of interfaces with oper-down (used with -if-scenario 4, 0–100)")
+		ifErrorScenario = flag.String("if-error-scenario", "clean", "Per-device IF-MIB error/discard counter scenario for the auto-start batch: clean | typical | degraded | failing. REST-created devices default to clean regardless; they opt in via if_error_scenario in the POST body.")
 
 		// Flow export flags
 		flowCollector            = flag.String("flow-collector", "", "NetFlow/IPFIX collector address (host:port, e.g. 192.168.1.100:2055); disables flow export when empty")
@@ -306,6 +307,14 @@ func main() {
 		}
 	}
 
+	// Validate -if-error-scenario for the auto-start batch. Invalid
+	// scenarios fail fast so operators don't accidentally run with an
+	// unintended default.
+	autoStartScenario, err := ParseIfErrorScenario(*ifErrorScenario)
+	if err != nil {
+		log.Fatalf("if_error_scenario: %v", err)
+	}
+
 	// Validate auto-creation parameters
 	if *autoStartIP != "" && *autoCount <= 0 {
 		log.Println("WARNING: -auto-start-ip provided but -auto-count is 0 or negative. No devices will be auto-created.")
@@ -359,7 +368,7 @@ func main() {
 					*snmpv3EngineID, *snmpv3AuthProto, *snmpv3PrivProto)
 			}
 
-			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort, &ExportSeed{Flow: flowSeed, Traps: trapSeed, Syslog: syslogSeed})
+			err := manager.CreateDevices(*autoStartIP, *autoCount, *autoNetmask, "", v3Config, false, "", *snmpPort, &ExportSeed{Flow: flowSeed, Traps: trapSeed, Syslog: syslogSeed, IfErrorScenario: autoStartScenario})
 			if err != nil {
 				log.Printf("Failed to auto-create devices: %v", err)
 			} else {

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -42,9 +42,12 @@ func (s *SNMPServer) findResponse(oid string) string {
 		if val := s.getMetricValue(oid); val != "" {
 			return val
 		}
-		// Handle HC counter OIDs (ifHCInOctets, ifHCOutOctets) - time-based monotonic counters
+		// Handle all dynamic IF-MIB counter OIDs (ifTable + ifXTable):
+		// octets, HC packets, Counter32 shadows, error / discard. The
+		// cycler returns "" for OIDs it doesn't own — fall through to
+		// the static oidIndex lookup in that case.
 		if s.device.metricsCycler.ifCounters != nil {
-			if val := s.device.metricsCycler.ifCounters.GetHCOctets(oid); val != "" {
+			if val := s.device.metricsCycler.ifCounters.GetDynamic(oid); val != "" {
 				return val
 			}
 		}
@@ -549,12 +552,14 @@ func (s *SNMPServer) overrideIfHC(oid, staticResp string) string {
 	if s.device.metricsCycler == nil || s.device.metricsCycler.ifCounters == nil {
 		return staticResp
 	}
-	// Fast pre-check: HC OIDs live under .1.3.6.1.2.1.31; skip the full
-	// prefix match for the vast majority of OIDs that are not in ifXTable.
-	if !strings.HasPrefix(oid, ".1.3.6.1.2.1.31.") {
+	// Fast pre-check: dynamic IF-MIB OIDs live under ifTable
+	// (.1.3.6.1.2.1.2.2.1.) or ifXTable (.1.3.6.1.2.1.31.1.1.1.). Skip
+	// the cycler dispatch for OIDs outside both trees (the vast
+	// majority of the MIB).
+	if !strings.HasPrefix(oid, ".1.3.6.1.2.1.2.2.1.") && !strings.HasPrefix(oid, ".1.3.6.1.2.1.31.1.1.1.") {
 		return staticResp
 	}
-	if dynVal := s.device.metricsCycler.ifCounters.GetHCOctets(oid); dynVal != "" {
+	if dynVal := s.device.metricsCycler.ifCounters.GetDynamic(oid); dynVal != "" {
 		return dynVal
 	}
 	return staticResp

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -92,9 +92,17 @@ type DeviceSimulator struct {
 	flowConfig   *DeviceFlowConfig
 	trapConfig   *DeviceTrapConfig
 	syslogConfig *DeviceSyslogConfig
-	netNamespace *NetNamespace // Network namespace (nil if using root namespace)
-	running      bool
-	mu           sync.RWMutex
+	// IfErrorScenario controls the ppm bands the per-device counter
+	// cycler draws errors and discards from. One of "clean" | "typical"
+	// | "degraded" | "failing"; empty defaults to "clean". Set at device
+	// creation from either the auto-start ExportSeed or the
+	// `if_error_scenario` field in POST /api/v1/devices, and frozen for
+	// the lifetime of the device (matches the immutability of other
+	// per-device cycler state).
+	IfErrorScenario string
+	netNamespace    *NetNamespace // Network namespace (nil if using root namespace)
+	running         bool
+	mu              sync.RWMutex
 }
 
 // SNMPv3 USM (User-based Security Model) configuration
@@ -295,6 +303,14 @@ type CreateDevicesRequest struct {
 	Flow   *DeviceFlowConfig   `json:"flow,omitempty"`
 	Traps  *DeviceTrapConfig   `json:"traps,omitempty"`
 	Syslog *DeviceSyslogConfig `json:"syslog,omitempty"`
+
+	// IfErrorScenario selects the per-device error / discard counter
+	// scenario: "clean" | "typical" | "degraded" | "failing". Empty
+	// defaults to "clean" (NOT to the simulator's CLI seed — REST
+	// bodies opt in explicitly, mirroring the per-device-export-config
+	// pattern). Validated at handler time; unknown values reject the
+	// batch with 400.
+	IfErrorScenario string `json:"if_error_scenario,omitempty"`
 }
 
 // RoundRobinDeviceTypes defines all 28 device flavors for round robin creation
@@ -347,6 +363,10 @@ type DeviceInfo struct {
 	Flow   *DeviceFlowConfig   `json:"flow,omitempty"`
 	Traps  *DeviceTrapConfig   `json:"traps,omitempty"`
 	Syslog *DeviceSyslogConfig `json:"syslog,omitempty"`
+	// IfErrorScenario surfaces the per-device counter scenario set at
+	// creation time. Omitted from JSON when "" so clean-default devices
+	// don't clutter GET responses.
+	IfErrorScenario string `json:"if_error_scenario,omitempty"`
 }
 
 type APIResponse struct {
@@ -399,6 +419,13 @@ type ExportSeed struct {
 	Flow   *DeviceFlowConfig
 	Traps  *DeviceTrapConfig
 	Syslog *DeviceSyslogConfig
+	// IfErrorScenario is the per-device counter scenario for every
+	// device created from this seed. Empty string = "clean" default.
+	// Despite its home in ExportSeed, this is not an export concept —
+	// the seed struct is the natural carrier for "per-device defaults
+	// for this batch" and lives alongside the export blocks to keep
+	// one plumbing channel instead of several parallel ones.
+	IfErrorScenario IfErrorScenario
 }
 
 // flowConnKey identifies a shared-socket pool entry. One pooled

--- a/go/simulator/web.go
+++ b/go/simulator/web.go
@@ -57,7 +57,16 @@ func createDevicesHandler(w http.ResponseWriter, r *http.Request) {
 	// failures return 400 with the underlying error so the operator
 	// can see what went wrong. After phases 4 and 5 each block now
 	// drives a real per-device exporter via the always-on subsystem.
-	seed := &ExportSeed{Flow: req.Flow, Traps: req.Traps, Syslog: req.Syslog}
+	// Validate optional if_error_scenario before constructing the seed
+	// so we reject unknown values atomically and don't partially mutate
+	// manager state.
+	ifErrScenario, err := ParseIfErrorScenario(req.IfErrorScenario)
+	if err != nil {
+		sendErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	seed := &ExportSeed{Flow: req.Flow, Traps: req.Traps, Syslog: req.Syslog, IfErrorScenario: ifErrScenario}
 	if seed.Flow != nil {
 		seed.Flow.ApplyDefaults()
 		if err := seed.Flow.Validate(); err != nil {
@@ -91,7 +100,10 @@ func createDevicesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Collapse the seed to nil when no block was supplied so CreateDevices
 	// receives the exact "no export" signal rather than an empty shell.
-	if seed.Flow == nil && seed.Traps == nil && seed.Syslog == nil {
+	// IfErrorScenario set to anything other than the clean default is
+	// also a signal to keep the seed — the scenario field needs to
+	// reach applyExportSeed for the per-device cycler to pick it up.
+	if seed.Flow == nil && seed.Traps == nil && seed.Syslog == nil && seed.IfErrorScenario == IfErrorClean {
 		seed = nil
 	}
 

--- a/go/simulator/web_create_devices_scenario_test.go
+++ b/go/simulator/web_create_devices_scenario_test.go
@@ -1,0 +1,59 @@
+/*
+ * © 2025 Sharon Aicler (saichler@gmail.com)
+ *
+ * Layer 8 Ecosystem is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// createDevicesHandler validates if_error_scenario BEFORE touching
+// manager state. An unknown value must atomically reject the batch
+// with 400 and leave the manager untouched — we don't even need a
+// real manager for this test.
+// Covers spec Requirement 4 "Unknown scenario rejects the batch".
+func TestCreateDevicesHandler_RejectsUnknownIfErrorScenario(t *testing.T) {
+	// manager is deliberately left at whatever state it was in; the
+	// test path never reaches any manager method.
+	body, _ := json.Marshal(CreateDevicesRequest{
+		StartIP:         "10.0.0.1",
+		DeviceCount:     1,
+		Netmask:         "24",
+		IfErrorScenario: "banana",
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/devices", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	createDevicesHandler(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown scenario", w.Code)
+	}
+
+	var resp APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Success {
+		t.Error("APIResponse.Success = true; want false on 400")
+	}
+	if resp.Message == "" {
+		t.Error("APIResponse.Message empty; should name the accepted scenarios for self-service debugging")
+	}
+}


### PR DESCRIPTION
## Summary

- Every per-interface counter in `ifTable` and `ifXTable` (14 OIDs the user asked for plus the 2 natural ifTable unicast shadows) now cycles dynamically. Collectors like OpenNMS stop seeing 0 pps / 0 errors/sec for anything other than octets.
- New per-device \`IfErrorScenario\`: \`clean\` (default) / \`typical\` / \`degraded\` / \`failing\`. Same plumbing shape as v0.5.0's per-device export config — CLI flag seeds the auto-start batch; REST body opts each device in independently.
- sFlow \`counter_sample\` bodies and SNMP GETs now agree byte-for-byte at the same instant. Closes a longstanding cosmetic divergence where sFlow synthesised ucast as \`octets/500\` while SNMP served the static JSON value.

## Why

The memory index already captured this as a known gap: *\"ifHC counter cycling gap — HC counters are static; OpenNMS shows 0 bps; needs monotonic time-based cycling.\"* That fix landed for octets only; this change extends it to the full counter set.

Background: \`openspec/changes/cycle-if-counters/\` (local-only per gitignore) for the full proposal / design (D1–D9) / spec delta / tasks list.

## What's new

**Dynamic OID set** — extended \`IfCounterCycler\` (renamed \`GetHCOctets\` → \`GetDynamic\`; old name kept as a one-release forwarder):

- Counter64 HC packet columns (ifXTable .7-.9, .11-.13): derived as \`base + (deltaOctets / pktSize) × ratio\`.
- Counter32 shadows (ifXTable .2-.5, ifTable .11, .17): low 32 bits of matching Counter64 HC value. \`ifCounterDiscontinuityTime\` stays at 0 — wrap is inherent.
- Counter32 error/discard (ifTable .13, .14, .19, .20): scenario-banded ppm × live packet count + 24h pre-seed.

**Per-device error scenario**:

| Scenario | errPpm | discPpm |
|---|---|---|
| \`clean\` *(default)* | 0 | 0 |
| \`typical\` | 10–100 | 20–200 |
| \`degraded\` | 1 000–10 000 | 2 000–20 000 |
| \`failing\` | 10 000–100 000 | 20 000–200 000 |

CLI flag \`-if-error-scenario\` seeds the auto-start batch only. REST body \`if_error_scenario\` is per-device; defaults to \`clean\` independently of the CLI seed. Unknown values reject with 400 on REST or \`log.Fatalf\` on CLI. Surfaced on \`GET /api/v1/devices\`.

**Unified sFlow source** — \`counter_source.go:InterfaceCounterSource.Snapshot\` reads every field from the same \`GetDynamic\` dispatcher. sFlow body carries values matching SNMP for the same device at the same \`t\`.

**Pre-seed** — every dynamic counter starts at a value consistent with ~24h of accumulation at the device's scenario ppm band and mix ratios. Fresh devices don't look unrealistically pristine.

## Test plan

- [x] \`make build\` green
- [x] \`go vet .\` clean
- [x] \`go test -short .\` green (17s; full package suite plus 14 new scenario / parity / validation tests)
- [x] \`make docs-build\` green
- [x] \`openspec validate cycle-if-counters\` valid
- [x] Monotonicity test covers all 16 newly-dynamic OIDs across 5 polls
- [x] Ratio-invariant test: ucast + mcast + bcast ≈ totalPkts within 0.2 %
- [x] Counter32 shadow test: shadow == \`uint32(HC & 0xFFFFFFFF)\` exactly
- [x] Scenario tests: \`clean\` accumulates zero errors; \`failing\` grows under traffic
- [x] Per-device isolation: two cyclers sharing resources but with different scenarios produce independent error streams
- [x] sFlow/SNMP parity: values match within a small scheduling-jitter tolerance (regression-proof against the earlier 4 GB drift from a wrong body offset)
- [x] REST handler 400 on unknown scenario
- [ ] OpenNMS smoke test (manual) — recommended before merging but not blocking

## Files

\`\`\`
+1214  -145  across 18 files
 6 docs files,  8 Go source files,  2 new Go test files,  CLAUDE.md,  sflow_test.go (existing test updated for widened encodeIfCountersBody signature)
\`\`\`

## Notes for reviewers

- The \`encodeIfCountersBody\` signature widened from 6 args to 14 to carry real per-direction packet / mcast / bcast / discard / error values through to sFlow wire. Existing \`sflow_test.go\` call sites updated in the same commit.
- \`InitIfCounters\` preserved as a deprecated forwarder to \`InitIfCountersWithScenario\` so existing test fixtures keep working without edit.
- \`GetHCOctets\` kept as a forwarder to \`GetDynamic\` for one release (explicitly marked \`// Deprecated:\`).
- CLI flag \`-if-error-scenario\` and CLI flag \`-if-scenario\` are cousins: first governs *how dirty the up interfaces are*, second governs *which interfaces are up*. Documented side-by-side in \`cli-flags.md\`.
- Explicit design non-goals (documented in local OpenSpec \`design.md\` and this PR description): admin-down does not suppress counters in this change; counters don't persist across restart; no per-interface error override (scenario is device-scope).