### PR TITLE
fix(deps): bump Go to 1.26.4 to patch stdlib vulnerabilities

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/labmonkeys-space/nl6/go
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
## Why

The Quality workflow's `make vuln` (govulncheck) gate is **failing on `main`**, which in turn blocks the two open Dependabot PRs (#165, #166). Those PRs only touch workflow files but install Go via `go-version-file: go/go.mod`, so they inherit `main`'s `go1.26.3` toolchain and trip the same gate.

govulncheck reports two **reachable** standard-library vulnerabilities on `go1.26.3`:

| Advisory | Package | Reached via | Fixed in |
|----------|---------|-------------|----------|
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | `http.Server.ListenAndServe` → `Reader.ReadMIMEHeader` | go1.26.4 |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | `Certificate.Verify` / `VerifyHostname` | go1.26.4 |

## What

Bump the `go` directive in `go/go.mod` from `1.26.3` → `1.26.4`. All three workflows (CI, Quality, Release) resolve their toolchain from `go-version-file: go/go.mod`, so this single line lifts them in lockstep.

## Follow-up

Once merged, rebase #165 and #166 onto the green `main` (`@dependabot rebase`) and they should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)