### PR TITLE
fix(api): expose resource_file on GET /api/v1/devices

### DIFF
--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -259,15 +259,22 @@ many-to-one (e.g. `cisco_catalyst_9500`, `cisco_crs_x`, and
 `cisco_nexus_9500` all surface as `"Cisco Router/Switch"`), so use
 `resource_file` for any replay or programmatic recreation use case.
 
+The field is omitted (JSON `omitempty`) for devices created via the
+`-auto-start-ip` CLI flag, which boots a fleet without specifying a
+resource file. POST-created devices always carry it.
+
 ## Export to CSV
 
 ```bash
 curl http://localhost:8080/api/v1/devices/export -o devices.csv
 ```
 
-The CSV includes a `Resource File` column for the same reason — so an
-exported inventory can be re-imported without hand-mapping display
-labels back to filenames.
+The CSV columns are, in order: `Device ID`, `IP Address`, `Interface`,
+`SNMP Port`, `SSH Port`, `Status`, `Resource File`. `Resource File` is
+appended at the end so any downstream consumer that indexes columns
+positionally (`cut -f2`, spreadsheet macros) is unaffected by the new
+column. Auto-start devices without a known resource file emit `N/A` in
+that column, matching the `Interface` convention.
 
 ## Generate a route script
 

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -259,9 +259,15 @@ many-to-one (e.g. `cisco_catalyst_9500`, `cisco_crs_x`, and
 `cisco_nexus_9500` all surface as `"Cisco Router/Switch"`), so use
 `resource_file` for any replay or programmatic recreation use case.
 
-The field is omitted (JSON `omitempty`) for devices created via the
-`-auto-start-ip` CLI flag, which boots a fleet without specifying a
-resource file. POST-created devices always carry it.
+The field is omitted (JSON `omitempty`) for devices whose underlying
+`device.resourceFile` is empty. Two paths produce that:
+
+- Devices created via the `-auto-start-ip` CLI flag (no CLI equivalent of
+  `resource_file`).
+- POST requests that omit **both** `resource_file` and `round_robin: true`,
+  falling back to the simulator's default resource set.
+
+POSTs that name a `resource_file` or use `round_robin: true` always carry it.
 
 ## Export to CSV
 
@@ -272,9 +278,14 @@ curl http://localhost:8080/api/v1/devices/export -o devices.csv
 The CSV columns are, in order: `Device ID`, `IP Address`, `Interface`,
 `SNMP Port`, `SSH Port`, `Status`, `Resource File`. `Resource File` is
 appended at the end so any downstream consumer that indexes columns
-positionally (`cut -f2`, spreadsheet macros) is unaffected by the new
-column. Auto-start devices without a known resource file emit `N/A` in
+positionally (`awk -F, '{print $2}'`, spreadsheet macros) is unaffected
+by the new column. Devices without a known resource file emit `N/A` in
 that column, matching the `Interface` convention.
+
+Note: `N/A` is a display sentinel, not a valid resource filename. A
+re-import tool that POSTs each row back must translate `N/A` to an
+omitted `resource_file` field, not pass it through as a literal value
+(POST would reject `"N/A"` as a non-existent file).
 
 ## Generate a route script
 

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -252,11 +252,22 @@ e.g. `"interval_ms": 10000` lands as a 400, not a silent drop.
 curl http://localhost:8080/api/v1/devices
 ```
 
+Each device record includes a `resource_file` field (e.g. `"asr9k.json"`)
+— the canonical identifier accepted by `POST /api/v1/devices`. The
+sibling `device_type` field is a human-readable display label and is
+many-to-one (e.g. `cisco_catalyst_9500`, `cisco_crs_x`, and
+`cisco_nexus_9500` all surface as `"Cisco Router/Switch"`), so use
+`resource_file` for any replay or programmatic recreation use case.
+
 ## Export to CSV
 
 ```bash
 curl http://localhost:8080/api/v1/devices/export -o devices.csv
 ```
+
+The CSV includes a `Resource File` column for the same reason — so an
+exported inventory can be re-imported without hand-mapping display
+labels back to filenames.
 
 ## Generate a route script
 

--- a/go/nl6/manager.go
+++ b/go/nl6/manager.go
@@ -214,12 +214,13 @@ func (sm *SimulatorManager) ListDevices() []DeviceInfo {
 	var devices []DeviceInfo
 	for _, device := range sm.devices {
 		info := DeviceInfo{
-			ID:         device.ID,
-			IP:         device.IP.String(),
-			SNMPPort:   device.SNMPPort,
-			SSHPort:    device.SSHPort,
-			Running:    device.running,
-			DeviceType: getDeviceTypeFromResourceFile(device.resourceFile),
+			ID:           device.ID,
+			IP:           device.IP.String(),
+			SNMPPort:     device.SNMPPort,
+			SSHPort:      device.SSHPort,
+			Running:      device.running,
+			ResourceFile: device.resourceFile,
+			DeviceType:   getDeviceTypeFromResourceFile(device.resourceFile),
 		}
 		if device.tunIface != nil {
 			info.Interface = device.tunIface.Name

--- a/go/nl6/types.go
+++ b/go/nl6/types.go
@@ -421,13 +421,19 @@ var RoundRobinDeviceTypes = []string{
 }
 
 type DeviceInfo struct {
-	ID         string `json:"id"`
-	IP         string `json:"ip"`
-	Interface  string `json:"interface,omitempty"`
-	SNMPPort   int    `json:"snmp_port"`
-	SSHPort    int    `json:"ssh_port"`
-	Running    bool   `json:"running"`
-	DeviceType string `json:"device_type,omitempty"`
+	ID        string `json:"id"`
+	IP        string `json:"ip"`
+	Interface string `json:"interface,omitempty"`
+	SNMPPort  int    `json:"snmp_port"`
+	SSHPort   int    `json:"ssh_port"`
+	Running   bool   `json:"running"`
+	// ResourceFile is the canonical device identifier (e.g.
+	// "asr9k.json") accepted by POST /api/v1/devices. Emitted so GET
+	// responses can be replayed against POST without the consumer
+	// having to reverse-derive the filename from `device_type` (which
+	// is a many-to-one display label).
+	ResourceFile string `json:"resource_file,omitempty"`
+	DeviceType   string `json:"device_type,omitempty"`
 	// Per-device export configuration echoed for GET /api/v1/devices
 	// consumers. Fields are omitted from JSON when nil. Populated from
 	// the device's runtime state in phases 3–5.

--- a/go/nl6/web.go
+++ b/go/nl6/web.go
@@ -362,8 +362,8 @@ func exportDevicesCSVHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Write CSV headers. "Resource File" is appended at the end so any
 	// downstream consumer that indexes columns positionally
-	// (`cut -f2`, spreadsheet macros) keeps working — inserting
-	// mid-row would silently shift every column to its right.
+	// (`awk -F,`, spreadsheet macros) keeps working — inserting mid-row
+	// would silently shift every column to its right.
 	headers := []string{"Device ID", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status", "Resource File"}
 	if err := writer.Write(headers); err != nil {
 		http.Error(w, "Failed to write CSV headers", http.StatusInternalServerError)

--- a/go/nl6/web.go
+++ b/go/nl6/web.go
@@ -360,8 +360,11 @@ func exportDevicesCSVHandler(w http.ResponseWriter, r *http.Request) {
 	writer := csv.NewWriter(w)
 	defer writer.Flush()
 
-	// Write CSV headers
-	headers := []string{"Device ID", "Resource File", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status"}
+	// Write CSV headers. "Resource File" is appended at the end so any
+	// downstream consumer that indexes columns positionally
+	// (`cut -f2`, spreadsheet macros) keeps working — inserting
+	// mid-row would silently shift every column to its right.
+	headers := []string{"Device ID", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status", "Resource File"}
 	if err := writer.Write(headers); err != nil {
 		http.Error(w, "Failed to write CSV headers", http.StatusInternalServerError)
 		return
@@ -379,14 +382,23 @@ func exportDevicesCSVHandler(w http.ResponseWriter, r *http.Request) {
 			interfaceName = "N/A"
 		}
 
+		// Auto-start devices (CLI -auto-start-ip path) carry an empty
+		// resource_file — substitute N/A to match the Interface
+		// column's convention and avoid an indistinguishable-from-error
+		// empty cell mid-row.
+		resourceFile := device.ResourceFile
+		if resourceFile == "" {
+			resourceFile = "N/A"
+		}
+
 		record := []string{
 			device.ID,
-			device.ResourceFile,
 			device.IP,
 			interfaceName,
 			fmt.Sprintf("%d", device.SNMPPort),
 			fmt.Sprintf("%d", device.SSHPort),
 			status,
+			resourceFile,
 		}
 
 		if err := writer.Write(record); err != nil {

--- a/go/nl6/web.go
+++ b/go/nl6/web.go
@@ -361,7 +361,7 @@ func exportDevicesCSVHandler(w http.ResponseWriter, r *http.Request) {
 	defer writer.Flush()
 
 	// Write CSV headers
-	headers := []string{"Device ID", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status"}
+	headers := []string{"Device ID", "Resource File", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status"}
 	if err := writer.Write(headers); err != nil {
 		http.Error(w, "Failed to write CSV headers", http.StatusInternalServerError)
 		return
@@ -381,6 +381,7 @@ func exportDevicesCSVHandler(w http.ResponseWriter, r *http.Request) {
 
 		record := []string{
 			device.ID,
+			device.ResourceFile,
 			device.IP,
 			interfaceName,
 			fmt.Sprintf("%d", device.SNMPPort),

--- a/go/nl6/web_list_devices_test.go
+++ b/go/nl6/web_list_devices_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"encoding/csv"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -75,19 +76,35 @@ func TestDeviceInfoOmitsEmptyResourceFile(t *testing.T) {
 	}
 }
 
-// TestExportDevicesCSVHeaderOrder pins the CSV column order so any
-// downstream consumer that indexes columns positionally
-// (`cut -f2`, spreadsheets, parsers keyed by position) does not break
-// silently on a future column addition. "Resource File" is the last
-// column by design (additive at the end, not inserted mid-row).
-func TestExportDevicesCSVHeaderOrder(t *testing.T) {
-	prev := manager
-	manager = &SimulatorManager{
+// TestExportDevicesCSV pins the CSV column order — header AND data
+// rows — so any downstream consumer that indexes columns positionally
+// (`awk -F,`, spreadsheets, parsers keyed by position) does not break
+// silently. "Resource File" is the last column by design (additive at
+// the end, not inserted mid-row). The data-row assertions catch a
+// future regression where headers stay correct but the row writer
+// swaps two adjacent values.
+//
+// Uses `swapGlobalManager` (interface_state_api_test.go) rather than
+// an inline swap so this test serializes correctly with any other
+// test that mutates the package-level `manager` global.
+func TestExportDevicesCSV(t *testing.T) {
+	sm := &SimulatorManager{
 		devices:         map[string]*DeviceSimulator{},
 		deviceIPs:       map[string]struct{}{},
 		deviceTypesByIP: map[string]string{},
 	}
-	t.Cleanup(func() { manager = prev })
+	// Two fixtures: one with an explicit resource file, one with an
+	// empty one (mirrors the auto-start path) to exercise the "N/A"
+	// fallback.
+	sm.devices["asr"] = &DeviceSimulator{
+		ID: "asr9k-10.42.0.3", IP: net.IPv4(10, 42, 0, 3),
+		SNMPPort: 161, SSHPort: 22, resourceFile: "asr9k.json",
+	}
+	sm.devices["def"] = &DeviceSimulator{
+		ID: "default-10.42.0.4", IP: net.IPv4(10, 42, 0, 4),
+		SNMPPort: 161, SSHPort: 22, // resourceFile == "" → N/A
+	}
+	t.Cleanup(swapGlobalManager(sm))
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/export", nil)
@@ -101,18 +118,41 @@ func TestExportDevicesCSVHeaderOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse CSV: %v", err)
 	}
-	if len(records) == 0 {
-		t.Fatalf("expected at least a header row, got empty CSV")
+
+	wantHeader := []string{"Device ID", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status", "Resource File"}
+	if len(records) != 1+len(sm.devices) {
+		t.Fatalf("row count = %d, want %d (header + %d devices)", len(records), 1+len(sm.devices), len(sm.devices))
+	}
+	for i, col := range wantHeader {
+		if records[0][i] != col {
+			t.Errorf("header[%d] = %q, want %q", i, records[0][i], col)
+		}
 	}
 
-	want := []string{"Device ID", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status", "Resource File"}
-	got := records[0]
-	if len(got) != len(want) {
-		t.Fatalf("header column count = %d, want %d; got=%v", len(got), len(want), got)
+	// Map iteration order in ListDevices is undefined; index data
+	// rows by Device ID before asserting positional content.
+	rowsByID := map[string][]string{}
+	for _, row := range records[1:] {
+		if len(row) != len(wantHeader) {
+			t.Errorf("row %q has %d columns, want %d", row[0], len(row), len(wantHeader))
+		}
+		rowsByID[row[0]] = row
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("header[%d] = %q, want %q", i, got[i], want[i])
+
+	wantRows := map[string][]string{
+		"asr9k-10.42.0.3":   {"asr9k-10.42.0.3", "10.42.0.3", "N/A", "161", "22", "Stopped", "asr9k.json"},
+		"default-10.42.0.4": {"default-10.42.0.4", "10.42.0.4", "N/A", "161", "22", "Stopped", "N/A"},
+	}
+	for id, want := range wantRows {
+		got, ok := rowsByID[id]
+		if !ok {
+			t.Errorf("missing row for %q", id)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("row %q column[%d] = %q, want %q", id, i, got[i], want[i])
+			}
 		}
 	}
 }

--- a/go/nl6/web_list_devices_test.go
+++ b/go/nl6/web_list_devices_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDeviceInfoEmitsResourceFile pins the GET /api/v1/devices JSON
+// contract: every device record carries the canonical resource_file
+// identifier that POST /api/v1/devices accepts. Without this, replaying
+// an exported inventory requires reverse-deriving the filename from
+// `device_type`, which is a many-to-one display label.
+func TestDeviceInfoEmitsResourceFile(t *testing.T) {
+	info := DeviceInfo{
+		ID:           "asr9k-10.42.0.3",
+		IP:           "10.42.0.3",
+		SNMPPort:     161,
+		SSHPort:      22,
+		Running:      true,
+		ResourceFile: "asr9k.json",
+		DeviceType:   "Cisco ASR9K",
+	}
+
+	body, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal DeviceInfo: %v", err)
+	}
+
+	got := string(body)
+	if !strings.Contains(got, `"resource_file":"asr9k.json"`) {
+		t.Errorf("expected resource_file in JSON, got: %s", got)
+	}
+}
+
+// TestDeviceInfoOmitsEmptyResourceFile guards the omitempty contract so
+// devices without a resolved resource file (theoretical edge case) don't
+// emit a noisy "resource_file":"" key.
+func TestDeviceInfoOmitsEmptyResourceFile(t *testing.T) {
+	info := DeviceInfo{ID: "x", IP: "10.42.0.3", SNMPPort: 161, SSHPort: 22}
+
+	body, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal DeviceInfo: %v", err)
+	}
+
+	if strings.Contains(string(body), "resource_file") {
+		t.Errorf("expected resource_file to be omitted when empty, got: %s", string(body))
+	}
+}

--- a/go/nl6/web_list_devices_test.go
+++ b/go/nl6/web_list_devices_test.go
@@ -6,16 +6,19 @@
 package main
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
 // TestDeviceInfoEmitsResourceFile pins the GET /api/v1/devices JSON
-// contract: every device record carries the canonical resource_file
-// identifier that POST /api/v1/devices accepts. Without this, replaying
-// an exported inventory requires reverse-deriving the filename from
-// `device_type`, which is a many-to-one display label.
+// contract: every POST-created device record carries the canonical
+// resource_file identifier that POST /api/v1/devices accepts. Without
+// this, replaying an exported inventory requires reverse-deriving the
+// filename from `device_type`, which is a many-to-one display label.
 func TestDeviceInfoEmitsResourceFile(t *testing.T) {
 	info := DeviceInfo{
 		ID:           "asr9k-10.42.0.3",
@@ -32,15 +35,29 @@ func TestDeviceInfoEmitsResourceFile(t *testing.T) {
 		t.Fatalf("marshal DeviceInfo: %v", err)
 	}
 
-	got := string(body)
-	if !strings.Contains(got, `"resource_file":"asr9k.json"`) {
-		t.Errorf("expected resource_file in JSON, got: %s", got)
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal DeviceInfo: %v", err)
+	}
+
+	raw, ok := got["resource_file"]
+	if !ok {
+		t.Fatalf("expected resource_file key in JSON, got keys: %v", keysOf(got))
+	}
+	var val string
+	if err := json.Unmarshal(raw, &val); err != nil {
+		t.Fatalf("resource_file is not a JSON string: %v", err)
+	}
+	if val != "asr9k.json" {
+		t.Errorf("resource_file = %q, want %q", val, "asr9k.json")
 	}
 }
 
-// TestDeviceInfoOmitsEmptyResourceFile guards the omitempty contract so
-// devices without a resolved resource file (theoretical edge case) don't
-// emit a noisy "resource_file":"" key.
+// TestDeviceInfoOmitsEmptyResourceFile guards the omitempty contract.
+// Devices created via the -auto-start-ip CLI path carry an empty
+// resource_file (no -resource-file flag exists); the JSON must omit
+// the key rather than emit "resource_file": "". The docs note this
+// carve-out — keep the two in sync.
 func TestDeviceInfoOmitsEmptyResourceFile(t *testing.T) {
 	info := DeviceInfo{ID: "x", IP: "10.42.0.3", SNMPPort: 161, SSHPort: 22}
 
@@ -49,7 +66,61 @@ func TestDeviceInfoOmitsEmptyResourceFile(t *testing.T) {
 		t.Fatalf("marshal DeviceInfo: %v", err)
 	}
 
-	if strings.Contains(string(body), "resource_file") {
-		t.Errorf("expected resource_file to be omitted when empty, got: %s", string(body))
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal DeviceInfo: %v", err)
 	}
+	if _, present := got["resource_file"]; present {
+		t.Errorf("resource_file should be omitted when empty, got: %s", string(body))
+	}
+}
+
+// TestExportDevicesCSVHeaderOrder pins the CSV column order so any
+// downstream consumer that indexes columns positionally
+// (`cut -f2`, spreadsheets, parsers keyed by position) does not break
+// silently on a future column addition. "Resource File" is the last
+// column by design (additive at the end, not inserted mid-row).
+func TestExportDevicesCSVHeaderOrder(t *testing.T) {
+	prev := manager
+	manager = &SimulatorManager{
+		devices:         map[string]*DeviceSimulator{},
+		deviceIPs:       map[string]struct{}{},
+		deviceTypesByIP: map[string]string{},
+	}
+	t.Cleanup(func() { manager = prev })
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/devices/export", nil)
+	exportDevicesCSVHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+
+	records, err := csv.NewReader(strings.NewReader(rr.Body.String())).ReadAll()
+	if err != nil {
+		t.Fatalf("parse CSV: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatalf("expected at least a header row, got empty CSV")
+	}
+
+	want := []string{"Device ID", "IP Address", "Interface", "SNMP Port", "SSH Port", "Status", "Resource File"}
+	got := records[0]
+	if len(got) != len(want) {
+		t.Fatalf("header column count = %d, want %d; got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("header[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/devices` currently surfaces `device_type`, a many-to-one
display label (e.g. `cisco_catalyst_9500.json`, `cisco_crs_x.json`, and
`cisco_nexus_9500.json` all map to `"Cisco Router/Switch"`). `POST
/api/v1/devices` only accepts `resource_file`, and `DisallowUnknownFields`
rejects `device_type` as input — so the response cannot be reliably
replayed against the input endpoint without reverse-deriving the
filename from the `id` prefix.

This patch adds the canonical `resource_file` to `DeviceInfo` and the
CSV export. The information was already on the device record
(`device.resourceFile`) — `ListDevices` just wasn't surfacing it.

## Changes

- `go/nl6/types.go` — new `ResourceFile string` field on `DeviceInfo`
  with `json:"resource_file,omitempty"`.
- `go/nl6/manager.go` — populate from `device.resourceFile` in
  `ListDevices`.
- `go/nl6/web.go` — append `Resource File` column at the **end** of
  `exportDevicesCSVHandler`'s headers/record (not inserted mid-row) so
  any downstream consumer that indexes columns positionally (`cut -f2`,
  spreadsheet macros) keeps working. Substitute `N/A` for an empty
  value, matching the existing `Interface` column convention.
- `docs/reference/web-api.md` — document the field, the rationale
  (many-to-one ambiguity of `device_type`), the auto-start
  (`-auto-start-ip`) carve-out where the field is omitted, and the CSV
  column order.
- `go/nl6/web_list_devices_test.go` — pin both contracts:
  - JSON: structural decode into `map[string]json.RawMessage` asserting
    the key is present when set and absent when empty (not a brittle
    substring match).
  - CSV: `TestExportDevicesCSVHeaderOrder` pins the exact column
    sequence so a future column edit can't silently break parsers.

`device_type` is kept as-is — additive change only, no breaking impact
on existing consumers. JSON uses `omitempty` so auto-start devices
(which carry an empty `device.resourceFile`) don't emit a noisy empty
key; the docs spell this carve-out out explicitly.

## Motivation

Discovered while writing a capture-and-replay provisioning script
against a running simulator. The roundtrip broke because the GET
response could not be programmatically replayed against POST — clients
had to either reverse-derive the filename from the `id` prefix
(`asr9k-10.42.0.3` → `asr9k.json`) or pre-compute the type→filename
mapping client-side, neither of which scales as the resource catalog
grows.

## Review trail

This PR landed in two commits:

1. The original fix — DeviceInfo field + ListDevices wiring + CSV
   column + docs + a single JSON marshaling test.
2. Adversarial + edge-case code review findings addressed:
   - CSV column position moved to the end (was inserted at index 1,
     which would have shifted every downstream column).
   - `N/A` fallback for empty `resource_file` in the CSV (auto-start
     devices have an empty value).
   - Docs amended to document the omit-on-auto-start carve-out and to
     pin the CSV column order.
   - JSON test switched from `strings.Contains` to structural decoding.
   - CSV header order regression test added.

Two findings deferred to follow-up issues: (a) a manager-level
end-to-end test that `ListDevices()` actually populates `ResourceFile`
from `device.resourceFile`, and (b) a GET→POST round-trip replay
integration test. Both require test infrastructure beyond this PR's
scope.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./nl6/...` passes (full suite, ~33s)
- [x] `TestDeviceInfoEmitsResourceFile` — JSON contract: field present
      via structural decode when set
- [x] `TestDeviceInfoOmitsEmptyResourceFile` — JSON contract: key
      absent (not empty-string) when unset
- [x] `TestExportDevicesCSVHeaderOrder` — CSV column sequence pinned
- [ ] Manual: `curl http://<simulator>:8080/api/v1/devices | jq '.data[0].resource_file'`
      returns the canonical filename (e.g. `"asr9k.json"`) for
      POST-created devices, and `null` (omitted) for `-auto-start-ip`
      devices
- [ ] Manual: `curl http://<simulator>:8080/api/v1/devices/export | head -1`
      matches `Device ID,IP Address,Interface,SNMP Port,SSH Port,Status,Resource File`