### PR TITLE
docs: sync README + landing for v0.5.1 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ network namespaces.
   [SNMP reference](https://labmonkeys-space.github.io/l8opensim/reference/snmp/)
   and [Web API](https://labmonkeys-space.github.io/l8opensim/reference/web-api/).
 - **Realistic dynamic metrics:** CPU / memory / temperature on 100-point
-  sine waves, analytic HC interface counters, per-GPU DCGM metrics — see
-  [GPU simulation](https://labmonkeys-space.github.io/l8opensim/reference/gpu/).
+  sine waves; full IF-MIB counter cycling (octets plus per-direction
+  unicast / multicast / broadcast packet counts, errors, discards) with
+  per-device error-scenario tuning (`clean` / `typical` / `degraded` /
+  `failing`); per-GPU DCGM metrics — see
+  [SNMP reference → Dynamic IF-MIB counters](https://labmonkeys-space.github.io/l8opensim/reference/snmp/#dynamic-if-mib-counters)
+  and [GPU simulation](https://labmonkeys-space.github.io/l8opensim/reference/gpu/).
+- **Self-reporting version:** `./simulator -version`, `GET /api/v1/version`,
+  and a hero-kicker `(vX.Y.Z)` in the web UI all report the running build
+  — no source checkout needed to identify a deployed simulator.
 - **Per-device flow export** (NetFlow v5 / v9, IPFIX, sFlow v5) with
   per-device source IPs — see
   [Flow export](https://labmonkeys-space.github.io/l8opensim/ops/flow-export/).

--- a/src/components/Landing/data.ts
+++ b/src/components/Landing/data.ts
@@ -16,7 +16,7 @@ export const FEATURES: Feature[] = [
   { icon: 'devices', title: '28 device types', body: 'Routers, switches, firewalls, servers, GPU servers (DGX/HGX), storage systems, Linux servers — across 8 categories.' },
   { icon: 'gpu', title: 'GPU simulation', body: 'NVIDIA DGX-A100 / H100 / HGX-H200 with per-GPU DCGM OIDs — utilization, VRAM, temp, power, fan, SM/memory clocks.' },
   { icon: 'isol', title: 'Namespace isolation', body: 'Each device runs in the dedicated opensim network namespace with its own TUN interface and IP.' },
-  { icon: 'metric', title: 'Dynamic metrics', body: '100-point pre-generated sine-wave cycling for CPU, memory, temperature — correlated across related metrics.' },
+  { icon: 'metric', title: 'Dynamic metrics', body: '100-point sine-wave cycling for CPU, memory, temperature; full IF-MIB counter set (octets, ucast / mcast / bcast packets, errors, discards) with per-device error scenarios; per-GPU DCGM OIDs.' },
 ];
 
 export const CATEGORIES: Category[] = [


### PR DESCRIPTION
## Summary

- README Highlights now describes the **full IF-MIB counter cycling** shipped in PR #140 (not just "analytic HC counters") and the per-device `if_error_scenario` tuning knob.
- README gains a Highlights bullet for the **simulator self-reporting version** surface shipped in PR #139 — `./simulator -version`, `GET /api/v1/version`, and the hero-kicker (previously undocumented in README).
- Landing page `Dynamic metrics` feature card updated to match.

## Why

Before tagging v0.5.1, the top-level discovery surfaces (README Highlights + landing page feature cards) should reflect what the last two releases actually added. Reference docs (`docs/reference/snmp.md`, `cli-flags.md`, `web-api.md`, `CLAUDE.md`) were already updated in the PRs that shipped the features; only the top-level marketing surfaces had drifted.

## What changed

- `README.md` — expanded "Realistic dynamic metrics" bullet + new "Self-reporting version" bullet in Highlights.
- `src/components/Landing/data.ts` — expanded the \"Dynamic metrics\" feature card body.

## Explicitly out of scope

The pre-existing \"Layer 8 overlay\" line in \`STATUS.Experimental\` (landing page) is tracked by the open \`cleanup-stale-l8-refs\` OpenSpec change and will ship on its own cadence.

## Test plan

- [x] \`make docs-build\` green
- [x] README anchors verified against \`docs/reference/snmp.md#dynamic-if-mib-counters\` (renamed in PR #140; anchor resolves)
- [ ] Spot-check rendered landing page locally via \`make docs-serve\` before merging if you want to eyeball the card copy