### PR TITLE
refactor(snmp): store IfCounterCycler behind atomic.Pointer

### DIFF
--- a/go/simulator/flow_exporter.go
+++ b/go/simulator/flow_exporter.go
@@ -374,9 +374,11 @@ func (sm *SimulatorManager) registerSFlowCounterSources(device *DeviceSimulator)
 		return
 	}
 	var sources []CounterSource
-	if device.metricsCycler != nil && device.metricsCycler.ifCounters != nil {
-		if s := NewInterfaceCounterSource(device.metricsCycler.ifCounters); s != nil {
-			sources = append(sources, s)
+	if device.metricsCycler != nil {
+		if ic := device.metricsCycler.ifCounters.Load(); ic != nil {
+			if s := NewInterfaceCounterSource(ic); s != nil {
+				sources = append(sources, s)
+			}
 		}
 	}
 	// CPUCounterSource's processor_information record already carries

--- a/go/simulator/if_counters.go
+++ b/go/simulator/if_counters.go
@@ -184,9 +184,14 @@ func scenarioBand(s IfErrorScenario) (errLo, errHi, discLo, discHi uint32) {
 // strictly monotonic.
 //
 // Thread safety: all fields are written once by InitIfCounters before
-// the device's SNMP server goroutine is started. Concurrent reads in
-// GetDynamic are safe because goroutine creation provides the required
-// happens-before relationship.
+// the cycler is published via MetricsCycler.ifCounters.Store(ic), and
+// the pointed-to IfCounterCycler is immutable after Store —
+// re-initialisation means building a fresh instance and calling Store
+// again with the new pointer. All readers must call
+// MetricsCycler.ifCounters.Load() at the top of the function and
+// operate on the captured local; the atomic Load/Store pair plus the
+// immutable-after-Store contract means concurrent reads in GetDynamic
+// are safe even across a future reset / rescenario control plane.
 type IfCounterCycler struct {
 	startTime      time.Time
 	maxIfIndex     int              // upper bound for array indexing
@@ -834,7 +839,11 @@ func (c *MetricsCycler) InitIfCountersWithScenario(resources *DeviceResources, s
 		ic.baseOutDisc[slot] = totalOutPkts24h * uint64(ic.discPpmOut[slot]) / 1_000_000
 	}
 
-	c.ifCounters = ic
+	// ic is fully constructed before the Store, so concurrent readers
+	// either see the complete new cycler or the previous pointer — never
+	// a partially-initialised intermediate. This is the contract the
+	// atomic.Pointer field on MetricsCycler depends on.
+	c.ifCounters.Store(ic)
 }
 
 // jitterAndNormalize applies ±jitter (as a fraction) to each ratio

--- a/go/simulator/if_counters_bench_test.go
+++ b/go/simulator/if_counters_bench_test.go
@@ -56,7 +56,7 @@ func BenchmarkNextDynamicOID(b *testing.B) {
 	res := buildBenchResources(b, speeds)
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 42)
-	ic := c.ifCounters
+	ic := c.ifCounters.Load()
 	if ic == nil {
 		b.Fatal("InitIfCounters did not create ifCounters")
 	}

--- a/go/simulator/if_counters_scenario_test.go
+++ b/go/simulator/if_counters_scenario_test.go
@@ -42,6 +42,7 @@ func TestGetDynamic_MonotonicAllColumns(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 42, IfErrorTypical)
+	ic := c.ifCounters.Load()
 
 	cases := []struct {
 		oid  string
@@ -74,7 +75,7 @@ func TestGetDynamic_MonotonicAllColumns(t *testing.T) {
 	for poll := 0; poll < 5; poll++ {
 		time.Sleep(5 * time.Millisecond)
 		for _, tc := range cases {
-			v := parseU(t, c.ifCounters.GetDynamic(tc.oid))
+			v := parseU(t, ic.GetDynamic(tc.oid))
 			if poll > 0 && v < prev[tc.oid] {
 				t.Errorf("poll %d: %s decreased %d → %d", poll, tc.desc, prev[tc.oid], v)
 			}
@@ -89,20 +90,21 @@ func TestGetDynamic_RatiosSumToTotalPackets(t *testing.T) {
 	res := buildTestResources(t, []uint64{10_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 2026, IfErrorClean)
+	ic := c.ifCounters.Load()
 
 	// Advance time so the derived packet counts have meaningful magnitude
 	// beyond the t≈0 floor.
 	time.Sleep(15 * time.Millisecond)
 
-	inUcast := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.7.1"))
-	inMcast := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.8.1"))
-	inBcast := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.9.1"))
-	inOctets := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.31.1.1.1.6.1"))
+	inUcast := parseU(t, ic.GetDynamic(".1.3.6.1.2.1.31.1.1.1.7.1"))
+	inMcast := parseU(t, ic.GetDynamic(".1.3.6.1.2.1.31.1.1.1.8.1"))
+	inBcast := parseU(t, ic.GetDynamic(".1.3.6.1.2.1.31.1.1.1.9.1"))
+	inOctets := parseU(t, ic.GetDynamic(".1.3.6.1.2.1.31.1.1.1.6.1"))
 
 	// totalInPkts(t) = inOctets / pktSizeIn  — approximate; ratio
 	// rounding to uint64 at each call can drop fractional packets so
 	// we allow 0.2 % tolerance.
-	pktSize := c.ifCounters.pktSizeIn[0]
+	pktSize := ic.pktSizeIn[0]
 	expectedTotal := float64(inOctets) / pktSize
 	gotTotal := float64(inUcast + inMcast + inBcast)
 	if expectedTotal == 0 {
@@ -121,6 +123,7 @@ func TestGetDynamic_Counter32ShadowEqualsLow32(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 99, IfErrorClean)
+	ic := c.ifCounters.Load()
 
 	// Check both directions for all three shadow pairs at t ≈ 0.
 	pairs := []struct {
@@ -139,10 +142,10 @@ func TestGetDynamic_Counter32ShadowEqualsLow32(t *testing.T) {
 	// Freeze a single evaluation instant so the shadow and HC columns
 	// see the same t — the invariant "shadow == uint32(HC & 0xFFFFFFFF)"
 	// is exact by construction of GetDynamicAt, not drift-tolerant.
-	tSec := time.Since(c.ifCounters.startTime).Seconds()
+	tSec := time.Since(ic.startTime).Seconds()
 	for _, p := range pairs {
-		hcVal := parseU(t, c.ifCounters.GetDynamicAt(p.hc, tSec))
-		shVal := parseU(t, c.ifCounters.GetDynamicAt(p.shadow, tSec))
+		hcVal := parseU(t, ic.GetDynamicAt(p.hc, tSec))
+		shVal := parseU(t, ic.GetDynamicAt(p.shadow, tSec))
 		want := hcVal & 0xFFFFFFFF
 		if shVal != want {
 			t.Errorf("%s=%d, want low-32 of %s (%d)=%d (must be exact at same t)",
@@ -157,6 +160,7 @@ func TestScenario_CleanHasZeroErrors(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 1, IfErrorClean)
+	ic := c.ifCounters.Load()
 
 	oids := []string{
 		".1.3.6.1.2.1.2.2.1.13.1", // ifInDiscards
@@ -166,11 +170,11 @@ func TestScenario_CleanHasZeroErrors(t *testing.T) {
 	}
 	start := map[string]uint64{}
 	for _, oid := range oids {
-		start[oid] = parseU(t, c.ifCounters.GetDynamic(oid))
+		start[oid] = parseU(t, ic.GetDynamic(oid))
 	}
 	time.Sleep(20 * time.Millisecond)
 	for _, oid := range oids {
-		got := parseU(t, c.ifCounters.GetDynamic(oid))
+		got := parseU(t, ic.GetDynamic(oid))
 		if got != start[oid] {
 			t.Errorf("%s grew under clean scenario: %d → %d", oid, start[oid], got)
 		}
@@ -183,10 +187,11 @@ func TestScenario_FailingAccumulatesErrors(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 1, IfErrorFailing)
+	ic := c.ifCounters.Load()
 
-	t0 := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	t0 := parseU(t, ic.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
 	time.Sleep(50 * time.Millisecond)
-	t1 := parseU(t, c.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	t1 := parseU(t, ic.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
 	if t1 <= t0 {
 		t.Errorf("failing scenario: ifInErrors did not grow across 50ms poll window (%d → %d)", t0, t1)
 	}
@@ -201,12 +206,14 @@ func TestScenario_PerDeviceIsolation(t *testing.T) {
 
 	clean := &MetricsCycler{}
 	clean.InitIfCountersWithScenario(res, 7, IfErrorClean)
+	cleanIC := clean.ifCounters.Load()
 
 	failing := &MetricsCycler{}
 	failing.InitIfCountersWithScenario(res, 7, IfErrorFailing)
+	failIC := failing.ifCounters.Load()
 
-	cleanStart := parseU(t, clean.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
-	failStart := parseU(t, failing.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	cleanStart := parseU(t, cleanIC.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	failStart := parseU(t, failIC.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
 	if cleanStart != 0 {
 		t.Errorf("clean device started with non-zero errors: %d", cleanStart)
 	}
@@ -216,8 +223,8 @@ func TestScenario_PerDeviceIsolation(t *testing.T) {
 
 	time.Sleep(30 * time.Millisecond)
 
-	cleanAfter := parseU(t, clean.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
-	failAfter := parseU(t, failing.ifCounters.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	cleanAfter := parseU(t, cleanIC.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
+	failAfter := parseU(t, failIC.GetDynamic(".1.3.6.1.2.1.2.2.1.14.1"))
 	if cleanAfter != cleanStart {
 		t.Errorf("clean device grew errors despite sharing resources with failing: %d → %d", cleanStart, cleanAfter)
 	}
@@ -262,15 +269,16 @@ func TestSFlowSnapshotMatchesSNMPAtSameInstant(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 555, IfErrorTypical)
+	ic := c.ifCounters.Load()
 
-	adapter := NewInterfaceCounterSource(c.ifCounters)
+	adapter := NewInterfaceCounterSource(ic)
 
 	// Freeze a single evaluation instant. Snapshot honors the passed-in
 	// time; the SNMP reads below use the same frozen tSec. This makes
 	// the "sFlow counter_sample matches concurrent SNMP GET" invariant
 	// a byte-for-byte equality (spec Requirement 5), not drift-tolerant.
 	snapshotAt := time.Now()
-	tSec := snapshotAt.Sub(c.ifCounters.startTime).Seconds()
+	tSec := snapshotAt.Sub(ic.startTime).Seconds()
 
 	recs := adapter.Snapshot(snapshotAt)
 	if len(recs) != 1 {
@@ -284,8 +292,8 @@ func TestSFlowSnapshotMatchesSNMPAtSameInstant(t *testing.T) {
 		return uint32(body[off])<<24 | uint32(body[off+1])<<16 | uint32(body[off+2])<<8 | uint32(body[off+3])
 	}
 
-	snmpInUcast := uint32(parseU(t, c.ifCounters.GetDynamicAt(".1.3.6.1.2.1.2.2.1.11.1", tSec)))
-	snmpInErr := uint32(parseU(t, c.ifCounters.GetDynamicAt(".1.3.6.1.2.1.2.2.1.14.1", tSec)))
+	snmpInUcast := uint32(parseU(t, ic.GetDynamicAt(".1.3.6.1.2.1.2.2.1.11.1", tSec)))
+	snmpInErr := uint32(parseU(t, ic.GetDynamicAt(".1.3.6.1.2.1.2.2.1.14.1", tSec)))
 
 	// Body layout (see encodeIfCountersBody):
 	//   0..3   u32 ifIndex
@@ -317,10 +325,11 @@ func TestCleanScenario_ZeroPreSeed(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 88, IfErrorClean)
+	ic := c.ifCounters.Load()
 
 	for _, col := range []string{"13", "14", "19", "20"} {
 		oid := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.%s.1", col)
-		if v := parseU(t, c.ifCounters.GetDynamic(oid)); v != 0 {
+		if v := parseU(t, ic.GetDynamic(oid)); v != 0 {
 			t.Errorf("clean scenario %s = %d at t≈0; want 0", oid, v)
 		}
 	}
@@ -333,12 +342,13 @@ func TestTypicalScenario_NonZeroPreSeed(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 88, IfErrorTypical)
+	ic := c.ifCounters.Load()
 
 	// ifInErrors / ifInDiscards should both be > 0 at t=0 — typical
 	// ppm × 24h packet pre-seed is orders of magnitude above 0.
 	for _, col := range []string{"13", "14", "19", "20"} {
 		oid := fmt.Sprintf(".1.3.6.1.2.1.2.2.1.%s.1", col)
-		if v := parseU(t, c.ifCounters.GetDynamic(oid)); v == 0 {
+		if v := parseU(t, ic.GetDynamic(oid)); v == 0 {
 			t.Errorf("typical scenario %s = 0 at t≈0; expected non-zero pre-seed", oid)
 		}
 	}
@@ -351,6 +361,7 @@ func TestGetDynamic_UnknownColumnFallsThrough(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 1, IfErrorClean)
+	ic := c.ifCounters.Load()
 
 	// ifType (.3), ifMtu (.4), ifAdminStatus (.7), ifOperStatus (.8)
 	// — none of these columns are in the dynamic set.
@@ -360,7 +371,7 @@ func TestGetDynamic_UnknownColumnFallsThrough(t *testing.T) {
 		".1.3.6.1.2.1.2.2.1.7.1",
 		".1.3.6.1.2.1.2.2.1.8.1",
 	} {
-		if v := c.ifCounters.GetDynamic(oid); v != "" {
+		if v := ic.GetDynamic(oid); v != "" {
 			t.Errorf("GetDynamic(%q) = %q; want empty (fall through to static JSON)", oid, v)
 		}
 	}
@@ -372,14 +383,15 @@ func TestGetHCOctets_LegacyShim(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCountersWithScenario(res, 1, IfErrorClean)
+	ic := c.ifCounters.Load()
 
-	in := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
-	out := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.10.1")
+	in := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	out := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.10.1")
 	if in == "" || out == "" {
 		t.Errorf("legacy GetHCOctets returned empty for HC octet OIDs: in=%q out=%q", in, out)
 	}
 	// Should return empty for non-HC-octet columns.
-	if v := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.7.1"); v != "" {
+	if v := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.7.1"); v != "" {
 		t.Errorf("legacy GetHCOctets returned %q for non-HC-octet OID; want empty", v)
 	}
 }

--- a/go/simulator/if_counters_test.go
+++ b/go/simulator/if_counters_test.go
@@ -65,7 +65,8 @@ func TestIfCounterCycler_Monotonic(t *testing.T) {
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 42)
 
-	if c.ifCounters == nil {
+	ic := c.ifCounters.Load()
+	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
 
@@ -74,8 +75,8 @@ func TestIfCounterCycler_Monotonic(t *testing.T) {
 	for poll := 0; poll < 5; poll++ {
 		time.Sleep(5 * time.Millisecond)
 
-		v1str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
-		v2str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.2")
+		v1str := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+		v2str := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.2")
 		v1, err1 := strconv.ParseUint(v1str, 10, 64)
 		v2, err2 := strconv.ParseUint(v2str, 10, 64)
 		if err1 != nil || err2 != nil {
@@ -99,7 +100,8 @@ func TestIfCounterCycler_NoWrapAtZero(t *testing.T) {
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 99)
 
-	vStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	ic := c.ifCounters.Load()
+	vStr := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v, err := strconv.ParseUint(vStr, 10, 64)
 	if err != nil {
 		t.Fatalf("non-numeric value at t≈0: %q", vStr)
@@ -125,18 +127,19 @@ func TestIfCounterCycler_RateInRange(t *testing.T) {
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 7)
 
-	if c.ifCounters == nil {
+	ic := c.ifCounters.Load()
+	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
 
 	// Sample over ~100 ms; compute average byte-rate.
 	start := time.Now()
-	v0str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	v0str := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v0, _ := strconv.ParseUint(v0str, 10, 64)
 
 	time.Sleep(100 * time.Millisecond)
 
-	v1str := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	v1str := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v1, _ := strconv.ParseUint(v1str, 10, 64)
 	elapsed := time.Since(start).Seconds()
 
@@ -157,12 +160,13 @@ func TestIfCounterCycler_UnknownOID(t *testing.T) {
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 1)
 
+	ic := c.ifCounters.Load()
 	// Wrong column — should return empty string
-	if v := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.7.1"); v != "" {
+	if v := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.7.1"); v != "" {
 		t.Errorf("expected empty for non-HC OID, got %q", v)
 	}
 	// Out-of-range interface index
-	if v := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.99"); v != "" {
+	if v := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.99"); v != "" {
 		t.Errorf("expected empty for out-of-range ifIndex, got %q", v)
 	}
 }
@@ -174,7 +178,8 @@ func TestIfCounterCycler_SparseIfIndex(t *testing.T) {
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 77)
 
-	if c.ifCounters == nil {
+	ic := c.ifCounters.Load()
+	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
 
@@ -183,7 +188,7 @@ func TestIfCounterCycler_SparseIfIndex(t *testing.T) {
 	// Known indices should return live values.
 	for _, idx := range []int{1, 3, 5} {
 		oid := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", idx)
-		if v := c.ifCounters.GetHCOctets(oid); v == "" {
+		if v := ic.GetHCOctets(oid); v == "" {
 			t.Errorf("expected non-empty for known ifIndex %d, got empty", idx)
 		}
 	}
@@ -191,7 +196,7 @@ func TestIfCounterCycler_SparseIfIndex(t *testing.T) {
 	// Missing indices must not return a live counter.
 	for _, idx := range []int{2, 4} {
 		oid := fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", idx)
-		if v := c.ifCounters.GetHCOctets(oid); v != "" {
+		if v := ic.GetHCOctets(oid); v != "" {
 			t.Errorf("expected empty for missing ifIndex %d, got %q", idx, v)
 		}
 	}
@@ -205,8 +210,9 @@ func TestIfCounterCycler_InOutDiffer(t *testing.T) {
 	c.InitIfCounters(res, 123456)
 
 	time.Sleep(10 * time.Millisecond)
-	inStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
-	outStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.10.1")
+	ic := c.ifCounters.Load()
+	inStr := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	outStr := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.10.1")
 
 	in, _ := strconv.ParseUint(inStr, 10, 64)
 	out, _ := strconv.ParseUint(outStr, 10, 64)
@@ -233,7 +239,7 @@ func TestIfCounterCycler_NoHCOIDs(t *testing.T) {
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 1)
 
-	if c.ifCounters != nil {
+	if c.ifCounters.Load() != nil {
 		t.Error("expected ifCounters to be nil for device with no HC OIDs")
 	}
 }
@@ -253,11 +259,12 @@ func TestInterfaceCounterSource_MatchesSNMPSurface(t *testing.T) {
 
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 4242)
-	if c.ifCounters == nil {
+	ic := c.ifCounters.Load()
+	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
 
-	adapter := NewInterfaceCounterSource(c.ifCounters)
+	adapter := NewInterfaceCounterSource(ic)
 	if adapter == nil {
 		t.Fatal("NewInterfaceCounterSource returned nil")
 	}
@@ -286,8 +293,8 @@ func TestInterfaceCounterSource_MatchesSNMPSurface(t *testing.T) {
 			t.Errorf("adapter missing ifIndex %d", ifIdx)
 			continue
 		}
-		inStr := c.ifCounters.GetHCOctets(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", ifIdx))
-		outStr := c.ifCounters.GetHCOctets(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", ifIdx))
+		inStr := ic.GetHCOctets(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.6.%d", ifIdx))
+		outStr := ic.GetHCOctets(fmt.Sprintf(".1.3.6.1.2.1.31.1.1.1.10.%d", ifIdx))
 		snmpIn, _ := strconv.ParseUint(inStr, 10, 64)
 		snmpOut, _ := strconv.ParseUint(outStr, 10, 64)
 
@@ -333,7 +340,8 @@ func TestIfCounterCycler_BaseIsPositive(t *testing.T) {
 	c.InitIfCounters(res, 99)
 
 	// Read immediately (t ≈ 0)
-	vStr := c.ifCounters.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
+	ic := c.ifCounters.Load()
+	vStr := ic.GetHCOctets(".1.3.6.1.2.1.31.1.1.1.6.1")
 	v, _ := strconv.ParseUint(vStr, 10, 64)
 
 	// ~24h of 80% traffic at 1 Gbps ≈ 8.64 TB; require at least 10 GB.
@@ -352,7 +360,7 @@ func TestIfCounterCycler_NextDynamicOID_WalksColumnWithoutStatic(t *testing.T) {
 	res := buildSparseTestResources(t, []int{1, 3, 5}, 1_000_000_000)
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 42)
-	ic := c.ifCounters
+	ic := c.ifCounters.Load()
 	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
@@ -390,7 +398,7 @@ func TestIfCounterCycler_NextDynamicOID_OrderAndBounds(t *testing.T) {
 	res := buildTestResources(t, []uint64{1_000_000_000, 1_000_000_000})
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 7)
-	ic := c.ifCounters
+	ic := c.ifCounters.Load()
 	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}

--- a/go/simulator/metrics_cycler.go
+++ b/go/simulator/metrics_cycler.go
@@ -35,7 +35,15 @@ type MetricsCycler struct {
 	memIndex   uint32               // atomic, current position
 	tempIndex  uint32               // atomic, current position
 	gpuMetrics []*GPUMetrics        // Per-GPU cycling metrics (nil for non-GPU devices)
-	ifCounters *IfCounterCycler     // Per-interface HC counter cycling (nil if no HC OIDs)
+	// ifCounters holds the per-interface HC counter cycler (nil if no HC OIDs).
+	//
+	// The pointer is stored atomically. The pointed-to IfCounterCycler is
+	// immutable after Store — re-initialisation means building a fresh
+	// instance and calling Store again with the new pointer. All readers
+	// must call Load() at the top of the function and operate on the
+	// captured local. This makes a future runtime reset / rescenario
+	// control plane safe to drop in without racing the SNMP hot path.
+	ifCounters atomic.Pointer[IfCounterCycler]
 }
 
 // NewMetricsCycler creates a cycler with 100 data points generated from the

--- a/go/simulator/sflow_test.go
+++ b/go/simulator/sflow_test.go
@@ -790,11 +790,12 @@ func TestSFlowInterfaceCounterSource_OneSamplePerIfIndex(t *testing.T) {
 
 	c := &MetricsCycler{}
 	c.InitIfCounters(res, 9999)
-	if c.ifCounters == nil {
+	ic := c.ifCounters.Load()
+	if ic == nil {
 		t.Fatal("InitIfCounters did not create ifCounters")
 	}
 
-	adapter := NewInterfaceCounterSource(c.ifCounters)
+	adapter := NewInterfaceCounterSource(ic)
 	recs := adapter.Snapshot(time.Now())
 	if len(recs) != 3 {
 		t.Fatalf("Snapshot returned %d records, want 3", len(recs))

--- a/go/simulator/snmp_handlers.go
+++ b/go/simulator/snmp_handlers.go
@@ -46,8 +46,8 @@ func (s *SNMPServer) findResponse(oid string) string {
 		// octets, HC packets, Counter32 shadows, error / discard. The
 		// cycler returns "" for OIDs it doesn't own — fall through to
 		// the static oidIndex lookup in that case.
-		if s.device.metricsCycler.ifCounters != nil {
-			if val := s.device.metricsCycler.ifCounters.GetDynamic(oid); val != "" {
+		if ic := s.device.metricsCycler.ifCounters.Load(); ic != nil {
+			if val := ic.GetDynamic(oid); val != "" {
 				return val
 			}
 		}
@@ -127,7 +127,7 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 	sortedMetricOIDs := GetSortedMetricOIDs(s.device.resourceFile)
 	var ifCycler *IfCounterCycler
 	if s.device.metricsCycler != nil {
-		ifCycler = s.device.metricsCycler.ifCounters
+		ifCycler = s.device.metricsCycler.ifCounters.Load()
 	}
 	ifCyclerHasRows := ifCycler != nil && len(ifCycler.sortedIfIndexes) > 0
 
@@ -144,7 +144,7 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 			compareOIDs(precomputedNextOID, ifCycler.firstDynOID) <= 0 ||
 			compareOIDs(currentOID, ifCycler.lastDynOID) >= 0
 		if metricsClear && ifCyclerClear {
-			return precomputedNextOID, s.overrideIfHC(precomputedNextOID, precomputedNextResp)
+			return precomputedNextOID, s.overrideIfHC(ifCycler, precomputedNextOID, precomputedNextResp)
 		}
 	}
 
@@ -274,7 +274,7 @@ func (s *SNMPServer) findNextOID(currentOID string) (string, string) {
 		}
 	}
 
-	return nextOID, s.overrideIfHC(nextOID, response)
+	return nextOID, s.overrideIfHC(ifCycler, nextOID, response)
 }
 
 // handleGetBulk processes SNMP GetBulk requests
@@ -570,8 +570,14 @@ func (s *SNMPServer) parseGetBulkParams(data []byte) (int, int) {
 // OIDs the cycler does not own (e.g. ifDescr). Used by findNextOID to return
 // live counter values during walks where the candidate OID originated from
 // the static oidIndex.
-func (s *SNMPServer) overrideIfHC(oid, staticResp string) string {
-	if s.device.metricsCycler == nil || s.device.metricsCycler.ifCounters == nil {
+//
+// The caller passes the *IfCounterCycler it already Load()ed at the top of
+// its function so the whole GETNEXT step reads a single consistent cycler
+// snapshot. A concurrent Store between the caller's Load and this call
+// would otherwise make the candidate-selection decision and the value
+// override disagree.
+func (s *SNMPServer) overrideIfHC(ic *IfCounterCycler, oid, staticResp string) string {
+	if ic == nil {
 		return staticResp
 	}
 	// Fast pre-check: dynamic IF-MIB OIDs live under ifTable
@@ -581,7 +587,7 @@ func (s *SNMPServer) overrideIfHC(oid, staticResp string) string {
 	if !strings.HasPrefix(oid, ".1.3.6.1.2.1.2.2.1.") && !strings.HasPrefix(oid, ".1.3.6.1.2.1.31.1.1.1.") {
 		return staticResp
 	}
-	if dynVal := s.device.metricsCycler.ifCounters.GetDynamic(oid); dynVal != "" {
+	if dynVal := ic.GetDynamic(oid); dynVal != "" {
 		return dynVal
 	}
 	return staticResp

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -498,10 +498,14 @@ func (sm *SimulatorManager) startDeviceTrapExporter(device *DeviceSimulator) err
 // ifTable resources).
 func deviceIfIndexFn(device *DeviceSimulator) func() int {
 	return func() int {
-		if device == nil || device.metricsCycler == nil || device.metricsCycler.ifCounters == nil {
+		if device == nil || device.metricsCycler == nil {
 			return 1
 		}
-		indices := device.metricsCycler.ifCounters.IfIndices()
+		ic := device.metricsCycler.ifCounters.Load()
+		if ic == nil {
+			return 1
+		}
+		indices := ic.IfIndices()
 		if len(indices) == 0 {
 			return 1
 		}


### PR DESCRIPTION
## Summary

- `MetricsCycler.ifCounters` is now `atomic.Pointer[IfCounterCycler]`. `InitIfCountersWithScenario` builds the cycler fully in a local and `Store`s it as its last action.
- Every production reader (`findResponse`, `findNextOID`, `overrideIfHC`, `flow_exporter.registerSFlowCounterSources`, `trap_manager.deviceIfIndexFn`) now `Load()`s the pointer once at the top of the function and operates on the captured local.
- Tests in `if_counters_test.go`, `if_counters_scenario_test.go`, `sflow_test.go`, and the `if_counters_bench_test.go` added in #145 follow the same pattern.
- The immutable-after-`Store` contract is documented on the `MetricsCycler.ifCounters` field and on the `IfCounterCycler` struct doc block.

## Why

The init-before-`device.Start()` contract keeps today's readers safe via goroutine-creation happens-before. This refactor makes the pointer swap atomic so a future runtime "reset counters" / "re-scenario" endpoint can drop in without racing with the SNMP hot path. **No behaviour change today** — this is plumbing.

## Test plan

- [x] `go test ./go/simulator/... -count=1` — full suite green.
- [x] `go test ./go/simulator/... -count=1 -race` — no races detected.
- [x] `go vet ./go/simulator/...` — clean.
- [x] Rebased on top of #145 and re-verified (the `if_counters_bench_test.go` introduced there uses the new `Load()` pattern in its benchmark harness).

## Out of scope

- The actual reset / re-scenario endpoint — intentionally deferred. This PR is the plumbing only.
- Value computation (`GetDynamic` / `GetDynamicAt` / `NextDynamicOID`) is untouched.

Closes #144.