### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # env file
 .env
 
+# macOS
+.DS_Store
+
 # Editor/IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` so macOS Finder metadata doesn't get tracked.

## Test plan
- [x] `.DS_Store` no longer shows up under `git status`.

Assisted-by: ClaudeCode:claude-opus-4-7