### PR TITLE
feat(api): add GET /api/v1/topology/graph viz-ready endpoint

### DIFF
--- a/go/nl6/topology_graph.go
+++ b/go/nl6/topology_graph.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sort"
+)
+
+// graphEndpoint is one end of an edge in the viz-ready graph.
+type graphEndpoint struct {
+	IP      string `json:"ip"`
+	IfIndex int    `json:"ifindex"`
+	IfName  string `json:"ifName,omitempty"`
+}
+
+// graphEdge is one undirected link with server-computed live state.
+// DownEnd names which endpoint(s) are down when Active is false:
+// "a" | "b" | "both"; it is omitted when the edge is active.
+type graphEdge struct {
+	A       graphEndpoint `json:"a"`
+	B       graphEndpoint `json:"b"`
+	Active  bool          `json:"active"`
+	DownEnd string        `json:"downEnd,omitempty"`
+}
+
+// graphNode is one device in the viz-ready graph. Missing is true when a
+// link references an IP that has no live device (a dangling endpoint),
+// which the visualization renders as an unresolved node.
+type graphNode struct {
+	IP      string `json:"ip"`
+	SysName string `json:"sysName,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Degree  int    `json:"degree"`
+	Missing bool   `json:"missing,omitempty"`
+}
+
+// topologyGraph is the GET /api/v1/topology/graph response.
+type topologyGraph struct {
+	Nodes []graphNode `json:"nodes"`
+	Edges []graphEdge `json:"edges"`
+}
+
+// endpointUp reports whether an endpoint is resolvable and operationally up.
+// A missing device (no live device at the IP) is down; otherwise liveness is
+// the interface-state oper-status (no-engine treated up, per operUp).
+func (sm *SimulatorManager) endpointUp(ip string, ifIndex int) bool {
+	d := sm.FindDeviceByIP(ip)
+	if d == nil {
+		return false
+	}
+	return operUp(d, ifIndex)
+}
+
+// topologyGraphHandler implements GET /api/v1/topology/graph — the
+// viz-ready join of the topology graph with device identity and live
+// per-link state. Returns {"nodes":[],"edges":[]} when no topology exists.
+func topologyGraphHandler(w http.ResponseWriter, r *http.Request) {
+	out := topologyGraph{Nodes: []graphNode{}, Edges: []graphEdge{}}
+	if manager == nil || manager.topology == nil {
+		writeJSON(w, out)
+		return
+	}
+
+	links := manager.topology.ListLinks()
+	degree := map[string]int{}
+
+	for _, l := range links {
+		degree[l.A.IP]++
+		degree[l.B.IP]++
+
+		aUp := manager.endpointUp(l.A.IP, l.A.IfIndex)
+		bUp := manager.endpointUp(l.B.IP, l.B.IfIndex)
+		edge := graphEdge{
+			A:      graphEndpoint{IP: l.A.IP, IfIndex: l.A.IfIndex, IfName: ifNameFor(manager, l.A.IP, l.A.IfIndex)},
+			B:      graphEndpoint{IP: l.B.IP, IfIndex: l.B.IfIndex, IfName: ifNameFor(manager, l.B.IP, l.B.IfIndex)},
+			Active: aUp && bUp,
+		}
+		if !edge.Active {
+			switch {
+			case !aUp && !bUp:
+				edge.DownEnd = "both"
+			case !aUp:
+				edge.DownEnd = "a"
+			default:
+				edge.DownEnd = "b"
+			}
+		}
+		out.Edges = append(out.Edges, edge)
+	}
+
+	// Build nodes from the distinct endpoint IPs, in a stable order.
+	ips := make([]string, 0, len(degree))
+	for ip := range degree {
+		ips = append(ips, ip)
+	}
+	sort.Slice(ips, func(i, j int) bool {
+		// Stable numeric order by IP; unparseable IPs fall back to string order.
+		a, b := net.ParseIP(ips[i]), net.ParseIP(ips[j])
+		if a != nil && b != nil {
+			return bytes.Compare(a.To16(), b.To16()) < 0
+		}
+		return ips[i] < ips[j]
+	})
+	for _, ip := range ips {
+		n := graphNode{IP: ip, Degree: degree[ip]}
+		if d := manager.FindDeviceByIP(ip); d != nil {
+			n.SysName = d.sysName
+			n.Type = manager.Model(ip)
+		} else {
+			n.Missing = true
+		}
+		out.Nodes = append(out.Nodes, n)
+	}
+
+	writeJSON(w, out)
+}
+
+// ifNameFor resolves an endpoint's ifDescr (falling back to a synthesized
+// name) for display, or "" when the device is unresolvable.
+func ifNameFor(sm *SimulatorManager, ip string, ifIndex int) string {
+	if d := sm.FindDeviceByIP(ip); d != nil {
+		return devIfDescr(d, ifIndex)
+	}
+	return ""
+}
+
+// writeJSON writes v as a JSON response with the correct content type.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/go/nl6/topology_graph_test.go
+++ b/go/nl6/topology_graph_test.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func getGraph(t *testing.T, router http.Handler) topologyGraph {
+	t.Helper()
+	w := doReq(t, router, http.MethodGet, "/api/v1/topology/graph", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("graph status = %d", w.Code)
+	}
+	var g topologyGraph
+	if err := json.Unmarshal(w.Body.Bytes(), &g); err != nil {
+		t.Fatalf("graph body: %v", err)
+	}
+	return g
+}
+
+func edgeFor(g topologyGraph, ip string, ifIndex int) (graphEdge, bool) {
+	for _, e := range g.Edges {
+		if (e.A.IP == ip && e.A.IfIndex == ifIndex) || (e.B.IP == ip && e.B.IfIndex == ifIndex) {
+			return e, true
+		}
+	}
+	return graphEdge{}, false
+}
+
+func nodeFor(g topologyGraph, ip string) (graphNode, bool) {
+	for _, n := range g.Nodes {
+		if n.IP == ip {
+			return n, true
+		}
+	}
+	return graphNode{}, false
+}
+
+func TestTopologyGraph_Empty(t *testing.T) {
+	newLLDPFixture(t)
+	g := getGraph(t, setupRoutes())
+	if len(g.Nodes) != 0 || len(g.Edges) != 0 {
+		t.Fatalf("empty topology graph = %d nodes / %d edges, want 0/0", len(g.Nodes), len(g.Edges))
+	}
+}
+
+func TestTopologyGraph_NodesEdgesAndDegree(t *testing.T) {
+	f := newLLDPFixture(t)
+	a := f.addDevice(t, 1, 4, "alpha")
+	b := f.addDevice(t, 2, 4, "bravo")
+	c := f.addDevice(t, 3, 4, "charlie")
+	// b is the hub: linked to both a and c → degree 2.
+	must(t, f.mgr.topology.AddLink(ep(a.IP.String(), 1), ep(b.IP.String(), 2)))
+	must(t, f.mgr.topology.AddLink(ep(b.IP.String(), 3), ep(c.IP.String(), 1)))
+
+	g := getGraph(t, setupRoutes())
+	if len(g.Nodes) != 3 || len(g.Edges) != 2 {
+		t.Fatalf("graph = %d nodes / %d edges, want 3/2", len(g.Nodes), len(g.Edges))
+	}
+	bn, ok := nodeFor(g, b.IP.String())
+	if !ok || bn.Degree != 2 || bn.SysName != "bravo" {
+		t.Errorf("hub node = %+v, want degree 2 sysName bravo", bn)
+	}
+	an, _ := nodeFor(g, a.IP.String())
+	if an.Degree != 1 || an.Missing {
+		t.Errorf("leaf node = %+v, want degree 1, present", an)
+	}
+	// Edge carries ifName from ifDescr on both endpoints.
+	e, ok := edgeFor(g, a.IP.String(), 1)
+	if !ok || !e.Active || e.A.IfName == "" || e.B.IfName == "" {
+		t.Errorf("edge a/1 = %+v", e)
+	}
+}
+
+func TestTopologyGraph_ActiveAndDownEnd(t *testing.T) {
+	f := newLLDPFixture(t)
+	a := f.addDevice(t, 1, 4, "alpha")
+	b := f.addDevice(t, 2, 4, "bravo")
+	must(t, f.mgr.topology.AddLink(ep(a.IP.String(), 1), ep(b.IP.String(), 2)))
+
+	g := getGraph(t, setupRoutes())
+	e, _ := edgeFor(g, a.IP.String(), 1)
+	if !e.Active || e.DownEnd != "" {
+		t.Fatalf("edge should start active, got %+v", e)
+	}
+
+	// Down the a-side → edge inactive, downEnd identifies a.
+	setOper(a, 1, false)
+	g = getGraph(t, setupRoutes())
+	e, _ = edgeFor(g, a.IP.String(), 1)
+	if e.Active {
+		t.Errorf("edge should be inactive after a-side down")
+	}
+	// Endpoint ordering in the edge isn't guaranteed; downEnd must point at
+	// whichever side carries alpha/if1.
+	downIsA := e.A.IP == a.IP.String() && e.A.IfIndex == 1
+	want := "a"
+	if !downIsA {
+		want = "b"
+	}
+	if e.DownEnd != want {
+		t.Errorf("downEnd = %q, want %q (alpha side)", e.DownEnd, want)
+	}
+}
+
+func TestTopologyGraph_MissingEndpointNode(t *testing.T) {
+	f := newLLDPFixture(t)
+	a := f.addDevice(t, 1, 4, "alpha")
+	// Link to a peer that does not exist → dangling endpoint.
+	must(t, f.mgr.topology.AddLink(ep(a.IP.String(), 1), ep("10.42.0.250", 7)))
+
+	g := getGraph(t, setupRoutes())
+	if len(g.Nodes) != 2 {
+		t.Fatalf("nodes = %d, want 2 (alpha + missing peer)", len(g.Nodes))
+	}
+	miss, ok := nodeFor(g, "10.42.0.250")
+	if !ok || !miss.Missing {
+		t.Errorf("missing peer node = %+v, want Missing=true", miss)
+	}
+	e, _ := edgeFor(g, a.IP.String(), 1)
+	if e.Active || e.DownEnd == "" {
+		t.Errorf("edge to missing peer should be inactive with a downEnd, got %+v", e)
+	}
+}

--- a/go/nl6/web.go
+++ b/go/nl6/web.go
@@ -509,6 +509,7 @@ func setupRoutes() *mux.Router {
 	api.HandleFunc("/topology", listTopologyHandler).Methods("GET")
 	api.HandleFunc("/topology", deleteTopologyHandler).Methods("DELETE")
 	api.HandleFunc("/topology/status", topologyStatusHandler).Methods("GET")
+	api.HandleFunc("/topology/graph", topologyGraphHandler).Methods("GET")
 	api.HandleFunc("/debug/pprof-memory", pprofMemoryHandler).Methods("GET")
 	api.HandleFunc("/debug/cpu-profile", cpuProfileHandler).Methods("GET")
 


### PR DESCRIPTION
## What

Adds `GET /api/v1/topology/graph` — the deployed topology as nodes + edges in one fetch, with **live per-link state** computed server-side. This is the data source for the upcoming topology visualization (`add-topology-visualization`), and is useful on its own for reconciling a deployed topology against intent.

## Shape

- **nodes**: `ip`, `sysName`, `type`, `degree`; dangling endpoints (links referencing a non-existent device) flagged `missing:true`.
- **edges**: both endpoints (`ip`/`ifindex`/`ifName`), `active` (both ends resolvable + oper-up), and `downEnd` (`a`/`b`/`both`, omitted when active).
- empty `{nodes:[],edges:[]}` when no topology is configured.

Reuses the existing topology graph, `FindDeviceByIP`, and per-endpoint `operUp` — no change to `/devices`, no new mutation surface.

## Tests

`topology_graph_test.go` (4): node/edge/degree shape, `active`/`downEnd` flip on oper-status DOWN, missing-endpoint node, empty topology. Full suite green; build + lint clean.

## Scope

Backend only — the first slice of `add-topology-visualization`. The sigma.js visualization (gated section, force layout, click-to-flap, scale guard) lands as a separate, browser-verified follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)