### PR TITLE
fix(manager): break DeleteDevice self-deadlock by moving schedulers behind atomic.Pointer

### DIFF
--- a/go/simulator/manager_delete_device_test.go
+++ b/go/simulator/manager_delete_device_test.go
@@ -105,7 +105,20 @@ func TestDeleteDeviceCleansMapsEvenOnTunDeleteError(t *testing.T) {
 // production: delete spinner never resolves, /traps/status and
 // /syslog/status hang on RLock, create-devices also blocks. With the
 // scheduler stored behind atomic.Pointer the accessors are lock-free.
+//
+// To prove the bug surface is actually exercised — and not just the
+// happy path — the test also runs concurrent GetTrapStatus /
+// GetSyslogStatus calls during the delete window and asserts they
+// return promptly. Without the fix, those status reads block on
+// sm.mu.RLock behind DeleteDevice's held write Lock; with the fix they
+// observe a consistent snapshot.
 func TestDeleteDeviceDoesNotDeadlockWithLiveTrapAndSyslogSubsystems(t *testing.T) {
+	// Register the package-global manager swap-back FIRST so it runs
+	// LAST in LIFO Cleanup order — ensuring StopTrap/SyslogExport
+	// (registered later, run earlier) still see the test's manager.
+	prevManager := manager
+	t.Cleanup(func() { manager = prevManager })
+
 	originalDelete := deleteDeviceTunInterfaces
 	t.Cleanup(func() { deleteDeviceTunInterfaces = originalDelete })
 	deleteDeviceTunInterfaces = func(sm *SimulatorManager, interfaceNames []string) error {
@@ -128,23 +141,25 @@ func TestDeleteDeviceDoesNotDeadlockWithLiveTrapAndSyslogSubsystems(t *testing.T
 	}
 	t.Cleanup(sm.StopSyslogExport)
 
-	prevManager := manager
 	manager = sm
-	t.Cleanup(func() { manager = prevManager })
 
 	deviceIP := net.IPv4(127, 0, 0, 42)
 	device := setupTestDeviceForAttach(t, sm, "dev-deadlock", deviceIP)
-	device.tunIface = &TunInterface{Name: "sim-deadlock"}
+	// PreAllocated avoids TunInterface.destroy() running syscall.Close
+	// on the zero-value fd in device.Stop (would close stdin of the
+	// test runner under -p).
+	device.tunIface = &TunInterface{Name: "sim-deadlock", PreAllocated: true}
 	device.trapConfig = &DeviceTrapConfig{
 		Collector:     "127.0.0.1:16299",
 		Mode:          "trap",
 		Community:     "public",
-		Interval:      jsonDuration(time.Second),
+		Interval:      jsonDuration(time.Hour), // match scheduler mean — no spurious fires
 		InformTimeout: jsonDuration(200 * time.Millisecond),
 	}
 	device.syslogConfig = &DeviceSyslogConfig{
 		Collector: "127.0.0.1:16599",
 		Format:    "5424",
+		Interval:  jsonDuration(time.Hour),
 	}
 	if err := sm.startDeviceTrapExporter(device); err != nil {
 		t.Fatalf("startDeviceTrapExporter: %v", err)
@@ -153,6 +168,18 @@ func TestDeleteDeviceDoesNotDeadlockWithLiveTrapAndSyslogSubsystems(t *testing.T
 		t.Fatalf("startDeviceSyslogExporter: %v", err)
 	}
 	device.running = true
+
+	// Concurrent status readers — pre-fix these would block on
+	// sm.mu.RLock behind DeleteDevice's held write Lock.
+	statusDone := make(chan struct{}, 2)
+	go func() {
+		_ = sm.GetTrapStatus()
+		statusDone <- struct{}{}
+	}()
+	go func() {
+		_ = sm.GetSyslogStatus()
+		statusDone <- struct{}{}
+	}()
 
 	done := make(chan error, 1)
 	go func() { done <- sm.DeleteDevice(device.ID) }()
@@ -163,5 +190,27 @@ func TestDeleteDeviceDoesNotDeadlockWithLiveTrapAndSyslogSubsystems(t *testing.T
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("DeleteDevice did not return within 5s — sm.mu likely self-deadlocked via device.Stop → getTrapScheduler / getSyslogScheduler")
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-statusDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("status reader did not return within 2s — likely blocked on sm.mu.RLock behind a held write Lock")
+		}
+	}
+
+	// Post-conditions: device fully removed and no longer running.
+	sm.mu.RLock()
+	_, stillPresent := sm.devices[device.ID]
+	sm.mu.RUnlock()
+	if stillPresent {
+		t.Errorf("device %s still present in sm.devices after DeleteDevice", device.ID)
+	}
+	device.mu.RLock()
+	stillRunning := device.running
+	device.mu.RUnlock()
+	if stillRunning {
+		t.Errorf("device.running = true after DeleteDevice")
 	}
 }

--- a/go/simulator/manager_delete_device_test.go
+++ b/go/simulator/manager_delete_device_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestDeleteDeviceDeletesTunInterface(t *testing.T) {
@@ -94,5 +95,73 @@ func TestDeleteDeviceCleansMapsEvenOnTunDeleteError(t *testing.T) {
 	}
 	if _, exists := sm.deviceTypesByIP[deviceIP.String()]; exists {
 		t.Fatal("device type was not removed from deviceTypesByIP despite netlink failure")
+	}
+}
+
+// Regression: DeleteDevice holds sm.mu.Lock() while calling
+// device.Stop(), which in turn calls getTrap/SyslogScheduler. If those
+// accessors take sm.mu.RLock, the same goroutine holds the write lock
+// and self-deadlocks (sync.RWMutex is not reentrant). Symptoms in
+// production: delete spinner never resolves, /traps/status and
+// /syslog/status hang on RLock, create-devices also blocks. With the
+// scheduler stored behind atomic.Pointer the accessors are lock-free.
+func TestDeleteDeviceDoesNotDeadlockWithLiveTrapAndSyslogSubsystems(t *testing.T) {
+	originalDelete := deleteDeviceTunInterfaces
+	t.Cleanup(func() { deleteDeviceTunInterfaces = originalDelete })
+	deleteDeviceTunInterfaces = func(sm *SimulatorManager, interfaceNames []string) error {
+		return nil
+	}
+
+	sm := newTestSimulatorManager()
+	if err := sm.StartTrapSubsystem(TrapSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopTrapExport)
+	if err := sm.StartSyslogSubsystem(SyslogSubsystemConfig{
+		SourcePerDevice:       false,
+		MeanSchedulerInterval: time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sm.StopSyslogExport)
+
+	prevManager := manager
+	manager = sm
+	t.Cleanup(func() { manager = prevManager })
+
+	deviceIP := net.IPv4(127, 0, 0, 42)
+	device := setupTestDeviceForAttach(t, sm, "dev-deadlock", deviceIP)
+	device.tunIface = &TunInterface{Name: "sim-deadlock"}
+	device.trapConfig = &DeviceTrapConfig{
+		Collector:     "127.0.0.1:16299",
+		Mode:          "trap",
+		Community:     "public",
+		Interval:      jsonDuration(time.Second),
+		InformTimeout: jsonDuration(200 * time.Millisecond),
+	}
+	device.syslogConfig = &DeviceSyslogConfig{
+		Collector: "127.0.0.1:16599",
+		Format:    "5424",
+	}
+	if err := sm.startDeviceTrapExporter(device); err != nil {
+		t.Fatalf("startDeviceTrapExporter: %v", err)
+	}
+	if err := sm.startDeviceSyslogExporter(device); err != nil {
+		t.Fatalf("startDeviceSyslogExporter: %v", err)
+	}
+	device.running = true
+
+	done := make(chan error, 1)
+	go func() { done <- sm.DeleteDevice(device.ID) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("DeleteDevice: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("DeleteDevice did not return within 5s — sm.mu likely self-deadlocked via device.Stop → getTrapScheduler / getSyslogScheduler")
 	}
 }

--- a/go/simulator/syslog_api_test.go
+++ b/go/simulator/syslog_api_test.go
@@ -428,7 +428,7 @@ func startSyslogForTest(t *testing.T, format SyslogFormat) (*SimulatorManager, *
 	device.syslogExporter = exp
 	sm.devices[device.ID] = device
 	sm.deviceIPs[device.IP.String()] = struct{}{}
-	sm.syslogScheduler.Register(device.IP, exp)
+	sm.syslogScheduler.Load().Register(device.IP, exp)
 
 	t.Cleanup(func() {
 		sm.StopSyslogExport()

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -177,7 +177,7 @@ type SyslogSubsystemConfig struct {
 // format / interval settings are now on each `DeviceSyslogConfig`. The
 // manager no longer holds those values simulator-wide.
 func (sm *SimulatorManager) StartSyslogSubsystem(cfg SyslogSubsystemConfig) error {
-	if sm.syslogScheduler != nil {
+	if sm.syslogScheduler.Load() != nil {
 		return fmt.Errorf("syslog export: subsystem already started")
 	}
 	if cfg.GlobalCap < 0 {
@@ -231,13 +231,15 @@ func (sm *SimulatorManager) StartSyslogSubsystem(cfg SyslogSubsystemConfig) erro
 	sm.mu.Lock()
 	sm.syslogCatalog = catalog
 	sm.syslogCatalogsByType = catalogsByType
-	sm.syslogScheduler = scheduler
 	sm.syslogEncodersByFmt = map[SyslogFormat]SyslogEncoder{}
 	sm.syslogLimiter = limiter
 	sm.syslogGlobalCap = cfg.GlobalCap
 	sm.syslogSourcePerDevice = cfg.SourcePerDevice
 	sm.syslogCatalogPath = cfg.CatalogPath
 	sm.mu.Unlock()
+	// Publish the scheduler last so any concurrent reader observing
+	// non-nil also sees the catalog/encoder/limiter writes above.
+	sm.syslogScheduler.Store(scheduler)
 
 	capStr := "unlimited"
 	if cfg.GlobalCap > 0 {
@@ -315,16 +317,16 @@ func (sm *SimulatorManager) closeSyslogConnPool() {
 }
 
 // getSyslogScheduler returns the manager's syslog scheduler pointer
-// under sm.mu.RLock so callers cannot race a concurrent
-// StopSyslogExport that nils the field (phase-5 review D3 fix). Safe
-// with nil manager.
+// via a lock-free atomic Load so callers (notably device.Stop, which
+// runs under sm.mu.Lock from the DeleteDevice path) cannot
+// self-deadlock by re-entering sm.mu. The atomic also closes the
+// original D3 race against a concurrent StopSyslogExport. Safe with
+// nil manager.
 func getSyslogScheduler(sm *SimulatorManager) *SyslogScheduler {
 	if sm == nil {
 		return nil
 	}
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	return sm.syslogScheduler
+	return sm.syslogScheduler.Load()
 }
 
 // persistSyslogCounters snapshots a SyslogExporter's cumulative counters
@@ -367,10 +369,7 @@ func (sm *SimulatorManager) persistSyslogCounters(fe *SyslogExporter) {
 // attach-path lock discipline (deferred D1 follow-up in the
 // per-device-export-config change).
 func (sm *SimulatorManager) StopSyslogExport() {
-	sm.mu.RLock()
-	scheduler := sm.syslogScheduler
-	sm.mu.RUnlock()
-
+	scheduler := sm.syslogScheduler.Load()
 	if scheduler == nil {
 		return // subsystem never started
 	}
@@ -401,8 +400,11 @@ func (sm *SimulatorManager) StopSyslogExport() {
 	}
 	sm.closeSyslogConnPool()
 
+	// Clear the scheduler first so a racing reader cannot observe the
+	// scheduler still alive while the dependent fields below are zeroed.
+	sm.syslogScheduler.Store(nil)
+
 	sm.mu.Lock()
-	sm.syslogScheduler = nil
 	sm.syslogCatalog = nil
 	sm.syslogCatalogsByType = nil
 	sm.syslogCatalogPath = ""
@@ -449,16 +451,16 @@ func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) e
 		return fmt.Errorf("syslog export: parse format: %w", err)
 	}
 
-	sm.mu.RLock()
-	sourcePerDevice := sm.syslogSourcePerDevice
-	scheduler := sm.syslogScheduler
-	deviceIPStr := device.IP.String()
-	modelLabel := modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr])
-	sm.mu.RUnlock()
-
+	scheduler := sm.syslogScheduler.Load()
 	if scheduler == nil {
 		return fmt.Errorf("syslog export: subsystem not started; call StartSyslogSubsystem first")
 	}
+
+	sm.mu.RLock()
+	sourcePerDevice := sm.syslogSourcePerDevice
+	deviceIPStr := device.IP.String()
+	modelLabel := modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr])
+	sm.mu.RUnlock()
 
 	encoder, err := sm.syslogEncoderFor(format)
 	if err != nil {
@@ -605,7 +607,7 @@ func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
 
 	sm.mu.RLock()
 	limiter := sm.syslogLimiter
-	status := SyslogStatus{SubsystemActive: sm.syslogScheduler != nil}
+	status := SyslogStatus{SubsystemActive: sm.syslogScheduler.Load() != nil}
 
 	if len(sm.syslogCatalogsByType) > 0 {
 		status.CatalogsByType = make(map[string]CatalogSourceInfo, len(sm.syslogCatalogsByType))
@@ -698,10 +700,7 @@ func (sm *SimulatorManager) GetSyslogStatus() SyslogStatus {
 //   - ErrSyslogDeviceNotFound → 404
 //   - ErrSyslogEntryNotFound  → 400
 func (sm *SimulatorManager) FireSyslogOnDevice(ip, entryName string, overrides map[string]string) error {
-	sm.mu.RLock()
-	schedulerStarted := sm.syslogScheduler != nil
-	sm.mu.RUnlock()
-	if !schedulerStarted {
+	if sm.syslogScheduler.Load() == nil {
 		return ErrSyslogExportDisabled
 	}
 	device := sm.FindDeviceByIP(ip)

--- a/go/simulator/syslog_manager.go
+++ b/go/simulator/syslog_manager.go
@@ -236,10 +236,13 @@ func (sm *SimulatorManager) StartSyslogSubsystem(cfg SyslogSubsystemConfig) erro
 	sm.syslogGlobalCap = cfg.GlobalCap
 	sm.syslogSourcePerDevice = cfg.SourcePerDevice
 	sm.syslogCatalogPath = cfg.CatalogPath
-	sm.mu.Unlock()
-	// Publish the scheduler last so any concurrent reader observing
-	// non-nil also sees the catalog/encoder/limiter writes above.
+	// Publish the scheduler under sm.mu.Lock alongside the dependent
+	// fields so any reader holding sm.mu.RLock sees a consistent
+	// snapshot (scheduler-non-nil ⇔ deps populated). atomic.Pointer is
+	// only here so getSyslogScheduler can Load lock-free from the
+	// DeleteDevice path.
 	sm.syslogScheduler.Store(scheduler)
+	sm.mu.Unlock()
 
 	capStr := "unlimited"
 	if cfg.GlobalCap > 0 {
@@ -400,11 +403,11 @@ func (sm *SimulatorManager) StopSyslogExport() {
 	}
 	sm.closeSyslogConnPool()
 
-	// Clear the scheduler first so a racing reader cannot observe the
-	// scheduler still alive while the dependent fields below are zeroed.
-	sm.syslogScheduler.Store(nil)
-
 	sm.mu.Lock()
+	// Clear the scheduler under sm.mu.Lock alongside the dependent
+	// fields so any reader holding sm.mu.RLock sees a consistent
+	// snapshot (scheduler-nil ⇔ deps cleared).
+	sm.syslogScheduler.Store(nil)
 	sm.syslogCatalog = nil
 	sm.syslogCatalogsByType = nil
 	sm.syslogCatalogPath = ""
@@ -451,16 +454,20 @@ func (sm *SimulatorManager) startDeviceSyslogExporter(device *DeviceSimulator) e
 		return fmt.Errorf("syslog export: parse format: %w", err)
 	}
 
-	scheduler := sm.syslogScheduler.Load()
-	if scheduler == nil {
-		return fmt.Errorf("syslog export: subsystem not started; call StartSyslogSubsystem first")
-	}
-
+	// Snapshot scheduler + dependent fields under one RLock so a
+	// concurrent Stop cannot interleave between the scheduler nil-check
+	// and the rest of the snapshot. With Store inside sm.mu.Lock the
+	// RLock window is the consistent unit.
 	sm.mu.RLock()
+	scheduler := sm.syslogScheduler.Load()
 	sourcePerDevice := sm.syslogSourcePerDevice
 	deviceIPStr := device.IP.String()
 	modelLabel := modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr])
 	sm.mu.RUnlock()
+
+	if scheduler == nil {
+		return fmt.Errorf("syslog export: subsystem not started; call StartSyslogSubsystem first")
+	}
 
 	encoder, err := sm.syslogEncoderFor(format)
 	if err != nil {

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -135,7 +135,7 @@ type TrapSubsystemConfig struct {
 // `DeviceTrapConfig`. The manager no longer holds those values
 // simulator-wide.
 func (sm *SimulatorManager) StartTrapSubsystem(cfg TrapSubsystemConfig) error {
-	if sm.trapScheduler != nil {
+	if sm.trapScheduler.Load() != nil {
 		return fmt.Errorf("trap export: subsystem already started")
 	}
 	if cfg.GlobalCap < 0 {
@@ -184,13 +184,16 @@ func (sm *SimulatorManager) StartTrapSubsystem(cfg TrapSubsystemConfig) error {
 	sm.mu.Lock()
 	sm.trapCatalog = catalog
 	sm.trapCatalogsByType = catalogsByType
-	sm.trapScheduler = scheduler
 	sm.trapEncoder = SNMPv2cEncoder{}
 	sm.trapLimiter = limiter
 	sm.trapGlobalCap = cfg.GlobalCap
 	sm.trapSourcePerDevice = cfg.SourcePerDevice
 	sm.trapCatalogPath = cfg.CatalogPath
 	sm.mu.Unlock()
+	// Publish the scheduler last so any concurrent reader observing
+	// non-nil also sees the catalog/encoder/limiter writes above
+	// (release/acquire ordering via atomic.Pointer.Store/Load).
+	sm.trapScheduler.Store(scheduler)
 
 	capStr := "unlimited"
 	if cfg.GlobalCap > 0 {
@@ -257,16 +260,16 @@ func (sm *SimulatorManager) TrapSourcePerDevice() bool {
 	return sm.trapSourcePerDevice
 }
 
-// getTrapScheduler returns the manager's trap scheduler pointer under
-// sm.mu.RLock so callers cannot race a concurrent StopTrapExport that
-// nils the field (phase-5 review D3 fix). Safe with nil manager.
+// getTrapScheduler returns the manager's trap scheduler pointer via a
+// lock-free atomic Load so callers (notably device.Stop, which runs
+// under sm.mu.Lock from the DeleteDevice path) cannot self-deadlock by
+// re-entering sm.mu. The atomic also closes the original D3 race
+// against a concurrent StopTrapExport. Safe with nil manager.
 func getTrapScheduler(sm *SimulatorManager) *TrapScheduler {
 	if sm == nil {
 		return nil
 	}
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	return sm.trapScheduler
+	return sm.trapScheduler.Load()
 }
 
 // persistTrapCounters snapshots a TrapExporter's cumulative counters
@@ -316,8 +319,12 @@ func (sm *SimulatorManager) persistTrapCounters(fe *TrapExporter) {
 // without first tightening the attach-path lock discipline (see the
 // deferred D1 follow-up in the per-device-export-config change).
 func (sm *SimulatorManager) StopTrapExport() {
+	scheduler := sm.trapScheduler.Load()
+	if scheduler == nil {
+		return // subsystem never started
+	}
+
 	sm.mu.RLock()
-	scheduler := sm.trapScheduler
 	devices := make([]*DeviceSimulator, 0, len(sm.devices))
 	for _, d := range sm.devices {
 		if d.trapExporter != nil {
@@ -325,10 +332,6 @@ func (sm *SimulatorManager) StopTrapExport() {
 		}
 	}
 	sm.mu.RUnlock()
-
-	if scheduler == nil {
-		return // subsystem never started
-	}
 	scheduler.Stop()
 	for _, d := range devices {
 		// Take d.mu to synchronise with a concurrent device.Stop path.
@@ -346,8 +349,11 @@ func (sm *SimulatorManager) StopTrapExport() {
 	}
 	sm.closeTrapConnPool()
 
+	// Clear the scheduler first so a racing reader cannot observe the
+	// scheduler still alive while the dependent fields below are zeroed.
+	sm.trapScheduler.Store(nil)
+
 	sm.mu.Lock()
-	sm.trapScheduler = nil
 	sm.trapCatalog = nil
 	sm.trapCatalogsByType = nil
 	sm.trapCatalogPath = ""
@@ -393,18 +399,18 @@ func (sm *SimulatorManager) startDeviceTrapExporter(device *DeviceSimulator) err
 		return fmt.Errorf("trap export: parse mode: %w", err)
 	}
 
+	scheduler := sm.trapScheduler.Load()
+	if scheduler == nil {
+		return fmt.Errorf("trap export: subsystem not started; call StartTrapSubsystem first")
+	}
+
 	sm.mu.RLock()
 	sourcePerDevice := sm.trapSourcePerDevice
-	scheduler := sm.trapScheduler
 	encoder := sm.trapEncoder
 	limiter := sm.trapLimiter
 	deviceIPStr := device.IP.String()
 	modelLabel := modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr])
 	sm.mu.RUnlock()
-
-	if scheduler == nil {
-		return fmt.Errorf("trap export: subsystem not started; call StartTrapSubsystem first")
-	}
 	if mode == TrapModeInform && !sourcePerDevice {
 		return fmt.Errorf("trap export: INFORM mode requires -trap-source-per-device=true")
 	}
@@ -531,7 +537,7 @@ func (sm *SimulatorManager) GetTrapStatus() TrapStatus {
 
 	sm.mu.RLock()
 	limiter := sm.trapLimiter
-	status := TrapStatus{SubsystemActive: sm.trapScheduler != nil}
+	status := TrapStatus{SubsystemActive: sm.trapScheduler.Load() != nil}
 
 	if len(sm.trapCatalogsByType) > 0 {
 		status.CatalogsByType = make(map[string]CatalogSourceInfo, len(sm.trapCatalogsByType))
@@ -722,10 +728,7 @@ func trapCatalogSource(slug, catalogFlagPath string) string {
 //   - ErrTrapDeviceNotFound → 404
 //   - ErrTrapEntryNotFound  → 400
 func (sm *SimulatorManager) FireTrapOnDevice(ip, trapName string, overrides map[string]string) (uint32, error) {
-	sm.mu.RLock()
-	schedulerStarted := sm.trapScheduler != nil
-	sm.mu.RUnlock()
-	if !schedulerStarted {
+	if sm.trapScheduler.Load() == nil {
 		return 0, ErrTrapExportDisabled
 	}
 	device := sm.FindDeviceByIP(ip)

--- a/go/simulator/trap_manager.go
+++ b/go/simulator/trap_manager.go
@@ -189,11 +189,14 @@ func (sm *SimulatorManager) StartTrapSubsystem(cfg TrapSubsystemConfig) error {
 	sm.trapGlobalCap = cfg.GlobalCap
 	sm.trapSourcePerDevice = cfg.SourcePerDevice
 	sm.trapCatalogPath = cfg.CatalogPath
-	sm.mu.Unlock()
-	// Publish the scheduler last so any concurrent reader observing
-	// non-nil also sees the catalog/encoder/limiter writes above
-	// (release/acquire ordering via atomic.Pointer.Store/Load).
+	// Publish the scheduler under sm.mu.Lock alongside the dependent
+	// fields so any reader holding sm.mu.RLock sees a consistent
+	// snapshot (scheduler-non-nil ⇔ deps populated). The atomic.Pointer
+	// only exists to give getTrapScheduler a lock-free Load — that
+	// closes the DeleteDevice self-deadlock without sacrificing the
+	// consistency that the RLock-protected readers rely on.
 	sm.trapScheduler.Store(scheduler)
+	sm.mu.Unlock()
 
 	capStr := "unlimited"
 	if cfg.GlobalCap > 0 {
@@ -349,11 +352,11 @@ func (sm *SimulatorManager) StopTrapExport() {
 	}
 	sm.closeTrapConnPool()
 
-	// Clear the scheduler first so a racing reader cannot observe the
-	// scheduler still alive while the dependent fields below are zeroed.
-	sm.trapScheduler.Store(nil)
-
 	sm.mu.Lock()
+	// Clear the scheduler under sm.mu.Lock alongside the dependent
+	// fields so any reader holding sm.mu.RLock sees a consistent
+	// snapshot (scheduler-nil ⇔ deps cleared).
+	sm.trapScheduler.Store(nil)
 	sm.trapCatalog = nil
 	sm.trapCatalogsByType = nil
 	sm.trapCatalogPath = ""
@@ -399,18 +402,22 @@ func (sm *SimulatorManager) startDeviceTrapExporter(device *DeviceSimulator) err
 		return fmt.Errorf("trap export: parse mode: %w", err)
 	}
 
-	scheduler := sm.trapScheduler.Load()
-	if scheduler == nil {
-		return fmt.Errorf("trap export: subsystem not started; call StartTrapSubsystem first")
-	}
-
+	// Snapshot scheduler + dependent fields under one RLock so a
+	// concurrent Stop cannot interleave between the scheduler nil-check
+	// and the encoder/limiter reads. With the Start/Stop fix that puts
+	// Store inside sm.mu.Lock, the RLock window is the consistent unit.
 	sm.mu.RLock()
+	scheduler := sm.trapScheduler.Load()
 	sourcePerDevice := sm.trapSourcePerDevice
 	encoder := sm.trapEncoder
 	limiter := sm.trapLimiter
 	deviceIPStr := device.IP.String()
 	modelLabel := modelLabelForSlug(sm.deviceTypesByIP[deviceIPStr])
 	sm.mu.RUnlock()
+
+	if scheduler == nil {
+		return fmt.Errorf("trap export: subsystem not started; call StartTrapSubsystem first")
+	}
 	if mode == TrapModeInform && !sourcePerDevice {
 		return fmt.Errorf("trap export: INFORM mode requires -trap-source-per-device=true")
 	}

--- a/go/simulator/types.go
+++ b/go/simulator/types.go
@@ -244,7 +244,7 @@ type SimulatorManager struct {
 	// as a legacy alias for the fallback.
 	trapCatalog         *Catalog
 	trapCatalogsByType  map[string]*Catalog
-	trapScheduler       *TrapScheduler
+	trapScheduler       atomic.Pointer[TrapScheduler] // lock-free read so device.Stop can deregister without taking sm.mu
 	trapEncoder         TrapEncoder
 	trapLimiter         *rate.Limiter // shared global cap (nil = unlimited)
 	trapConns           sync.Map      // key: string collector, value: *net.UDPConn (shared-socket fallback pool, TRAP mode only)
@@ -263,8 +263,8 @@ type SimulatorManager struct {
 	// syslogCatalogsByType mirrors trapCatalogsByType for the syslog side.
 	syslogCatalog         *SyslogCatalog
 	syslogCatalogsByType  map[string]*SyslogCatalog
-	syslogScheduler       *SyslogScheduler
-	syslogEncodersByFmt   map[SyslogFormat]SyslogEncoder // one encoder per format; lazily populated
+	syslogScheduler       atomic.Pointer[SyslogScheduler] // lock-free read so device.Stop can deregister without taking sm.mu
+	syslogEncodersByFmt   map[SyslogFormat]SyslogEncoder  // one encoder per format; lazily populated
 	syslogLimiter         *rate.Limiter                  // independent of trap's limiter (design.md §D9)
 	syslogConns           sync.Map                       // key: syslogConnKey, value: *net.UDPConn (shared-socket fallback pool)
 	syslogAggregates      sync.Map                       // key: syslogConnKey, value: *syslogCollectorAggregate — monotonic counters surviving device delete


### PR DESCRIPTION
## Summary

- Fixes the self-deadlock in `DeleteDevice` / `DeleteAllDevices` where the same goroutine held `sm.mu.Lock()` and then re-entered `sm.mu.RLock()` via `device.Stop()` → `getTrapScheduler` / `getSyslogScheduler`. Once wedged, status endpoints and create-devices all piled up behind it and only a restart cleared it.
- Stores `trapScheduler` / `syslogScheduler` behind `atomic.Pointer[…]` so the accessors are lock-free Load()s. The original D3 race against a concurrent `StopTrap/SyslogExport` is still closed (the field swap is atomic), but the accessors no longer re-enter `sm.mu`.
- Adds a regression test (`TestDeleteDeviceDoesNotDeadlockWithLiveTrapAndSyslogSubsystems`) that would have hung the test runner before this change.

Fixes #148.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./simulator/ -count=1` green (20.3s)
- [x] `go test -race ./simulator/ -count=1` green (21.0s)
- [x] New regression test passes; manual verification that, with the accessors restored to the old `sm.mu.RLock()` form, the new test hangs (5s timeout fires) — confirming it actually exercises the deadlock
- [ ] Manual smoke: delete a device on a running simulator with trap + syslog subsystems active; verify spinner resolves, status endpoints stay responsive, create-devices works