### PR TITLE
docs: add LLDP topology page to the reference sidebar

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -49,6 +49,7 @@ const sidebars: SidebarsConfig = {
         'reference/flow-export',
         'reference/gnmi',
         'reference/interface-state',
+        'reference/lldp-topology',
         'reference/resource-files',
         {
           type: 'category',


### PR DESCRIPTION
The `reference/lldp-topology` page shipped in v0.10.0 but was never added to `sidebars.ts`, so it is unreachable from the docs navigation.

Lists it after `interface-state` (its closest relative — interface state drives LLDP neighbor liveness). Verified with `make docs-build` (onBrokenLinks=throw) — builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)