### PR TITLE
fix(snmp): walk dynamic ifTable/ifXTable counter columns without static rows

### DIFF
--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,18 +41,18 @@ const (
 // ifXTable and ifTable column numbers handled dynamically.
 const (
 	// ifXTable (.1.3.6.1.2.1.31.1.1.1.X)
-	colIfInMulticastPkts     = 2
-	colIfInBroadcastPkts     = 3
-	colIfOutMulticastPkts    = 4
-	colIfOutBroadcastPkts    = 5
-	colIfHCInOctets          = 6
-	colIfHCInUcastPkts       = 7
-	colIfHCInMulticastPkts   = 8
-	colIfHCInBroadcastPkts   = 9
-	colIfHCOutOctets         = 10
-	colIfHCOutUcastPkts      = 11
-	colIfHCOutMulticastPkts  = 12
-	colIfHCOutBroadcastPkts  = 13
+	colIfInMulticastPkts    = 2
+	colIfInBroadcastPkts    = 3
+	colIfOutMulticastPkts   = 4
+	colIfOutBroadcastPkts   = 5
+	colIfHCInOctets         = 6
+	colIfHCInUcastPkts      = 7
+	colIfHCInMulticastPkts  = 8
+	colIfHCInBroadcastPkts  = 9
+	colIfHCOutOctets        = 10
+	colIfHCOutUcastPkts     = 11
+	colIfHCOutMulticastPkts = 12
+	colIfHCOutBroadcastPkts = 13
 
 	// ifTable (.1.3.6.1.2.1.2.2.1.X)
 	colIfInUcastPkts  = 11
@@ -61,6 +62,35 @@ const (
 	colIfOutDiscards  = 19
 	colIfOutErrors    = 20
 )
+
+// ifCyclerColumns lists every (table, column) pair the cycler owns, in
+// strict MIB lex order. Walk enumeration (NextDynamicOID) iterates this
+// list, and ordering must match compareOIDs — the 7th sub-identifier
+// puts ifTable (2.2.1) strictly before ifXTable (31.1.1.1) numerically,
+// and within each table the column numbers are ascending.
+var ifCyclerColumns = []struct {
+	prefix string
+	col    int
+}{
+	{ifTablePrefix, colIfInUcastPkts},         // .11
+	{ifTablePrefix, colIfInDiscards},          // .13
+	{ifTablePrefix, colIfInErrors},            // .14
+	{ifTablePrefix, colIfOutUcastPkts},        // .17
+	{ifTablePrefix, colIfOutDiscards},         // .19
+	{ifTablePrefix, colIfOutErrors},           // .20
+	{ifXTablePrefix, colIfInMulticastPkts},    // .2
+	{ifXTablePrefix, colIfInBroadcastPkts},    // .3
+	{ifXTablePrefix, colIfOutMulticastPkts},   // .4
+	{ifXTablePrefix, colIfOutBroadcastPkts},   // .5
+	{ifXTablePrefix, colIfHCInOctets},         // .6
+	{ifXTablePrefix, colIfHCInUcastPkts},      // .7
+	{ifXTablePrefix, colIfHCInMulticastPkts},  // .8
+	{ifXTablePrefix, colIfHCInBroadcastPkts},  // .9
+	{ifXTablePrefix, colIfHCOutOctets},        // .10
+	{ifXTablePrefix, colIfHCOutUcastPkts},     // .11
+	{ifXTablePrefix, colIfHCOutMulticastPkts}, // .12
+	{ifXTablePrefix, colIfHCOutBroadcastPkts}, // .13
+}
 
 // IfErrorScenario controls per-device error / discard counter behavior.
 // Scenarios scale the errors-per-million (errPpm) and discards-per-million
@@ -165,7 +195,15 @@ type IfCounterCycler struct {
 	// allocation-free on the hot path (trap varbind template resolution
 	// calls it per fire). Populated once in InitIfCounters; read-only after.
 	ifIndexList []int
-	ifSpeedBps  []uint64  // per-interface link speed in bps (slot = ifIndex-1)
+	// sortedIfIndexes is ifIndexList sorted ascending — required so
+	// NextDynamicOID emits rows in MIB lex order during SNMP walks.
+	sortedIfIndexes []int
+	// firstDynOID / lastDynOID bracket the entire set of OIDs this
+	// cycler owns. findNextOID uses them to decide whether the static
+	// "next OID" fast path is safe without scanning every cycler row.
+	firstDynOID string
+	lastDynOID  string
+	ifSpeedBps  []uint64 // per-interface link speed in bps (slot = ifIndex-1)
 
 	// Octet-cycler dials (existing).
 	baseInOctets  []uint64  // per-interface starting octet counter (in)
@@ -348,6 +386,51 @@ func (ic *IfCounterCycler) GetDynamicAt(oid string, t float64) string {
 	return ""
 }
 
+// FirstDynamicOID returns the smallest OID this cycler owns. Empty
+// string when the cycler has no rows.
+func (ic *IfCounterCycler) FirstDynamicOID() string {
+	if ic == nil {
+		return ""
+	}
+	return ic.firstDynOID
+}
+
+// LastDynamicOID returns the largest OID this cycler owns. Empty string
+// when the cycler has no rows.
+func (ic *IfCounterCycler) LastDynamicOID() string {
+	if ic == nil {
+		return ""
+	}
+	return ic.lastDynOID
+}
+
+// NextDynamicOID returns the next (oid, value) pair the cycler owns that
+// is strictly greater than currentOID in MIB lex order. Returns ("", "")
+// when currentOID is at or past the last dynamic row.
+//
+// This is the walk counterpart to GetDynamic — without it, snmpwalk on a
+// column whose instances are not declared in the device's static JSON
+// (e.g. ifHCInMulticastPkts on many device types) would skip the whole
+// column because findNextOID only enumerates OIDs that already exist in
+// oidIndex / sortedOIDs.
+func (ic *IfCounterCycler) NextDynamicOID(currentOID string) (string, string) {
+	if ic == nil || len(ic.sortedIfIndexes) == 0 {
+		return "", ""
+	}
+	t := time.Since(ic.startTime).Seconds()
+	for _, tc := range ifCyclerColumns {
+		for _, idx := range ic.sortedIfIndexes {
+			oid := tc.prefix + strconv.Itoa(tc.col) + "." + strconv.Itoa(idx)
+			if compareOIDs(oid, currentOID) > 0 {
+				if val := ic.GetDynamicAt(oid, t); val != "" {
+					return oid, val
+				}
+			}
+		}
+	}
+	return "", ""
+}
+
 // safePktSize shields every pktSize-divided derivation from a zero or
 // negative divisor. Init draws pktSize from [400, 600] so this is
 // unreachable today, but widening the jitter or allowing an operator
@@ -504,38 +587,54 @@ func (c *MetricsCycler) InitIfCountersWithScenario(resources *DeviceResources, s
 		indexList = append(indexList, idx)
 	}
 
+	// Sorted copy used by walk enumeration — must be ascending so that
+	// NextDynamicOID emits (col, ifIndex) rows in MIB lex order.
+	sortedIndexList := make([]int, len(indexList))
+	copy(sortedIndexList, indexList)
+	sort.Ints(sortedIndexList)
+
+	// Precompute the first/last OID the cycler owns so findNextOID can
+	// cheaply decide whether a static-only fast path is safe.
+	firstCol := ifCyclerColumns[0]
+	lastCol := ifCyclerColumns[len(ifCyclerColumns)-1]
+	firstDynOID := firstCol.prefix + strconv.Itoa(firstCol.col) + "." + strconv.Itoa(sortedIndexList[0])
+	lastDynOID := lastCol.prefix + strconv.Itoa(lastCol.col) + "." + strconv.Itoa(sortedIndexList[len(sortedIndexList)-1])
+
 	ic := &IfCounterCycler{
-		startTime:      time.Now(),
-		maxIfIndex:     maxIdx,
-		knownIfIndexes: knownIdxs,
-		ifIndexList:    indexList,
-		ifSpeedBps:     make([]uint64, maxIdx),
-		baseInOctets:   make([]uint64, maxIdx),
-		baseOutOctets:  make([]uint64, maxIdx),
-		phaseIn:        make([]float64, maxIdx),
-		phaseOut:       make([]float64, maxIdx),
-		pktSizeIn:      make([]float64, maxIdx),
-		pktSizeOut:     make([]float64, maxIdx),
-		ucastRatioIn:   make([]float64, maxIdx),
-		mcastRatioIn:   make([]float64, maxIdx),
-		bcastRatioIn:   make([]float64, maxIdx),
-		ucastRatioOut:  make([]float64, maxIdx),
-		mcastRatioOut:  make([]float64, maxIdx),
-		bcastRatioOut:  make([]float64, maxIdx),
-		baseInUcast:    make([]uint64, maxIdx),
-		baseInMcast:    make([]uint64, maxIdx),
-		baseInBcast:    make([]uint64, maxIdx),
-		baseOutUcast:   make([]uint64, maxIdx),
-		baseOutMcast:   make([]uint64, maxIdx),
-		baseOutBcast:   make([]uint64, maxIdx),
-		errPpmIn:       make([]uint32, maxIdx),
-		errPpmOut:      make([]uint32, maxIdx),
-		discPpmIn:      make([]uint32, maxIdx),
-		discPpmOut:     make([]uint32, maxIdx),
-		baseInErr:      make([]uint64, maxIdx),
-		baseOutErr:     make([]uint64, maxIdx),
-		baseInDisc:     make([]uint64, maxIdx),
-		baseOutDisc:    make([]uint64, maxIdx),
+		startTime:       time.Now(),
+		maxIfIndex:      maxIdx,
+		knownIfIndexes:  knownIdxs,
+		ifIndexList:     indexList,
+		sortedIfIndexes: sortedIndexList,
+		firstDynOID:     firstDynOID,
+		lastDynOID:      lastDynOID,
+		ifSpeedBps:      make([]uint64, maxIdx),
+		baseInOctets:    make([]uint64, maxIdx),
+		baseOutOctets:   make([]uint64, maxIdx),
+		phaseIn:         make([]float64, maxIdx),
+		phaseOut:        make([]float64, maxIdx),
+		pktSizeIn:       make([]float64, maxIdx),
+		pktSizeOut:      make([]float64, maxIdx),
+		ucastRatioIn:    make([]float64, maxIdx),
+		mcastRatioIn:    make([]float64, maxIdx),
+		bcastRatioIn:    make([]float64, maxIdx),
+		ucastRatioOut:   make([]float64, maxIdx),
+		mcastRatioOut:   make([]float64, maxIdx),
+		bcastRatioOut:   make([]float64, maxIdx),
+		baseInUcast:     make([]uint64, maxIdx),
+		baseInMcast:     make([]uint64, maxIdx),
+		baseInBcast:     make([]uint64, maxIdx),
+		baseOutUcast:    make([]uint64, maxIdx),
+		baseOutMcast:    make([]uint64, maxIdx),
+		baseOutBcast:    make([]uint64, maxIdx),
+		errPpmIn:        make([]uint32, maxIdx),
+		errPpmOut:       make([]uint32, maxIdx),
+		discPpmIn:       make([]uint32, maxIdx),
+		discPpmOut:      make([]uint32, maxIdx),
+		baseInErr:       make([]uint64, maxIdx),
+		baseOutErr:      make([]uint64, maxIdx),
+		baseInDisc:      make([]uint64, maxIdx),
+		baseOutDisc:     make([]uint64, maxIdx),
 	}
 
 	rng := rand.New(rand.NewSource(seed))

--- a/go/simulator/if_counters_test.go
+++ b/go/simulator/if_counters_test.go
@@ -342,3 +342,81 @@ func TestIfCounterCycler_BaseIsPositive(t *testing.T) {
 		t.Errorf("initial counter value %d is unexpectedly small (< %d); base seeding may have failed", v, minExpected)
 	}
 }
+
+// TestIfCounterCycler_NextDynamicOID_WalksColumnWithoutStatic exercises the
+// bug that `snmpwalk .1.3.6.1.2.1.31.1.1.1.8` reported "OID not supported"
+// on devices whose JSON omits ifHCInMulticastPkts instances. The cycler
+// must enumerate the column analytically so the walk machinery has
+// instance rows to return.
+func TestIfCounterCycler_NextDynamicOID_WalksColumnWithoutStatic(t *testing.T) {
+	res := buildSparseTestResources(t, []int{1, 3, 5}, 1_000_000_000)
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 42)
+	ic := c.ifCounters
+	if ic == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	// Starting from the bare ifHCInMulticastPkts column, the walk must
+	// land on the smallest owned ifIndex (1), then step through 3 and 5,
+	// then cross into column 9 (ifHCInBroadcastPkts) at ifIndex 1.
+	want := []string{
+		".1.3.6.1.2.1.31.1.1.1.8.1",
+		".1.3.6.1.2.1.31.1.1.1.8.3",
+		".1.3.6.1.2.1.31.1.1.1.8.5",
+		".1.3.6.1.2.1.31.1.1.1.9.1",
+	}
+	cur := ".1.3.6.1.2.1.31.1.1.1.8"
+	for i, exp := range want {
+		next, val := ic.NextDynamicOID(cur)
+		if next != exp {
+			t.Fatalf("step %d: got next=%q, want %q", i, next, exp)
+		}
+		if val == "" {
+			t.Fatalf("step %d: empty value for %s", i, next)
+		}
+		if _, err := strconv.ParseUint(val, 10, 64); err != nil {
+			t.Fatalf("step %d: non-numeric value %q for %s: %v", i, val, next, err)
+		}
+		cur = next
+	}
+}
+
+// TestIfCounterCycler_NextDynamicOID_OrderAndBounds pins the enumeration
+// order: ifTable columns come before ifXTable, within each table columns
+// are ascending, within each column ifIndexes are ascending, and walking
+// past the last owned OID returns ("", "").
+func TestIfCounterCycler_NextDynamicOID_OrderAndBounds(t *testing.T) {
+	res := buildTestResources(t, []uint64{1_000_000_000, 1_000_000_000})
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 7)
+	ic := c.ifCounters
+	if ic == nil {
+		t.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	// Before the first dynamic row, walk must land on it.
+	if got, _ := ic.NextDynamicOID(".1.3.6.1.2.1.2"); got != ic.FirstDynamicOID() {
+		t.Errorf("pre-first: got %q, want FirstDynamicOID=%q", got, ic.FirstDynamicOID())
+	}
+
+	// First dynamic row must be ifTable column 11 ifIndex 1 (ifInUcastPkts.1).
+	if got := ic.FirstDynamicOID(); got != ".1.3.6.1.2.1.2.2.1.11.1" {
+		t.Errorf("FirstDynamicOID: got %q, want .1.3.6.1.2.1.2.2.1.11.1", got)
+	}
+	// Last dynamic row must be ifXTable column 13 at the largest ifIndex (2).
+	if got := ic.LastDynamicOID(); got != ".1.3.6.1.2.1.31.1.1.1.13.2" {
+		t.Errorf("LastDynamicOID: got %q, want .1.3.6.1.2.1.31.1.1.1.13.2", got)
+	}
+
+	// ifTable → ifXTable boundary: stepping past the last ifTable column
+	// (.20.2) must cross into the first ifXTable column (.2.1).
+	if got, _ := ic.NextDynamicOID(".1.3.6.1.2.1.2.2.1.20.2"); got != ".1.3.6.1.2.1.31.1.1.1.2.1" {
+		t.Errorf("ifTable→ifXTable boundary: got %q, want .1.3.6.1.2.1.31.1.1.1.2.1", got)
+	}
+
+	// Past the last dynamic row → end of walk.
+	if got, val := ic.NextDynamicOID(ic.LastDynamicOID()); got != "" || val != "" {
+		t.Errorf("past-last: got (%q, %q), want empty", got, val)
+	}
+}

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -122,24 +122,28 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 		}
 	}
 
-	// Fast path: if this device has no dynamic metric OIDs and we have a
-	// pre-computed next OID, return it immediately (O(1)).
+	// Resolve dynamic sources up front so both fast-path and slow-path
+	// candidate assembly can see them.
 	sortedMetricOIDs := GetSortedMetricOIDs(s.device.resourceFile)
-	if len(sortedMetricOIDs) == 0 && precomputedNextOID != "" {
-		return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
+	var ifCycler *IfCounterCycler
+	if s.device.metricsCycler != nil {
+		ifCycler = s.device.metricsCycler.ifCounters
 	}
+	ifCyclerHasRows := ifCycler != nil && len(ifCycler.sortedIfIndexes) > 0
 
-	// If we have a pre-computed next OID and it's lexicographically before
-	// the first dynamic metric OID, no metric OID can fall between current
-	// and next — safe to return immediately.
-	if precomputedNextOID != "" && len(sortedMetricOIDs) > 0 {
-		firstMetricOID := sortedMetricOIDs[0]
-		if compareOIDs(precomputedNextOID, firstMetricOID) <= 0 {
-			return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
-		}
-		// Also safe if currentOID is already past all metric OIDs
-		lastMetricOID := sortedMetricOIDs[len(sortedMetricOIDs)-1]
-		if compareOIDs(currentOID, lastMetricOID) >= 0 {
+	// Fast path: precomputedNextOID is safe to return immediately iff no
+	// dynamic source can emit a candidate in (currentOID, precomputedNextOID].
+	// For each source that condition is: source is empty, OR its first
+	// owned OID is at/after precomputedNextOID, OR currentOID is at/after
+	// its last owned OID.
+	if precomputedNextOID != "" {
+		metricsClear := len(sortedMetricOIDs) == 0 ||
+			compareOIDs(precomputedNextOID, sortedMetricOIDs[0]) <= 0 ||
+			compareOIDs(currentOID, sortedMetricOIDs[len(sortedMetricOIDs)-1]) >= 0
+		ifCyclerClear := !ifCyclerHasRows ||
+			compareOIDs(precomputedNextOID, ifCycler.firstDynOID) <= 0 ||
+			compareOIDs(currentOID, ifCycler.lastDynOID) >= 0
+		if metricsClear && ifCyclerClear {
 			return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
 		}
 	}
@@ -239,6 +243,20 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 					break // Only need the first (smallest) metric OID greater than current
 				}
 			}
+		}
+	}
+
+	// Add the next dynamic ifTable/ifXTable counter row as a candidate.
+	// Columns served analytically by IfCounterCycler (e.g.
+	// ifHCInMulticastPkts) frequently have no static-JSON instance rows,
+	// so without this a walk would skip the whole column even though GET
+	// on a specific instance works.
+	if ifCyclerHasRows {
+		if nextOID, val := ifCycler.NextDynamicOID(currentOID); nextOID != "" {
+			candidates = append(candidates, struct{ oid, resp string }{
+				oid:  nextOID,
+				resp: val,
+			})
 		}
 	}
 
@@ -545,9 +563,13 @@ func (s *SNMPServer) parseGetBulkParams(data []byte) (int, int) {
 	return nonRepeaters, maxRepetitions
 }
 
-// overrideIfHC replaces staticResp with the dynamic HC counter value when oid
-// is an ifHCInOctets or ifHCOutOctets OID. Returns staticResp unchanged for
-// all other OIDs. Used by findNextOID to return live counter values during walks.
+// overrideIfHC replaces staticResp with the live cycler value for any ifTable
+// or ifXTable OID the IfCounterCycler owns (octets, HC packets, Counter32
+// shadows, errors, discards — see if_counters.go for the full column list).
+// Returns staticResp unchanged for OIDs outside those trees, or for in-tree
+// OIDs the cycler does not own (e.g. ifDescr). Used by findNextOID to return
+// live counter values during walks where the candidate OID originated from
+// the static oidIndex.
 func (s *SNMPServer) overrideIfHC(oid, staticResp string) string {
 	if s.device.metricsCycler == nil || s.device.metricsCycler.ifCounters == nil {
 		return staticResp


### PR DESCRIPTION
## Summary

- `snmpwalk .1.3.6.1.2.1.31.1.1.1.8` (and other cycler-owned columns) returned `STRING: "OID not supported"` on devices whose JSON omitted per-instance rows for that column, even though a direct `snmpget .8.<ifIndex>` returned a live `Counter64:`.
- Root cause: `findNextOID` enumerated only static `oidIndex` entries and CPU/memory metric OIDs — the `IfCounterCycler` rows were invisible to GETNEXT/GETBULK despite being served analytically by `findResponse`.
- `IfCounterCycler` gains `NextDynamicOID` that emits (oid, value) pairs in MIB lex order across every cycler-owned column (ifTable 11, 13, 14, 17, 19, 20; ifXTable 2–13). `findNextOID` uses it as a new candidate source, and the fast-path short-circuit now checks both dynamic sources (metrics + cycler) before returning a precomputed static OID.

## Test plan

- [x] `go test ./go/simulator/...` — full suite green (`ok  …/simulator  20.7s`).
- [x] New unit tests pin enumeration order and walk-across-columns behaviour:
  - `TestIfCounterCycler_NextDynamicOID_WalksColumnWithoutStatic` — sparse ifIndex `{1,3,5}`, walk from `.31.1.1.1.8` steps `.8.1 → .8.3 → .8.5 → .9.1`.
  - `TestIfCounterCycler_NextDynamicOID_OrderAndBounds` — ifTable-before-ifXTable, column ascending, ifIndex ascending, past-last returns `("","")`.
- [ ] Manual on a real device: `snmpwalk -v2c -c public <device-ip> .1.3.6.1.2.1.31.1.1.1.8` now returns `Counter64:` rows for every known ifIndex; `snmpwalk ... .1.3.6.1.2.1.31.1.1.1` traverses the full ifXTable including columns without static JSON backing.
- [ ] OpenNMS collection: confirm ifHCInMulticastPkts / ifHCInBroadcastPkts graphs populate for simulator-fed nodes.

## Deferred (not in this PR)

- `NextDynamicOID` is `O(columns × ifIndexes)` per GETNEXT step. Fine at current poll cadences (worst case ~3600 comparisons per call for 200 interfaces), but can be reduced to `O(log N)` by parsing `currentOID` into `(col, ifIndex)` and using `sort.SearchInts`.
- Cycler fields are written by `InitIfCountersWithScenario` and read on the SNMP hot path. Today's init-before-`device.Start()` contract keeps this safe via goroutine happens-before; if a runtime "reset counters" control plane is ever added, the cycler pointer should become `atomic.Pointer[IfCounterCycler]`.

## Surfaces not touched

- `overrideIfHC` body unchanged — it already delegates to `GetDynamic` and covers every cycler column. Only the stale comment was refreshed to match the actual behaviour.
- No resource JSON changes. The fix is orthogonal to which columns a device declares statically.