### PR TITLE
perf(snmp): reduce NextDynamicOID to O(log N) via binary search

### DIFF
--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -413,22 +413,146 @@ func (ic *IfCounterCycler) LastDynamicOID() string {
 // (e.g. ifHCInMulticastPkts on many device types) would skip the whole
 // column because findNextOID only enumerates OIDs that already exist in
 // oidIndex / sortedOIDs.
+//
+// Implementation is O(log N) in the number of interfaces: parse
+// currentOID once into (table, col, ifIndex), locate the column position
+// in ifCyclerColumns by linear scan over its 18 entries, and use
+// sort.SearchInts on sortedIfIndexes to find the successor ifIndex.
+// The previous O(cols × ifIndexes) implementation built and compared an
+// OID string for every (col, ifIndex) pair on each GETNEXT step, which
+// made walking a 1000-interface device ~18000 string allocations per
+// step.
 func (ic *IfCounterCycler) NextDynamicOID(currentOID string) (string, string) {
 	if ic == nil || len(ic.sortedIfIndexes) == 0 {
 		return "", ""
 	}
 	t := time.Since(ic.startTime).Seconds()
-	for _, tc := range ifCyclerColumns {
-		for _, idx := range ic.sortedIfIndexes {
-			oid := tc.prefix + strconv.Itoa(tc.col) + "." + strconv.Itoa(idx)
-			if compareOIDs(oid, currentOID) > 0 {
-				if val := ic.GetDynamicAt(oid, t); val != "" {
-					return oid, val
-				}
+
+	// Parse currentOID into (isIfX, col, ifIndex). The two outcomes that
+	// matter for routing are:
+	//   - matched=true, haveCol=true:  search inside the cycler range
+	//   - everything else:             jump to first owned OID if currentOID
+	//                                  sorts before it, else end of walk
+	var (
+		suffix  string
+		isIfX   bool
+		matched bool
+	)
+	switch {
+	case strings.HasPrefix(currentOID, ifXTablePrefix):
+		suffix = currentOID[len(ifXTablePrefix):]
+		isIfX = true
+		matched = true
+	case strings.HasPrefix(currentOID, ifTablePrefix):
+		suffix = currentOID[len(ifTablePrefix):]
+		matched = true
+	}
+
+	// emitFromColumn returns the (oid, value) for column at index colIdx in
+	// ifCyclerColumns, at the supplied ifIndex.
+	emitFromColumn := func(colIdx, ifIndex int) (string, string) {
+		c := ifCyclerColumns[colIdx]
+		oid := c.prefix + strconv.Itoa(c.col) + "." + strconv.Itoa(ifIndex)
+		val := ic.GetDynamicAt(oid, t)
+		if val == "" {
+			// Defensive: every (owned col, owned ifIndex) pair must
+			// resolve. Falling through to "" here means a config /
+			// init mismatch — surface as end-of-walk rather than
+			// looping.
+			return "", ""
+		}
+		return oid, val
+	}
+
+	if !matched {
+		// currentOID is outside the cycler's prefix range. If it sorts
+		// before our first OID, start at the first owned row; if it
+		// sorts at or past our last OID, the walk is done.
+		if compareOIDs(currentOID, ic.firstDynOID) < 0 {
+			return emitFromColumn(0, ic.sortedIfIndexes[0])
+		}
+		return "", ""
+	}
+
+	// Parse the suffix into (col, ifIndex). Tolerate forms that lack an
+	// ifIndex ("<col>" or "<col>.") by treating the missing ifIndex as 0
+	// — successor lookup will then return the first owned ifIndex.
+	var (
+		col, ifIndex int
+		haveCol      bool
+	)
+	if dot := strings.IndexByte(suffix, '.'); dot > 0 {
+		if c, err := strconv.Atoi(suffix[:dot]); err == nil {
+			col, haveCol = c, true
+			if idx, err := strconv.Atoi(suffix[dot+1:]); err == nil {
+				ifIndex = idx
 			}
 		}
+	} else if dot < 0 && suffix != "" {
+		if c, err := strconv.Atoi(suffix); err == nil {
+			col, haveCol = c, true
+		}
 	}
-	return "", ""
+
+	if !haveCol {
+		// Suffix was empty or unparseable — currentOID sits at the
+		// table prefix itself (e.g. ".1.3.6.1.2.1.2.2.1."). Land on
+		// the first owned column of the matching table.
+		for i, tc := range ifCyclerColumns {
+			entryIsIfX := tc.prefix == ifXTablePrefix
+			if entryIsIfX == isIfX {
+				return emitFromColumn(i, ic.sortedIfIndexes[0])
+			}
+		}
+		return "", ""
+	}
+
+	// Locate the first ifCyclerColumns entry whose (table, col) is at or
+	// after the parsed (isIfX, col). 18-entry list — linear scan is
+	// faster than sort.Search on a slice this small.
+	colIdx := -1
+	for i, tc := range ifCyclerColumns {
+		entryIsIfX := tc.prefix == ifXTablePrefix
+		switch {
+		case isIfX && !entryIsIfX:
+			// currentOID is in ifXTable; skip ifTable entries.
+			continue
+		case !isIfX && entryIsIfX:
+			// currentOID is in ifTable but col is past every owned
+			// ifTable column — first ifXTable entry is the target.
+			colIdx = i
+		default:
+			// Same table. Take the first owned col >= parsed col.
+			if tc.col >= col {
+				colIdx = i
+			}
+		}
+		if colIdx >= 0 {
+			break
+		}
+	}
+	if colIdx < 0 {
+		// Past every owned column — end of walk.
+		return "", ""
+	}
+
+	chosen := ifCyclerColumns[colIdx]
+	chosenIsIfX := chosen.prefix == ifXTablePrefix
+	if chosenIsIfX == isIfX && chosen.col == col {
+		// Same column as currentOID — find the successor ifIndex.
+		pos := sort.SearchInts(ic.sortedIfIndexes, ifIndex+1)
+		if pos < len(ic.sortedIfIndexes) {
+			return emitFromColumn(colIdx, ic.sortedIfIndexes[pos])
+		}
+		// All ifIndexes in this column already walked — advance to the
+		// next owned column at its first ifIndex.
+		if colIdx+1 >= len(ifCyclerColumns) {
+			return "", ""
+		}
+		return emitFromColumn(colIdx+1, ic.sortedIfIndexes[0])
+	}
+	// Advanced past currentOID's column — emit at first ifIndex.
+	return emitFromColumn(colIdx, ic.sortedIfIndexes[0])
 }
 
 // safePktSize shields every pktSize-divided derivation from a zero or

--- a/go/simulator/if_counters_bench_test.go
+++ b/go/simulator/if_counters_bench_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The OpenNMS Group, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Created by Ronny Trommer <ronny@opennms.com>
+ */
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// buildBenchResources is the benchmark-side equivalent of
+// buildTestResources — accepts *testing.B (vs *testing.T) so it can be
+// used outside the standard test entry points without changing the
+// existing helpers.
+func buildBenchResources(b *testing.B, speeds []uint64) *DeviceResources {
+	b.Helper()
+	res := &DeviceResources{oidIndex: &sync.Map{}}
+	for i, spd := range speeds {
+		ifIndex := i + 1
+		res.oidIndex.Store(
+			fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.15.%d", ifIndex),
+			strconv.FormatUint(spd/1_000_000, 10),
+		)
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", ifIndex), "0")
+		res.oidIndex.Store(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", ifIndex), "0")
+	}
+	return res
+}
+
+// BenchmarkNextDynamicOID measures NextDynamicOID at four representative
+// walk positions on a 1000-interface device:
+//
+//   - "before-first": currentOID sorts before the first owned dynamic
+//     OID (cold-start of an snmpwalk that begins at the IF-MIB root).
+//   - "ifTable-mid":   middle of an ifTable column — exercises the
+//     successor-ifIndex binary search inside sortedIfIndexes.
+//   - "table-cross":   last ifIndex of the last ifTable column —
+//     exercises the cross-table boundary.
+//   - "near-last":     last ifIndex of the second-to-last ifXTable
+//     column — exercises end-of-walk advance.
+//
+// All four sub-benchmarks call b.ReportAllocs() so the per-step
+// allocation profile is visible alongside ns/op.
+func BenchmarkNextDynamicOID(b *testing.B) {
+	const numIfaces = 1000
+	speeds := make([]uint64, numIfaces)
+	for i := range speeds {
+		speeds[i] = 1_000_000_000
+	}
+	res := buildBenchResources(b, speeds)
+	c := &MetricsCycler{}
+	c.InitIfCounters(res, 42)
+	ic := c.ifCounters
+	if ic == nil {
+		b.Fatal("InitIfCounters did not create ifCounters")
+	}
+
+	cases := []struct {
+		name string
+		oid  string
+	}{
+		// Before the first dynamic OID — falls into the !matched
+		// before-first branch.
+		{"before-first", ".1.3.6.1.2.1.2"},
+		// Middle of ifTable column 14 (ifInErrors) at ifIndex 500 —
+		// hits the same-column successor-search hot path.
+		{"ifTable-mid", ".1.3.6.1.2.1.2.2.1.14.500"},
+		// Last ifIndex of last ifTable column (.20) — successor falls
+		// off the end of sortedIfIndexes and must cross into the first
+		// ifXTable column (.2).
+		{"table-cross", ".1.3.6.1.2.1.2.2.1.20.1000"},
+		// Last ifIndex of the second-to-last ifXTable column (.12).
+		{"near-last", ".1.3.6.1.2.1.31.1.1.1.12.1000"},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = ic.NextDynamicOID(tc.oid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `IfCounterCycler.NextDynamicOID` (introduced in #142) scanned the full 18×N cross-product of owned columns × ifIndexes per SNMP GETNEXT step, constructing an OID string and calling `compareOIDs` each iteration.
- Rewritten to O(log N): parse `currentOID` once into `(table, col, ifIndex)`, locate the column's position in `ifCyclerColumns` (linear scan of 18 entries), then `sort.SearchInts(sortedIfIndexes, ifIndex+1)` for the successor. When the successor falls off the end, advance to the next owned column; when `currentOID` sits outside the ifTable/ifXTable range or on an unowned column, jump to the appropriate starting point.

## Benchmark (Apple M1 Max, 1000 interfaces)

| Position | ns/op | B/op | allocs/op |
|---|---|---|---|
| before-first dynamic row | 427.0 | 328 | 4 |
| ifTable mid (hot path) | 156.8 | 35 | 2 |
| ifTable → ifXTable cross | 167.2 | 48 | 2 |
| near-last | 190.0 | 48 | 2 |

The hot-middle path is now ~157 ns / 2 allocs regardless of interface count. The pre-fix version allocated ~9000 intermediate OID strings per call at this position.

## Test plan

- [x] `go test ./go/simulator/... -run TestIfCounterCycler_NextDynamicOID -count=1` — both existing tests (`WalksColumnWithoutStatic`, `OrderAndBounds`) pass without modification.
- [x] `go test ./go/simulator/... -count=1` — full suite green.
- [x] `go vet ./go/simulator/...` — clean.
- [x] New `BenchmarkNextDynamicOID` covers all four representative positions with `b.ReportAllocs()`.

## Out of scope

- The value computation itself (`GetDynamicAt`) is untouched.
- The column list (`ifCyclerColumns`) and field set (`sortedIfIndexes`, `firstDynOID`, `lastDynOID`) are unchanged.

Closes #143.